### PR TITLE
Fix [Config] Proxy to Nuclio API not working in production

### DIFF
--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -9,5 +9,5 @@ export const functionTemplatesHttpClient = axios.create({
 })
 
 export const nuclioHttpClient = axios.create({
-  baseURL: `${process.env.PUBLIC_URL}/nuclio`
+  baseURL: '/nuclio'
 })


### PR DESCRIPTION
Requests were sent relative to base public URL (`/mlrun`), for example `/mlrun/nuclio`, instead of `/nuclio` absolutely.
Relates to PR https://github.com/mlrun/ui/pull/271.