### PR TITLE
Impl [Artifacts] Add Metadata tab

### DIFF
--- a/src/components/ArtifactFilterLabels/ArtifactFilterLabels.js
+++ b/src/components/ArtifactFilterLabels/ArtifactFilterLabels.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 
 import './artifactfilterlabels.scss'
 
@@ -20,6 +21,10 @@ const ArtifactFilterLabels = ({ onChange }) => {
       />
     </div>
   )
+}
+
+ArtifactFilterLabels.propTypes = {
+  onChange: PropTypes.func.isRequired
 }
 
 export default ArtifactFilterLabels

--- a/src/components/ArtifactInfoMetadata/ArtifactInfoMetada.js
+++ b/src/components/ArtifactInfoMetadata/ArtifactInfoMetada.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+import './artifactinfometadata.scss'
+
+const ArtifactInfoMetadata = ({ item }) => {
+  const { primaryKey } = item.schema
+  let metadata = item.schema.fields.map(_item => {
+    const { name, type } = _item
+    return {
+      name: name,
+      type: type,
+      primary: primaryKey.includes(name) ? 'Yes' : '',
+      count: item.stats[name] && item.stats[name].count,
+      mean: item.stats[name] && item.stats[name].mean,
+      std: item.stats[name] && item.stats[name].std.toFixed(8),
+      min: item.stats[name] && item.stats[name].min,
+      '25%': item.stats[name] && item.stats[name]['25%'],
+      '50%': item.stats[name] && item.stats[name]['50%'],
+      '75%': item.stats[name] && item.stats[name]['75%'],
+      max: item.stats[name] && item.stats[name].max
+    }
+  })
+
+  let headers = metadata.reduce((prev, cur) => {
+    return Object.keys(cur)
+  }, {})
+
+  return (
+    <div className="artifact_metadata_table">
+      <div className="artifact_metadata_table_header">
+        {headers.map(header => {
+          return (
+            <div className="artifact_metadata_table_header_item" key={header}>
+              <span>{header}</span>
+            </div>
+          )
+        })}
+      </div>
+      <div className="artifact_metadata_table_body">
+        {metadata.map(item => {
+          return (
+            <div key={item.name} className="artifact_metadata_table_body_row">
+              {Object.keys(item).map(key => {
+                return (
+                  <div
+                    key={key}
+                    className="artifact_metadata_table_body_row_item"
+                  >
+                    {key === 'name' ? (
+                      <Tooltip
+                        template={<TextTooltipTemplate text={item[key]} />}
+                      >
+                        {item[key]}
+                      </Tooltip>
+                    ) : (
+                      <span>{item[key]}</span>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+ArtifactInfoMetadata.propTypes = {
+  item: PropTypes.shape({}).isRequired
+}
+
+export default ArtifactInfoMetadata

--- a/src/components/ArtifactInfoMetadata/artifactinfometadata.scss
+++ b/src/components/ArtifactInfoMetadata/artifactinfometadata.scss
@@ -1,0 +1,48 @@
+@import '../../scss/colors.scss';
+@import '../../scss/borders.scss';
+
+.artifact_metadata {
+  &_table {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    padding: 20px;
+    &_header {
+      display: flex;
+      padding: 10px;
+      border-bottom: $tableBorder;
+      font-weight: bold;
+      color: $topaz;
+      &_item {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        text-transform: capitalize;
+        min-width: 80px;
+      }
+    }
+    &_body {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      &_row {
+        display: flex;
+        padding: 10px;
+        flex-direction: row;
+        border-bottom: $tableBorder;
+        &_item {
+          display: flex;
+          flex: 1;
+          align-items: center;
+          min-width: 80px;
+          span,
+          div {
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow-x: hidden;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/ArtifactInfoSources/ArtifactInfoSources.js
+++ b/src/components/ArtifactInfoSources/ArtifactInfoSources.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import arrowIcon from '../../images/arrow.png'
 
@@ -9,6 +9,12 @@ import './artifactinfosources.scss'
 const ArtifactInfoSources = ({ header, sources }) => {
   const [isShow, setIsShow] = useState(false)
   const sourcesLength = Object.values(sources).length
+
+  useEffect(() => {
+    if (sourcesLength === 0 && isShow === true) {
+      setIsShow(false)
+    }
+  }, [sourcesLength, isShow])
 
   return (
     <li

--- a/src/components/Artifacts/Artifacts.js
+++ b/src/components/Artifacts/Artifacts.js
@@ -28,6 +28,7 @@ const Artifacts = ({
   const fetchData = useCallback(
     item => {
       setLoading(true)
+      selectArtifact({ isPreview: false, item: {} })
       fetchArtifacts(item)
         .then(data => {
           const artifacts = data.map(artifact => {
@@ -66,7 +67,7 @@ const Artifacts = ({
           setArtifactsContent(content)
         })
     },
-    [fetchArtifacts]
+    [fetchArtifacts, selectArtifact]
   )
 
   useEffect(() => {

--- a/src/components/Artifacts/artifactsData.json
+++ b/src/components/Artifacts/artifactsData.json
@@ -1,5 +1,4 @@
 {
-  "artifactsProducerInfoHeaders": ["Kind", "Name", "Owner", "Uri", "Workflow"],
   "artifactsInfoHeaders": [
     "Key",
     "Iter",

--- a/src/components/ArtifactsPreview/ArtifactsPreview.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreview.js
@@ -13,9 +13,20 @@ const ArtifactsPreview = ({ artifact }) => {
     type: null,
     data: null
   })
+
   useEffect(() => {
-    getArtifactPreview(artifact.target_path.schema, artifact.target_path.path)
-  }, [artifact.target_path])
+    if (artifact.schema) {
+      setPreview({
+        type: 'table',
+        data: {
+          headers: artifact.header,
+          content: artifact.preview
+        }
+      })
+    } else {
+      getArtifactPreview(artifact.target_path.schema, artifact.target_path.path)
+    }
+  }, [artifact.target_path, artifact])
 
   const getArtifactPreview = (schema, path) => {
     setLoader(true)

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
 import { Link, useHistory } from 'react-router-dom'
@@ -14,6 +14,7 @@ import ArtifactsPreview from '../ArtifactsPreview/ArtifactsPreview'
 import ActionsMenu from '../../common/ActionsMenu/ActionsMenu'
 import Tooltip from '../../common/Tooltip/Tooltip'
 import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+import ArtifactInfoMetadata from '../ArtifactInfoMetadata/ArtifactInfoMetada'
 
 import { formatDatetime } from '../../utils'
 import artifactsAction from '../../actions/artifacts'
@@ -45,6 +46,21 @@ const Details = ({
       })
     )
   }
+
+  useEffect(() => {
+    if (match.params.tab === 'metadata' && item.schema === undefined) {
+      history.push(
+        `/projects/${match.params.projectName}/artifacts/${match.params.name}/info`
+      )
+    }
+  }, [
+    history,
+    item.schema,
+    match.params.name,
+    match.params.projectName,
+    match.params.tab
+  ])
+
   return (
     <div className="table__item" onClick={hideChips}>
       <div className="item-header">
@@ -101,6 +117,15 @@ const Details = ({
               tab={link}
             />
           ))}
+          {item.schema && (
+            <DetailsMenuItem
+              id={item.uid}
+              match={match}
+              name={item.key}
+              page={page}
+              tab={'metadata'}
+            />
+          )}
         </ul>
       </div>
       {match.params.tab === 'info' && (
@@ -110,22 +135,21 @@ const Details = ({
           page={page}
         />
       )}
-      <div className="preview_container">
-        {match.params.tab === 'preview' && (
-          <>
-            <button onClick={() => handlePreview()} className="preview_popout">
-              <img src={popout} alt="preview" />
-            </button>
-            <ArtifactsPreview artifact={item} />
-          </>
-        )}
-        {match.params.tab === 'inputs' && (
-          <DetailsInputs inputs={item.inputs} />
-        )}
-        {match.params.tab === 'artifacts' && <DetailsArtifacts match={match} />}
-        {match.params.tab === 'results' && <DetailsResults job={item} />}
-        {match.params.tab === 'logs' && <DetailsLogs match={match} />}
-      </div>
+      {match.params.tab === 'preview' && (
+        <div className="preview_container">
+          <button onClick={() => handlePreview()} className="preview_popout">
+            <img src={popout} alt="preview" />
+          </button>
+          <ArtifactsPreview artifact={item} />
+        </div>
+      )}
+      {match.params.tab === 'inputs' && <DetailsInputs inputs={item.inputs} />}
+      {match.params.tab === 'artifacts' && <DetailsArtifacts match={match} />}
+      {match.params.tab === 'results' && <DetailsResults job={item} />}
+      {match.params.tab === 'logs' && <DetailsLogs match={match} />}
+      {match.params.tab === 'metadata' && item.schema && (
+        <ArtifactInfoMetadata item={item} />
+      )}
     </div>
   )
 }

--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -18,6 +18,17 @@ const DetailsArtifacts = ({ jobsStore }) => {
         ? item.target_path.slice(index + '://'.length)
         : item.target_path
     }
+    if (item.schema) {
+      return {
+        schema: item.schema,
+        header: item.header,
+        preview: item.preview,
+        key: item.key,
+        target_path: target_path,
+        size: item.size ? prettyBytes(item.size) : 'N/A',
+        date: formatDatetime(jobsStore.selectedJob.startTime)
+      }
+    }
     return {
       key: item.key,
       target_path: target_path,

--- a/src/components/DetailsInfo/DetailsInfo.js
+++ b/src/components/DetailsInfo/DetailsInfo.js
@@ -34,13 +34,7 @@ const DetailsInfo = ({ item, handleShowElements, page }) => {
     item.labels,
     item.sources
   ]
-  const artifactsProducerInfoContent = item.producer && [
-    item.producer.kind,
-    item.producer.name,
-    item.producer.owner,
-    item.producer.uri,
-    item.producer.workflow
-  ]
+  console.log('123', item.producer)
 
   return (
     <div>
@@ -156,14 +150,16 @@ const DetailsInfo = ({ item, handleShowElements, page }) => {
         <>
           <h3 className="table__item_details_preview_header">Producer</h3>
           <ul className="table__item_details">
-            {artifactsData.artifactsProducerInfoHeaders.map((header, i) => (
-              <ArtifactsDetailsInfoItem
-                key={header}
-                page={page}
-                info={artifactsProducerInfoContent[i]}
-                header={header}
-              />
-            ))}
+            {Object.keys(item.producer).map(key => {
+              return (
+                <ArtifactsDetailsInfoItem
+                  key={key}
+                  page={page}
+                  info={item.producer[key]}
+                  header={key}
+                />
+              )
+            })}
           </ul>
         </>
       )}

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -12,6 +12,7 @@ import collapseIcon from '../../images/collapse.png'
 import expandIcon from '../../images/expand.png'
 
 import './filterMenu.scss'
+import { useHistory } from 'react-router-dom'
 
 const FilterMenu = ({
   expand,
@@ -28,7 +29,7 @@ const FilterMenu = ({
   const [itemsFilterTree] = useState(['Latest'])
   const [valueFilterTree, setValueFilterTree] = useState('')
   const [labels, setLabels] = useState('')
-
+  const history = useHistory()
   const handleChangeArtifactFilterTree = item => {
     const value = item.toLowerCase()
     onChange({ tag: value, project: match.params.projectName })
@@ -88,6 +89,7 @@ const FilterMenu = ({
                     project: match.params.projectName
                   })
                 : onChange()
+              history.push(`/projects/${match.params.projectName}/${page}`)
             }}
           >
             <img src={refreshIcon} alt="refresh" />

--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -42,9 +42,6 @@ const Jobs = ({ fetchJobs, jobsStore, match, setSelectedJob, history }) => {
     setExpand(false)
     setLoading(true)
     setSelectedJob({})
-
-    history.push(`/projects/${match.params.projectName}/jobs`)
-
     fetchJobs(
       match.params.projectName,
       stateFilter !== jobsData.initialStateFilter ? stateFilter : false
@@ -53,13 +50,7 @@ const Jobs = ({ fetchJobs, jobsStore, match, setSelectedJob, history }) => {
         return setJobs(jobs)
       })
       .then(() => setLoading(false))
-  }, [
-    fetchJobs,
-    history,
-    match.params.projectName,
-    setSelectedJob,
-    stateFilter
-  ])
+  }, [fetchJobs, match.params.projectName, setSelectedJob, stateFilter])
 
   useEffect(() => {
     refreshJobs()

--- a/src/elements/JobsTableRow/JobsTableRow.js
+++ b/src/elements/JobsTableRow/JobsTableRow.js
@@ -95,11 +95,13 @@ const JobsTableRow = ({
             <TableCell
               data={value}
               handleShowElements={handleShowElements}
-              item={content[index]}
+              item={content.filter(item => item.uid === rowItem.uid.value)[0]}
               link={
                 i === 0 &&
                 `/projects/${match.params.projectName}/jobs/${content.length >
-                  0 && content[index].uid}${
+                  0 &&
+                  content.filter(item => item.uid === rowItem.uid.value)[0]
+                    .uid}${
                   match.params.tab
                     ? `/${match.params.tab}`
                     : `/${jobsData.detailsMenu[0]}`

--- a/src/elements/TableCell/TableCell.js
+++ b/src/elements/TableCell/TableCell.js
@@ -148,22 +148,25 @@ const TableCell = ({
   } else if (data.type === 'producer') {
     return (
       <div className={`table-body__cell ${data.size}`}>
-        <Tooltip
-          template={
-            <ProducerTooltipTemplate
-              kind={data.value.kind}
-              owner={data.value.owner ? data.value.owner : ''}
-            />
-          }
-        >
-          <Link
-            to={`/projects/${match.params.projectName}/jobs/${
-              data.value.uri.split('/')[1]
-            }/${jobsData.detailsMenu[0]}`}
+        {data.value.uri && (
+          <Tooltip
+            template={
+              <ProducerTooltipTemplate
+                kind={data.value.kind}
+                owner={data.value.owner ? data.value.owner : ''}
+              />
+            }
           >
-            {data.value.name}
-          </Link>
-        </Tooltip>
+            <Link
+              to={`/projects/${match.params.projectName}/jobs/${data.value
+                .uri && data.value.uri.split('/')[1]}/${
+                jobsData.detailsMenu[0]
+              }`}
+            >
+              {data.value.name}
+            </Link>
+          </Tooltip>
+        )}
       </div>
     )
   } else if (data.type === 'buttonPopout') {


### PR DESCRIPTION
- Jobs › Details pane › Artifacts tab: For dataset artifacts, when there is `preview` and `header` properties, display them as the preview instead of downloading actual file and parsing it
- Artifacts › Details pane:
    - Info tab:
      - Producer: Expect producer kinds other than "run" (show URI and Workflow only to "run" producer kind)
    - Preview tab: For dataset artifacts, when there is `preview` and `header` properties, display them as the preview instead of downloading actual file and parsing it
    - Add new tab "Metadata" with table schema and statistics of fields

Replaces #51 that were mistakenly merged without squash.