### PR TITLE
fixed bug with recursive call

### DIFF
--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -93,7 +93,7 @@ const Jobs = ({
   const getWorkflows = useCallback(
     token => {
       fetchWorkflows(token).then(pageToken => {
-        if (pageToken.length > 0) {
+        if (pageToken?.length > 0) {
           getWorkflows(pageToken)
         }
       })

--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -93,7 +93,7 @@ const Jobs = ({
   const getWorkflows = useCallback(
     token => {
       fetchWorkflows(token).then(pageToken => {
-        if (pageToken) {
+        if (pageToken.length > 0) {
           getWorkflows(pageToken)
         }
       })


### PR DESCRIPTION
When an error occurred on `GET /api/workflows` the error was not handled correctly and caused a wrong request to be sent, such as this one:

`GET /api/workflows?page_size=100&page_token=%7B%22type%22:%22FETCH_WORKFLOWS_FAILURE%22,%22payload%22:%7B%22message%22:%22Request+failed+with+status+code+414%22,%22name%22:%22Error%22,%22stack%22:%22Error:+Request+failed+with+status+code+414%5Cn++++at+n.exports+(http:%2F%2F127.0.0.1:8080%2Fstatic%2Fjs%2F0.04bae032.chunk.js:1:4208)%5Cn++++at+n.exports+(http:%2F%2F127.0.0.1:8080%2Fstatic%2Fjs%2F0.04bae032.chunk.js:1:10108)%5Cn++++at+XMLHttpRequest.h.onreadystatechange+(http:%2F%2F127.0.0.1:8080%2Fstatic%2Fjs%2F0.04bae032.chunk.js:1:3037)%22,%22config%22:%7B%22url%22:%22%2Fworkflows%22,%22method%22:%22get%22,%22params%22:%7B%22page_size%22:100,%22page_token%22:%7B%22type%22:%22FETCH_WORKFLOWS_FAILURE%22,%22payload%22:%7B%22message%22:%22Request+failed+with+status+code+414%22,%22name%22:%22Error%22,%22stack%22:%22Error:+Request+failed+with+status+code+414%5Cn++++at+n.exports+(http:%2F%2F127.0.0.1:8080%2Fstatic%2Fjs%2F0.04bae032.chunk.js:1:4208)%5Cn++++at+n.exports+`