### PR TITLE
Fix [Jobs] Artifacts: preview not working, wrong user value sent

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -31,7 +31,7 @@ const DetailsArtifacts = ({ jobsStore, selectedItem }) => {
         date: formatDatetime(selectedItem.startTime),
         user: selectedItem?.labels
           ?.find(item => item.match(/v3io_user|owner/g))
-          .replace(/v3io_user|owner: /, '')
+          .replace(/(v3io_user|owner): /, '')
       }
     }
     return {
@@ -41,7 +41,7 @@ const DetailsArtifacts = ({ jobsStore, selectedItem }) => {
       date: formatDatetime(selectedItem.startTime),
       user: selectedItem?.labels
         ?.find(item => item.match(/v3io_user|owner/g))
-        .replace(/v3io_user|owner: /, '')
+        .replace(/(v3io_user|owner): /, '')
     }
   })
 


### PR DESCRIPTION
For example: `user=:+admin` is sent as a search param.

Bug originated in PR https://github.com/mlrun/ui/pull/70