### PR TITLE
Fix [Create Job] Schedule>Simple>Weekly: wrong day indexes

### DIFF
--- a/src/api/jobs-api.js
+++ b/src/api/jobs-api.js
@@ -2,7 +2,7 @@ import { mainHttpClient } from '../httpClient'
 
 export default {
   filterByStatus: (project, state) =>
-    mainHttpClient.get(`/runs?project=${project}&&state=${state}`),
+    mainHttpClient.get(`/runs?project=${project}&state=${state}`),
   getAll: (project, state, event) => {
     let url = `/runs?project=${project}`
 

--- a/src/components/ScheduleJob/ScheduleJob.js
+++ b/src/components/ScheduleJob/ScheduleJob.js
@@ -106,7 +106,7 @@ const ScheduleJob = ({ handleRunJob, match, setOpenScheduleJob }) => {
             .filter(day =>
               recurringState.scheduleRepeat.week.days.includes(day.id)
             )
-            .map(day => day.index)
+            .map(day => (day.index + 6) % 7) // temporarily make Monday=0, Tuesday=1, ..., Sunday=6
             .sort()
             .join(',')
 

--- a/src/components/ScheduleJob/ScheduleJobView.js
+++ b/src/components/ScheduleJob/ScheduleJobView.js
@@ -55,7 +55,6 @@ const ScheduleJobView = ({
         </h3>
         {activeTab === tabs[0].id && (
           <ScheduleJobSimple
-            cron={cron}
             date={date}
             daysOfWeek={daysOfWeek}
             handleDaysOfWeek={handleDaysOfWeek}
@@ -64,7 +63,6 @@ const ScheduleJobView = ({
             recurringDispatch={recurringDispatch}
             recurringState={recurringState}
             selectOptions={selectOptions}
-            setCron={setCron}
             setDate={setDate}
             setIsRecurring={setIsRecurring}
             setTime={setTime}

--- a/src/components/ScheduleJobSimple/ScheduleJobSimple.js
+++ b/src/components/ScheduleJobSimple/ScheduleJobSimple.js
@@ -9,7 +9,6 @@ import TimePicker from '../../common/TimePicker/TimePicker'
 import './scheduleJobSimple.scss'
 
 const ScheduleJobSimple = ({
-  cron,
   date,
   daysOfWeek,
   handleDaysOfWeek,
@@ -18,7 +17,6 @@ const ScheduleJobSimple = ({
   recurringDispatch,
   recurringState,
   selectOptions,
-  setCron,
   setDate,
   setIsRecurring,
   setTime,
@@ -39,7 +37,6 @@ const ScheduleJobSimple = ({
       </div>
       {isRecurring && (
         <ScheduleRecurring
-          cron={cron}
           daysOfWeek={daysOfWeek}
           handleDaysOfWeek={handleDaysOfWeek}
           match={match}
@@ -53,7 +50,6 @@ const ScheduleJobSimple = ({
 }
 
 ScheduleJobSimple.propTypes = {
-  cron: PropTypes.string.isRequired,
   date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   daysOfWeek: PropTypes.array.isRequired,
   handleDaysOfWeek: PropTypes.func.isRequired,
@@ -62,7 +58,6 @@ ScheduleJobSimple.propTypes = {
   recurringDispatch: PropTypes.func.isRequired,
   recurringState: PropTypes.shape({}).isRequired,
   selectOptions: PropTypes.shape({}).isRequired,
-  setCron: PropTypes.func.isRequired,
   setDate: PropTypes.func.isRequired,
   setIsRecurring: PropTypes.func.isRequired,
   setTime: PropTypes.func.isRequired,


### PR DESCRIPTION
Mon = 0, Tue = 1, Wed = 2, Thu = 3, Fri = 4, Sat = 5, Sun = 6

originated in https://github.com/mlrun/ui/pull/226