### PR TITLE
Impl [General] Change breadcrumbs divider symbol + cleanup

### DIFF
--- a/src/common/Breadcrumbs/Breadcrumbs.js
+++ b/src/common/Breadcrumbs/Breadcrumbs.js
@@ -22,18 +22,18 @@ const Breadcrumbs = ({ match = { path: '', url: '' }, onClick }) => {
           const to = `/${urlItems.slice(0, i + 1).join('/')}`
           const last = i === urlItems.length - 1
           return last ? (
-            <li className="breadcrumbs__list__item" key={i + item}>
+            <li className="breadcrumbs__list__item" key={`${i}${item}`}>
               {label}
             </li>
           ) : (
             [
-              <li key={i + item} className="breadcrumbs__list__item">
+              <li key={`${i}${item}`} className="breadcrumbs__list__item">
                 <Link to={to} onClick={onClick}>
                   {label}
                 </Link>
               </li>,
               <li key={i} className="breadcrumbs__list_separator">
-                >
+                ›
               </li>
             ]
           )

--- a/src/components/JobsItemInternal/JobsItemInternalView.js
+++ b/src/components/JobsItemInternal/JobsItemInternalView.js
@@ -27,7 +27,7 @@ const JobsItemInternalView = ({
           {formatDatetime(job.startTime)}{' '}
           <i
             className={job.state}
-            title={job.state[0].toUpperCase() + job.state.slice(1)}
+            title={`${job.state[0].toUpperCase()}${job.state.slice(1)}`}
           />
         </span>
       </div>

--- a/src/components/JobsItemInternal/jobItemInternal.scss
+++ b/src/components/JobsItemInternal/jobItemInternal.scss
@@ -10,7 +10,7 @@
   height: 100%;
   overflow-y: scroll;
   border-left: $tableBorder;
-color: $tableFontColor;
+  color: $tableFontColor;
   &_opened {
     height: 72vh;
     overflow-y: scroll;

--- a/src/components/SideBar/SideBarView.js
+++ b/src/components/SideBar/SideBarView.js
@@ -20,7 +20,7 @@ const SideBarView = ({ currentPage, onClick }) => {
               key={item.value}
               className={`${currentPage === item.value &&
                 'active'} sidebar__menu__item`}
-              title={item.value[0].toUpperCase() + item.value.slice(1)}
+              title={`${item.value[0].toUpperCase()}${item.value.slice(1)}`}
             >
               <Link
                 to={`/${item.value}`}

--- a/src/elements/ChipCell/ChipCell.js
+++ b/src/elements/ChipCell/ChipCell.js
@@ -6,7 +6,10 @@ const ChipCell = ({ elements, className }) => {
   return elements
     ? elements.sortedArr.map((item, i) => {
         return (
-          <div className="jobs__table_body__chips__block" key={item.value + i}>
+          <div
+            className="jobs__table_body__chips__block"
+            key={`${item.value}${i}`}
+          >
             <Chip
               key={item.value}
               className={className}

--- a/src/elements/JobInternalInfo/JobInternalInfo.js
+++ b/src/elements/JobInternalInfo/JobInternalInfo.js
@@ -26,7 +26,7 @@ const JobInternalInfo = ({ job, handleShowElements }) => {
         <li className="jobs__table__item_details_item">
           <div className="jobs__table__item_details_item_header">Status</div>
           <div className="jobs__table__item_details_item_data">
-            {job.state[0].toUpperCase() + job.state.slice(1)}
+            {`${job.state[0].toUpperCase()}${job.state.slice(1)}`}
             <i className={job.state} />
           </div>
         </li>

--- a/src/elements/JobInternalInputs/JobInternalInputs.js
+++ b/src/elements/JobInternalInputs/JobInternalInputs.js
@@ -2,15 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const JobInternalInputs = ({ job }) => {
-  const keys = Object.keys(job.inputs)
-  const values = Object.values(job.inputs)
   return (
     <div>
       <ul className="jobs__table__item_inputs">
-        {keys.map((item, i) => (
-          <li className="jobs__table__item_inputs_item" key={item}>
-            <div>{item}</div>
-            <div>{values[i]}</div>
+        {Object.entries(job.inputs || {}).map(([key, value]) => (
+          <li className="jobs__table__item_inputs_item" key={key}>
+            <div>{key}</div>
+            <div>{value}</div>
           </li>
         ))}
       </ul>

--- a/src/elements/JobInternalResults/JobInternalResults.js
+++ b/src/elements/JobInternalResults/JobInternalResults.js
@@ -33,17 +33,17 @@ const JobInternalResults = ({ job }) => {
                 {item.map((value, i) => {
                   if (typeof value === typeof '') {
                     return (
-                      <td key={value + '' + i}>
+                      <td key={`${value}${i}`}>
                         <i
                           className={value}
-                          title={value[0].toUpperCase() + value.slice(1)}
+                          title={`${value[0].toUpperCase()}${value.slice(1)}`}
                         />
                       </td>
                     )
                   } else if (value === job.results.best_iteration) {
                     return (
                       <td
-                        key={value + '' + i}
+                        key={`${value}${i}`}
                         className="jobs__table__item_results__table_medal"
                       >
                         {value}
@@ -55,7 +55,7 @@ const JobInternalResults = ({ job }) => {
                       </td>
                     )
                   } else {
-                    return <td key={value + '' + i}>{value}</td>
+                    return <td key={`${value}${i}`}>{value}</td>
                   }
                 })}
               </tr>

--- a/src/elements/JobsTable/JobsTableView.js
+++ b/src/elements/JobsTable/JobsTableView.js
@@ -46,7 +46,7 @@ const JobsTableView = ({
               handleShowElements
             )
             return (
-              <tr key={item + i}>
+              <tr key={`${item}${i}`}>
                 <td>
                   <Link
                     to={`/jobs/${item.uid}/info`}
@@ -62,7 +62,9 @@ const JobsTableView = ({
                 <td>
                   <i
                     className={item.state}
-                    title={item.state[0].toUpperCase() + item.state.slice(1)}
+                    title={`${item.state[0].toUpperCase()}${item.state.slice(
+                      1
+                    )}`}
                   />
                 </td>
                 <td className="jobs__table_body__chips_cell">

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -1,2 +1,2 @@
 export const truncateUid = (value = '') =>
-  value.length > 7 ? '...' + value.slice(-7) : value
+  value.length > 7 ? `...${value.slice(-7)}` : value


### PR DESCRIPTION
- Use template literals rather than `+` operator for string concatenation.
- Use `Object.entries` + destructuring rather than `Object.keys` with `Object.values` with synced index.