### PR TITLE
Fix [General] Default Nuclio API URL to resolvable host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY nginx/nginx.conf.tmpl /etc/nginx/conf.d/
 EXPOSE 80
 
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}"
-ENV MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-disabled}"
+ENV MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://nuclio-dashboard:8070}"
 ENV MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-disabled}"
 ENV MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 ENV MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY nginx/nginx.conf.tmpl /etc/nginx/conf.d/
 EXPOSE 80
 
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}"
-ENV MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://nuclio-dashboard:8070}"
+ENV MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://localhost:8070}"
 ENV MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-disabled}"
 ENV MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 ENV MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master}"

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ You can pass the following environment variables to the `docker run` command to 
 | Name  | Description |
 | ----- | ----------- |
 | `MLRUN_API_PROXY_URL` | Sets the base URL of the backend API<br />Default: `http://localhost:80`<br />Example: `http://17.220.101.245:30080` |
-| `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `disabled`<br />Example: `http://17.220.101.245:30080` |
-| `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `disabled`<br />Example: `http://17.220.101.245:30080` |
+| `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `http://nuclio-dashboard:8070`<br />Example: `http://17.220.101.245:30070` |
+| `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `disabled`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_V3IO_ACCESS_KEY` | Sets the V3IO access key to use for accessing V3IO containers<br />Example: `a7097c94-6e8f-436d-9717-a84abe2861d1` |
 | `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com/mlrun/functions/master` |
 
 Example:
 
-`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30081 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30081 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
+`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
 
 ### Docker container contents
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can pass the following environment variables to the `docker run` command to 
 | Name  | Description |
 | ----- | ----------- |
 | `MLRUN_API_PROXY_URL` | Sets the base URL of the backend API<br />Default: `http://localhost:80`<br />Example: `http://17.220.101.245:30080` |
-| `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `http://nuclio-dashboard:8070`<br />Example: `http://17.220.101.245:30070` |
+| `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `disabled`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_V3IO_ACCESS_KEY` | Sets the V3IO access key to use for accessing V3IO containers<br />Example: `a7097c94-6e8f-436d-9717-a84abe2861d1` |
 | `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com/mlrun/functions/master` |


### PR DESCRIPTION
the old default - `disabled` - wasn't working, the nginx failed starting, when a host is given to `proxy_pass` it must be resolvable, therefore deafulting to `http://localhost:8070` instead