### PR TITLE
Override x-v3io-session-key header only if it's empty

### DIFF
--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -1,3 +1,8 @@
+map $http_x_v3io_session_key $v3io_session_key {
+    default   $http_x_v3io_session_key;
+    ""        ${MLRUN_V3IO_ACCESS_KEY};
+}
+
 server {
 
   listen 80;
@@ -14,7 +19,7 @@ server {
   }
 
   location /api {
-    proxy_set_header x-v3io-session-key ${MLRUN_V3IO_ACCESS_KEY};
+    proxy_set_header x-v3io-session-key $v3io_session_key;
     proxy_pass ${MLRUN_API_PROXY_URL};
   }
 


### PR DESCRIPTION
the old config with `proxy_set_header x-v3io-session-key ${MLRUN_V3IO_ACCESS_KEY};` override the `x-v3io-session-key` no matter what (even if the env var is not set)
with the new config we override the header only if the header (not the env var) is not set already
how it's working:
```
map $http_x_v3io_session_key $v3io_session_key {
    default   $http_x_v3io_session_key;
    ""        ${MLRUN_V3IO_ACCESS_KEY};
}
```
this basically says, if the value of the `x-v3io-session-key` header (`$http_x_v3io_session_key`) is `""` assign the `$v3io_session_key` variable with the value of `${MLRUN_V3IO_ACCESS_KEY}` otherwise (`default`) assign it the header value

and afterwards we assign the variable to the header
`proxy_set_header x-v3io-session-key $v3io_session_key;`

the `map` directive is only allowed under an http block (the root), that's why it's not inside the `location /api {` block