### PR TITLE
Impl [General] Enable proxying to function templates relatively

### DIFF
--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -2,8 +2,10 @@ server {
 
   listen 80;
 
-  # https://raw.githubusercontent.com/mlrun/functions/master/catalog.json
-  rewrite ^/function-catalog$ ${MLRUN_FUNCTION_CATALOG_URL} redirect;
+  # https://raw.githubusercontent.com/mlrun/functions/master
+  location /function-catalog {
+    proxy_pass ${MLRUN_FUNCTION_CATALOG_URL};
+  }
 
   location / {
     root   /usr/share/nginx/html;

--- a/src/actions/functions.js
+++ b/src/actions/functions.js
@@ -32,7 +32,7 @@ const functionsActions = {
   }),
   fetchFunctionsTemplates: () => dispatch => {
     return functionsApi
-      .getFunctionsTemplates()
+      .getFunctionTemplatesCatalog()
       .then(result => {
         const templates = Object.keys(result.data).map(func => {
           return {

--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -1,4 +1,4 @@
-import { mainHTTPClient } from '../httpClient'
+import { mainHttpClient } from '../httpClient'
 
 export default {
   getArtifacts: item => {
@@ -21,7 +21,7 @@ export default {
       url = `${url}&name=${item.name}`
     }
 
-    return mainHTTPClient.get(url)
+    return mainHttpClient.get(url)
   },
   getArtifactPreview: (schema, path, user) => {
     let url = '/files?'
@@ -38,8 +38,8 @@ export default {
       url = `${url}&user=${user}`
     }
 
-    return mainHTTPClient.get(url)
+    return mainHttpClient.get(url)
   },
   getArtifactTag: project =>
-    mainHTTPClient.get(`/projects/${project}/artifact-tags`)
+    mainHttpClient.get(`/projects/${project}/artifact-tags`)
 }

--- a/src/api/functions-api.js
+++ b/src/api/functions-api.js
@@ -1,6 +1,8 @@
-import { functionsTemplatesHTTPClient, mainHTTPClient } from '../httpClient'
+import { functionTemplatesHttpClient, mainHttpClient } from '../httpClient'
 
 export default {
-  getAll: project => mainHTTPClient.get(`/funcs?project=${project}`),
-  getFunctionsTemplates: () => functionsTemplatesHTTPClient.get('')
+  getAll: project => mainHttpClient.get(`/funcs?project=${project}`),
+  getFunctionTemplate: path => functionTemplatesHttpClient.get(path),
+  getFunctionTemplatesCatalog: () =>
+    functionTemplatesHttpClient.get('catalog.json')
 }

--- a/src/api/jobs-api.js
+++ b/src/api/jobs-api.js
@@ -1,4 +1,4 @@
-import { mainHTTPClient } from '../httpClient'
+import { mainHttpClient } from '../httpClient'
 
 export default {
   getAll: (project, state, event) => {
@@ -17,10 +17,10 @@ export default {
       url = `${url}&name=${event.name}`
     }
 
-    return mainHTTPClient.get(url)
+    return mainHttpClient.get(url)
   },
-  getJobLogs: (id, project) => mainHTTPClient.get(`/log/${project}/${id}`),
+  getJobLogs: (id, project) => mainHttpClient.get(`/log/${project}/${id}`),
   filterByStatus: (project, state) =>
-    mainHTTPClient.get(`/runs?project=${project}&&state=${state}`),
-  runJob: postData => mainHTTPClient.post('/submit_job', postData)
+    mainHttpClient.get(`/runs?project=${project}&&state=${state}`),
+  runJob: postData => mainHttpClient.post('/submit_job', postData)
 }

--- a/src/api/projects-api.js
+++ b/src/api/projects-api.js
@@ -1,7 +1,7 @@
-import { mainHTTPClient } from '../httpClient'
+import { mainHttpClient } from '../httpClient'
 
 export default {
   getProjects: () => {
-    return mainHTTPClient.get('/projects?full=yes')
+    return mainHttpClient.get('/projects?full=yes')
   }
 }

--- a/src/common/Download/Download.js
+++ b/src/common/Download/Download.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 
 import ProgressRing from '../ProgressRing/ProgressRing'
 
-import { mainHTTPClient } from '../../httpClient'
+import { mainHttpClient } from '../../httpClient'
 import notificationDownloadAction from '../../actions/notificationDownload'
 import downloadFile from '../../utils/downloadFile'
 import { DOWNLOAD_PROGRESS_RING } from '../../colorConstants'
@@ -38,7 +38,7 @@ const Download = ({ path, schema, setNotificationDownload, user }) => {
         })
       }
 
-      mainHTTPClient
+      mainHttpClient
         .get(
           schema
             ? `/files?schema=${schema}&path=${path}&user=${user}`

--- a/src/components/NotificationDownload/NotificationDownload.js
+++ b/src/components/NotificationDownload/NotificationDownload.js
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux'
 
 import NotificationDownloadView from './NotificationDownloadView'
 
-import { mainHTTPClient } from '../../httpClient'
+import { mainHttpClient } from '../../httpClient'
 import downloadFile from '../../utils/downloadFile'
 import notificationDownloadAction from '../../actions/notificationDownload'
 
@@ -24,7 +24,7 @@ const NotificationDownload = () => {
 
   const handleRetry = (id, url, file) => {
     dispatch(notificationDownloadAction.removeNotificationDownload(id))
-    mainHTTPClient(url)
+    mainHttpClient(url)
       .then(response => {
         downloadFile(file, response)
         dispatch(

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -1,9 +1,9 @@
 import axios from 'axios'
 
-export const mainHTTPClient = axios.create({
+export const mainHttpClient = axios.create({
   baseURL: '/api'
 })
 
-export const functionsTemplatesHTTPClient = axios.create({
+export const functionTemplatesHttpClient = axios.create({
   baseURL: '/function-catalog'
 })

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -11,8 +11,7 @@ module.exports = function(app) {
   app.use(
     '/function-catalog',
     createProxyMiddleware({
-      target:
-        'https://raw.githubusercontent.com/mlrun/functions/master/catalog.json',
+      target: 'https://raw.githubusercontent.com/mlrun/functions/master',
       pathRewrite: {
         '^/function-catalog': ''
       },


### PR DESCRIPTION
- /function-catalog/catalog.json - to return the entire catalog.
- /function-catalog/aggregate/function.yaml - to get specific function.
- Also renamed `HTTP` to `Http` in methods/properties names.