### PR TITLE
Adding GH action to build image per commit to development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,7 @@ name: Build
 on:
   push:
     branches:
-    - adding_build_ci
-#    - development
+    - development
 #    - '[0-9]+.[0-9]+.x'
 
 jobs:
@@ -13,14 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'hedingber/ui'
+    if: github.repository == 'mlrun/ui'
 
     steps:
     - uses: actions/checkout@v2
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Set MLRUN_DOCKER_REPO env var
-      # When developing set this to your github username
       run: echo "::set-env name=MLRUN_DOCKER_REPO::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
     - name: Set LATEST_VERSION env var
       run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,6 @@ jobs:
       run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set GIT_HASH env var
       run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
-    - name: Set MLRUN_DOCKER_TAG env var
-      run: echo "::set-env name=MLRUN_DOCKER_TAG::$(echo $LATEST_VERSION-$GIT_HASH)"
     - name: Setup Node.js 12
       uses: actions/setup-node@v1
       with:
@@ -36,6 +34,6 @@ jobs:
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Build image
 
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG=${{ github.repository_owner }} npm run docker
     - name: Push image
-      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:"$MLRUN_DOCKER_TAG"
+      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:${{ github.repository_owner }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,6 @@ on:
 #    - development
 #    - '[0-9]+.[0-9]+.x'
 
-env:
-  # When developing set this to your github username
-  MLRUN_DOCKER_REPO: 'hedingber'
-
 jobs:
   build-images:
     name: Build and push ui image
@@ -18,6 +14,9 @@ jobs:
 
     # let's not run this on every fork, change to your fork when developing
     if: github.repository == 'hedingber/ui'
+    env:
+      # When developing set this to your github username
+      MLRUN_DOCKER_REPO: 'hedingber'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,6 @@ jobs:
     - name: Docker login
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Build image
-
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=${{ env.MLRUN_DOCKER_REPO }} MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
     - name: Push image
-      run: docker push ghcr.io/${{ env.MLRUN_DOCKER_REPO }}/ui:"$MLRUN_DOCKER_TAG"
+      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/mlrun-ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,13 +7,17 @@ on:
 #    - development
 #    - '[0-9]+.[0-9]+.x'
 
+env:
+  # When developing set this to your github username
+  MLRUN_DOCKER_REPO: hedingber
+
 jobs:
   build-images:
     name: Build and push ui image
     runs-on: ubuntu-latest
 
-    # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'hedingber/ui'
+    # let's not run this on every fork
+    if: github.repository == '${{ env.MLRUN_DOCKER_REPO }}/ui'
 
     steps:
     - uses: actions/checkout@v2
@@ -23,13 +27,16 @@ jobs:
       run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set GIT_HASH env var
       run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Set MLRUN_DOCKER_TAG env var
+      run: echo "::set-env name=MLRUN_DOCKER_TAG::$($LATEST_VERSION-$GIT_HASH)"
     - name: Setup Node.js 12
       uses: actions/setup-node@v1
       with:
         node-version: '12'
     - name: Docker login
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
-    - name: Pull cache, build and push image
+    - name: Build image
 
-      # When developing add MLRUN_DOCKER_REPO=<your fork name>
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=hedingber MLRUN_DOCKER_TAG="$LATEST_VERSION"-"$GIT_HASH" npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
+    - name: Push image
+      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,6 @@ jobs:
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Build image
 
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG=${{ github.repository_owner }} npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=${{ github.repository_owner }} MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
     - name: Push image
       run: docker push ghcr.io/${{ github.repository_owner }}/ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,6 @@ jobs:
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Build image
 
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=${{ env.MLRUN_DOCKER_REPO }} MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
     - name: Push image
-      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:"$MLRUN_DOCKER_TAG"
+      run: docker push ghcr.io/${{ env.MLRUN_DOCKER_REPO }}/ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'hedingber/ui'
     env:
       # When developing set this to your github username
-      MLRUN_DOCKER_REPO: 'hedingber'
+      MLRUN_DOCKER_REPO: 'hedier'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,14 +14,14 @@ jobs:
 
     # let's not run this on every fork, change to your fork when developing
     if: github.repository == 'hedingber/ui'
-    env:
-      # When developing set this to your github username
-      MLRUN_DOCKER_REPO: 'hedier'
 
     steps:
     - uses: actions/checkout@v2
     - name: Install curl and jq
       run: sudo apt-get install curl jq
+    - name: Set MLRUN_DOCKER_REPO env var
+      # When developing set this to your github username
+      run: echo "::set-env name=MLRUN_DOCKER_REPO::$(echo hedingber)"
     - name: Set LATEST_VERSION env var
       run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set GIT_HASH env var

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - adding_build_ci
+#    - development
+#    - '[0-9]+.[0-9]+.x'
+
+jobs:
+  build-images:
+    name: Build and push ui image
+    runs-on: ubuntu-latest
+
+    # let's not run this on every fork, change to your fork when developing
+    if: github.repository == 'hedingber/ui'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install curl and jq
+      run: sudo apt-get install curl jq
+    - name: Set LATEST_VERSION env var
+      run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+    - name: Set GIT_HASH env var
+      run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Setup Node.js 12
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - run: npm install
+    - name: Docker login
+      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
+    - name: Pull cache, build and push image
+
+      # When developing add MLRUN_DOCKER_REPO=<your fork name>
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=hedingber MLRUN_DOCKER_TAG="$LATEST_VERSION"-"$GIT_HASH" npm run docker

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,11 +21,13 @@ jobs:
       run: sudo apt-get install curl jq
     - name: Set MLRUN_DOCKER_REPO env var
       # When developing set this to your github username
-      run: echo "::set-env name=MLRUN_DOCKER_REPO::$(echo hedingber)"
+      run: echo "::set-env name=MLRUN_DOCKER_REPO::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
     - name: Set LATEST_VERSION env var
       run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set GIT_HASH env var
       run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Set MLRUN_DOCKER_TAG env var
+      run: echo "::set-env name=MLRUN_DOCKER_TAG::$(echo $LATEST_VERSION-$GIT_HASH)"
     - name: Setup Node.js 12
       uses: actions/setup-node@v1
       with:
@@ -34,6 +36,6 @@ jobs:
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Build image
 
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO=${{ github.repository_owner }} MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG="$MLRUN_DOCKER_TAG" npm run docker
     - name: Push image
-      run: docker push ghcr.io/${{ github.repository_owner }}/ui:"$MLRUN_DOCKER_TAG"
+      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   # When developing set this to your github username
-  MLRUN_DOCKER_REPO: hedingber
+  MLRUN_DOCKER_REPO: 'hedingber'
 
 jobs:
   build-images:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set GIT_HASH env var
       run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
     - name: Set MLRUN_DOCKER_TAG env var
-      run: echo "::set-env name=MLRUN_DOCKER_TAG::$($LATEST_VERSION-$GIT_HASH)"
+      run: echo "::set-env name=MLRUN_DOCKER_TAG::$(echo $LATEST_VERSION-$GIT_HASH)"
     - name: Setup Node.js 12
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork
-    if: github.repository == '${{ env.MLRUN_DOCKER_REPO }}/ui'
+    if: github.repository == ${{ env.MLRUN_DOCKER_REPO }}/ui
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,4 +36,4 @@ jobs:
 
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_DOCKER_TAG=${{ github.repository_owner }} npm run docker
     - name: Push image
-      run: docker push ghcr.io/"$MLRUN_DOCKER_REPO"/ui:${{ github.repository_owner }}
+      run: docker push ghcr.io/${{ github.repository_owner }}/ui:"$MLRUN_DOCKER_TAG"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ jobs:
     name: Build and push ui image
     runs-on: ubuntu-latest
 
-    # let's not run this on every fork
-    if: github.repository == ${{ env.MLRUN_DOCKER_REPO }}/ui
+    # let's not run this on every fork, change to your fork when developing
+    if: github.repository == 'hedingber/ui'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12'
-    - run: npm install
     - name: Docker login
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Pull cache, build and push image


### PR DESCRIPTION
This will trigger a github action for each commit to development.
The github action will build this image `ghcr.io/mlrun/mlrun-ui:<latest-version>-<commit-hash>` (`latest-version` is latest released MLRun version (not RC), e.g. as of writing this - `0.5.2`)
The github action will push this image and we can see it in the mlrun organization packages.

To make this to work 2 secrets need to be set in the GH repo:
`CR_PAT` (Container registry personal access token) - I currently used PAT of mlrun-iguazio
`CR_USERNAME` - currently `mlrun-iguazio`
