### PR TITLE
Fix [Artifacts] Refresh: `tag=latest` should not be sent

### DIFF
--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -13,7 +13,7 @@ export default {
       url = `${url}&${labels}`
     }
 
-    if (item?.tag) {
+    if (item?.tag && !/latest/i.test(item.tag)) {
       url = `${url}&tag=${item.tag}`
     }
 

--- a/src/components/Artifacts/Artifacts.js
+++ b/src/components/Artifacts/Artifacts.js
@@ -173,7 +173,7 @@ const Artifacts = ({
 
   const handleArtifactFilterTree = useCallback(
     item => {
-      const value = item.toLowerCase() !== 'latest' ? item.toLowerCase() : ''
+      const value = item.toLowerCase()
       fetchData({
         tag: value,
         project: match.params.projectName,
@@ -182,7 +182,7 @@ const Artifacts = ({
       })
       setArtifactFilter({
         ...artifactsStore.filter,
-        tag: value || 'latest'
+        tag: value
       })
     },
     [fetchData, artifactsStore, match, setArtifactFilter]

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -68,7 +68,7 @@ const FilterMenu = ({
           })
         )
         onChange({
-          tag: artifactFilter.tag !== 'latest' ? artifactFilter.tag : '',
+          tag: artifactFilter.tag,
           project: match.params.projectName,
           labels,
           name


### PR DESCRIPTION
Backports PR https://github.com/mlrun/ui/pull/251 from **development** branch into **0.5.x** branch.