### PR TITLE
Impl [Config] Add `x-v3io-session-key` req header to nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY nginx/nginx.conf.tmpl /etc/nginx/conf.d/
 EXPOSE 80
 
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}"
-ENV MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master/catalog.json}"
+ENV MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY}"
+ENV MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master}"
 
-CMD ["/bin/sh", "-c", "envsubst '${MLRUN_API_PROXY_URL} ${MLRUN_FUNCTION_CATALOG_URL}' < /etc/nginx/conf.d/nginx.conf.tmpl > /etc/nginx/conf.d/nginx.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${MLRUN_API_PROXY_URL} ${MLRUN_V3IO_ACCESS_KEY} ${MLRUN_FUNCTION_CATALOG_URL}' < /etc/nginx/conf.d/nginx.conf.tmpl > /etc/nginx/conf.d/nginx.conf && nginx -g 'daemon off;'"]

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -14,7 +14,8 @@ server {
   }
 
   location /api {
-      proxy_pass ${MLRUN_API_PROXY_URL};
+    proxy_set_header x-v3io-session-key ${MLRUN_V3IO_ACCESS_KEY};
+    proxy_pass ${MLRUN_API_PROXY_URL};
   }
 
   error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
For example, add this when running docker image:

```
-e MLRUN_V3IO_ACCESS_KEY=0a55b9d4-431e-443a-848b-c20f727c9943
```

Related to PR https://github.com/mlrun/ui/pull/98