### PR TITLE
Add proxy to Nuclio API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ COPY nginx/nginx.conf.tmpl /etc/nginx/conf.d/
 EXPOSE 80
 
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}"
+ENV NUCLIO_API_PROXY_URL="${NUCLIO_API_PROXY_URL:-http://localhost:8080}"
 ENV MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 ENV MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master}"
 
-CMD ["/bin/sh", "-c", "envsubst '${MLRUN_API_PROXY_URL} ${MLRUN_V3IO_ACCESS_KEY} ${MLRUN_FUNCTION_CATALOG_URL}' < /etc/nginx/conf.d/nginx.conf.tmpl > /etc/nginx/conf.d/nginx.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${MLRUN_API_PROXY_URL} ${NUCLIO_API_PROXY_URL} ${MLRUN_V3IO_ACCESS_KEY} ${MLRUN_FUNCTION_CATALOG_URL}' < /etc/nginx/conf.d/nginx.conf.tmpl > /etc/nginx/conf.d/nginx.conf && nginx -g 'daemon off;'"]

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ You can pass the following environment variables to the `docker run` command to 
 | Name  | Description |
 | ----- | ----------- |
 | `MLRUN_API_PROXY_URL` | Sets the base URL of the backend API<br />Default: `http://localhost:80`<br />Example: `http://17.220.101.245:30080` |
+| `NUCLIO_API_PROXY_URL` | Sets the base URL of the Nuclio backend API<br />Default: `http://localhost:8080`<br />Example: `http://17.220.101.245:30080` |
 | `MLRUN_V3IO_ACCESS_KEY` | Sets the V3IO access key to use for accessing V3IO containers<br />Example: `a7097c94-6e8f-436d-9717-a84abe2861d1` |
 | `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com/mlrun/functions/master` |
 
 Example:
 
-`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
+`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_API_PROXY_URL=http://17.220.101.245:30081 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
 
 ### Docker container contents
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -18,14 +18,14 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
-  location /api {
-    proxy_set_header x-v3io-session-key $v3io_session_key;
-    proxy_pass ${MLRUN_API_PROXY_URL};
-  }
-
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
     proxy_pass ${NUCLIO_API_PROXY_URL};
+  }
+
+  location /api {
+    proxy_set_header x-v3io-session-key $v3io_session_key;
+    proxy_pass ${MLRUN_API_PROXY_URL};
   }
 
   error_page   500 502 503 504  /50x.html;

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -23,6 +23,11 @@ server {
     proxy_pass ${MLRUN_API_PROXY_URL};
   }
 
+  location /nuclio {
+    rewrite ^/nuclio(/|$)(.*) /$2 last;
+    proxy_pass ${NUCLIO_API_PROXY_URL};
+  }
+
   error_page   500 502 503 504  /50x.html;
 
   location = /50x.html {

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -18,14 +18,14 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
-  location /nuclio {
-    rewrite ^/nuclio(/|$)(.*) /$2 break;
-    proxy_pass ${NUCLIO_API_PROXY_URL};
-  }
-
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
     proxy_pass ${MLRUN_API_PROXY_URL};
+  }
+
+  location /nuclio {
+    rewrite ^/nuclio(/|$)(.*) /$2 break;
+    proxy_pass ${NUCLIO_API_PROXY_URL};
   }
 
   error_page   500 502 503 504  /50x.html;

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -24,7 +24,7 @@ server {
   }
 
   location /nuclio {
-    rewrite ^/nuclio(/|$)(.*) /$2 last;
+    rewrite ^/nuclio(/|$)(.*) /$2 break;
     proxy_pass ${NUCLIO_API_PROXY_URL};
   }
 


### PR DESCRIPTION
Added this block in the nginx configuration:
```
  location /nuclio {
    rewrite ^/nuclio(/|$)(.*) /$2 break;
    proxy_pass ${NUCLIO_API_PROXY_URL};
  }
```
This basically enabled to get to Nuclio API through the UI URL (to prevent CORS)
Any request that has the `/nuclio` prefix will be proxied to Nuclio API.
The `break` in the `rewrite` is important, without it nginx would try to handle the request after changing it (its URI) it means that for example a request to `/nuclio/api/projects` will first change its URI to `/api/projects` but then instead of going to the Nuclio API it would be "caught" by the `location /api` directive (intended for requests to MLRun API) and go to MLRun API.
`break` tells nginx to not re-handle the request after changing it