### PR TITLE
[Jobs] Workflow jobs have wrong type icon

### DIFF
--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -17,7 +17,7 @@ const createJobsContent = (content, groupedByWorkflow) => {
           class: 'jobs_medium'
         },
         type: {
-          value: groupedByWorkflow ? 'workflow' : type,
+          value: typeof groupedByWorkflow !== 'boolean' ? 'workflow' : type,
           class: 'jobs_extra-small',
           type: 'type'
         },


### PR DESCRIPTION
https://trello.com/c/YZzOHS8o/489-jobs-workflow-jobs-have-wrong-type-icon

Before:
![image](https://user-images.githubusercontent.com/13918850/88798518-ae2db580-d1ad-11ea-8a76-57f6ef295e80.png)

After:
![image](https://user-images.githubusercontent.com/13918850/88798505-aa9a2e80-d1ad-11ea-8a0c-edb3d652cfd3.png)
