### PR TITLE
Impl [Build] Use MLRun docker image env vars in `docker` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "start": "node scripts/start.js --no-cache",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js",
-    "docker": "COMMIT_HASH=`git rev-parse --short HEAD`; docker build -t iguazio/mlrun-ui:${COMMIT_HASH} --build-arg COMMIT_HASH=${COMMIT_HASH} --build-arg DATE=\"`date -u`\" -f Dockerfile ."
+    "docker": "COMMIT_HASH=`git rev-parse --short HEAD`; docker build -t ${MLRUN_DOCKER_REGISTRY}${MLRUN_DOCKER_REPO:-iguazio}/mlrun-ui:${MLRUN_DOCKER_TAG:-${COMMIT_HASH}} --build-arg COMMIT_HASH=${COMMIT_HASH} --build-arg DATE=\"`date -u`\" -f Dockerfile ."
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
- `MLRUN_DOCKER_REGISTRY`: for example `quay.io/` (mind the `/`). If omitted will default to dockerhub.
- `MLRUN_DOCKER_REPO`: for example `mlrun` (defaults to `iguazio`).
- `MLRUN_DOCKER_TAG`: for example `latest` (defaults to the short form of the current git commit hash).

Usage example:

```
MLRUN_DOCKER_REGISTRY=quay.io/ MLRUN_DOCKER_REPO=mlrun MLRUN_DOCKER_TAG=latest npm run docker
```