### PR TITLE
[Jobs] Wizard: Use `@` instead of `:` for function link

### DIFF
--- a/src/components/JobsPanel/JobsPanel.js
+++ b/src/components/JobsPanel/JobsPanel.js
@@ -200,7 +200,7 @@ const JobsPanel = ({
           ...jobsStore.newJob.task.spec,
           output_path: panelState.outputPath,
           input_path: panelState.inputPath,
-          function: `${match.params.projectName}/${selectedFunction.metadata.name}:${selectedFunction.metadata.hash}`
+          function: `${match.params.projectName}/${selectedFunction.metadata.name}@${selectedFunction.metadata.hash}`
         }
       }
     }


### PR DESCRIPTION
https://trello.com/c/bWjIiDpI/471-jobs-wizard-use-instead-of-for-function-link