### PR TITLE
[Create Job] Volumes: wrong model property name

### DIFF
--- a/src/components/JobsPanel/JobsPanelView.js
+++ b/src/components/JobsPanel/JobsPanelView.js
@@ -90,7 +90,7 @@ const JobsPanelView = ({
                 panelState={panelState}
                 setNewJobVolumeMounts={setNewJobVolumeMounts}
                 setNewJobVolumes={setNewJobVolumes}
-                volumeMounts={jobsStore.newJob.function.spec.volumeMounts}
+                volumeMounts={jobsStore.newJob.function.spec.volume_mounts}
                 volumes={jobsStore.newJob.function.spec.volumes}
               />
             </Accordion>

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -145,7 +145,7 @@ export const generateTableData = (
       payload: {
         dataInputs: dataInputs,
         parameters,
-        volumeMounts,
+        volume_mounts: volumeMounts,
         volumes,
         environmentVariables: [],
         secretSources: []
@@ -154,7 +154,7 @@ export const generateTableData = (
     setNewJob({
       inputs: parseDefaultContent(dataInputs),
       parameters: parseDefaultContent(parameters),
-      volumeMounts: volumeMounts.length
+      volume_mounts: volumeMounts.length
         ? volumeMounts.map(volumeMounts => volumeMounts.data)
         : [],
       volumes,

--- a/src/components/JobsPanel/panelReducer.js
+++ b/src/components/JobsPanel/panelReducer.js
@@ -21,7 +21,7 @@ export const initialState = {
       dataInputs: [],
       parameters: [],
       volumes: [],
-      volumeMounts: [],
+      volume_mounts: [],
       environmentVariables: [],
       secretSources: []
     },
@@ -37,7 +37,7 @@ export const initialState = {
   tableData: {
     parameters: [],
     dataInputs: [],
-    volumeMounts: [],
+    volume_mounts: [],
     volumes: [],
     environmentVariables: [],
     secretSources: []
@@ -107,7 +107,7 @@ export const panelReducer = (state, { type, payload }) => {
             dataInputs: {},
             parameters: {},
             volumes: [],
-            volumeMounts: [],
+            volume_mounts: [],
             environmentVariables: [],
             secretSources: []
           },
@@ -334,7 +334,7 @@ export const panelReducer = (state, { type, payload }) => {
           ...state.previousPanelData,
           tableData: {
             ...state.previousPanelData.tableData,
-            volumeMounts: payload
+            volume_mounts: payload
           }
         }
       }
@@ -409,7 +409,7 @@ export const panelReducer = (state, { type, payload }) => {
         ...state,
         tableData: {
           ...state.tableData,
-          volumeMounts: payload
+          volume_mounts: payload
         }
       }
     default:

--- a/src/components/JobsPanelResources/JobsPanelResources.js
+++ b/src/components/JobsPanelResources/JobsPanelResources.js
@@ -141,12 +141,12 @@ const JobsPanelResources = ({
     }
 
     handleAddItem(
-      panelState.tableData.volumeMounts,
+      panelState.tableData.volume_mounts,
       resourcesDispatch,
       newItemObj,
       volumeMounts,
       panelDispatch,
-      panelState.previousPanelData.tableData.volumeMounts,
+      panelState.previousPanelData.tableData.volume_mounts,
       resourcesActions.REMOVE_NEW_VOLUME_DATA,
       resourcesActions.SET_ADD_NEW_VOLUME,
       panelActions.SET_TABLE_DATA_VOLUME_MOUNTS,
@@ -212,7 +212,7 @@ const JobsPanelResources = ({
     handleEditVolume()
     handleEdit(
       volumeMounts,
-      panelState.tableData.volumeMounts,
+      panelState.tableData.volume_mounts,
       resourcesDispatch,
       resourcesState.selectedVolume.newName,
       panelDispatch,
@@ -237,9 +237,9 @@ const JobsPanelResources = ({
     )
     handleDelete(
       volumeMounts,
-      panelState.tableData.volumeMounts,
+      panelState.tableData.volume_mounts,
       panelDispatch,
-      panelState.previousPanelData.tableData.volumeMounts,
+      panelState.previousPanelData.tableData.volume_mounts,
       item,
       setNewJobVolumeMounts,
       panelActions.SET_TABLE_DATA_VOLUME_MOUNTS,

--- a/src/elements/JobsPanelVolumesTable/JobsPanelVolumesTable.js
+++ b/src/elements/JobsPanelVolumesTable/JobsPanelVolumesTable.js
@@ -79,7 +79,7 @@ export const JobsPanelVolumesTable = ({
     <JobsPanelTable
       addNewItem={resourcesState.addNewVolume}
       className="data-inputs volumes"
-      content={panelState.tableData.volumeMounts}
+      content={panelState.tableData.volume_mounts}
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
       handleSetSelectedVolume={handleSetSelectedVolume}

--- a/src/reducers/jobReducer.js
+++ b/src/reducers/jobReducer.js
@@ -44,7 +44,7 @@ const initialState = {
     function: {
       spec: {
         volumes: [],
-        volumeMounts: [],
+        volume_mounts: [],
         env: []
       }
     }
@@ -165,7 +165,7 @@ export default (state = initialState, { type, payload }) => {
             ...state.newJob.function,
             spec: {
               ...state.newJob.function.spec,
-              volumeMounts: payload
+              volume_mounts: payload
             }
           }
         }
@@ -190,7 +190,7 @@ export default (state = initialState, { type, payload }) => {
           function: {
             spec: {
               volumes: [],
-              volumeMounts: [],
+              volume_mounts: [],
               env: []
             }
           }
@@ -253,7 +253,7 @@ export default (state = initialState, { type, payload }) => {
             ...state.newJob.function,
             spec: {
               ...state.newJob.function.spec,
-              volumeMounts: payload.volumeMounts,
+              volume_mounts: payload.volume_mounts,
               volumes: payload.volumes,
               env: payload.environmentVariables
             }


### PR DESCRIPTION
https://trello.com/c/ExbCGkee/525-create-job-volumes-wrong-model-property-name

In the body of the request to `POST /api/submit_job` the volumes were set in `function.spec.volumeMounts` instead of `function.spec.volume_mounts`.