### PR TITLE
[Create Job][Scheduled Job] Show human-readable schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "axios": "^0.19.0",
     "camelcase": "^5.2.0",
     "classnames": "^2.2.6",
+    "cronstrue": "^1.103.0",
     "dotenv": "6.2.0",
     "dotenv-expand": "5.1.0",
     "fs-extra": "7.0.1",

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -26,14 +26,18 @@ export const generateTableHeaders = scheduled => {
       },
       {
         header: 'Type',
-        class: 'jobs_big'
+        class: 'jobs_medium'
       },
       {
         header: 'Created time',
-        class: 'jobs_big'
+        class: 'jobs_medium'
       },
       {
         header: 'Next run (Local TZ)',
+        class: 'jobs_big'
+      },
+      {
+        header: 'Schedule',
         class: 'jobs_big'
       },
       {

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -37,7 +37,7 @@ export const generateTableHeaders = scheduled => {
         class: 'jobs_big'
       },
       {
-        header: 'Schedule',
+        header: 'Schedule (UTC)',
         class: 'jobs_big'
       },
       {

--- a/src/components/ScheduleCron/ScheduleCron.js
+++ b/src/components/ScheduleCron/ScheduleCron.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
+import cronstrue from 'cronstrue'
 
 import Input from '../../common/Input/Input'
 import { ReactComponent as Alert } from '../../images/unsuccess_alert.svg'
@@ -16,7 +17,7 @@ const ScheduleCron = ({ cron, error, setCron, setEditMode }) => {
         <Alert className="error-icon" />
         {error}
       </div>
-      Note: all times are interpreted in UTC timezone
+      <p>Note: all times are interpreted in UTC timezone</p>
       <Input
         placeholder="10 * * * *"
         value={cron}
@@ -25,6 +26,11 @@ const ScheduleCron = ({ cron, error, setCron, setEditMode }) => {
         onFocus={setEditMode}
         type="text"
       />
+      <p>
+        {cronstrue.toString(cron, {
+          throwExceptionOnParseError: false
+        })}
+      </p>
       <div>
         You can use{' '}
         <a

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -1,5 +1,6 @@
 import { formatDatetime } from './datetime'
 import measureTime from './measureTime'
+import cronstrue from 'cronstrue'
 
 const createJobsContent = (content, groupedByWorkflow, scheduled) => {
   return content.map(contentItem => {
@@ -12,18 +13,22 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
           },
           type: {
             value: contentItem.type,
-            class: 'jobs_big',
+            class: 'jobs_medium',
             type: 'type'
           },
           createdTime: {
             value: formatDatetime(contentItem.createdTime, 'Not yet started'),
-            class: 'jobs_big',
+            class: 'jobs_medium',
             type: 'date'
           },
           nextRun: {
             value: formatDatetime(contentItem.nextRun),
             class: 'jobs_big',
             type: 'date'
+          },
+          schedule: {
+            value: cronstrue.toString(contentItem.scheduled_object.schedule),
+            class: 'jobs_big'
           }
         }
       } else {


### PR DESCRIPTION
https://trello.com/c/1eS2UK2Y/571-create-jobscheduled-job-show-human-readable-schedule

- **Scheduled Jobs**: Added "Schedule" column with a human-readable description of the cronstring of the scheduled job.
  ![image](https://user-images.githubusercontent.com/13918850/97708490-8c501180-1ac1-11eb-8707-924b26030c1c.png)
- **Create Job**: In "Cronstring" tab of scheduling a new job, add human-readable description of the entered cronstring.
  ![image](https://user-images.githubusercontent.com/13918850/97708934-34fe7100-1ac2-11eb-8b23-199fe5ea7761.png)