### PR TITLE
[Artifacts] Details: added tooltip to download button

### DIFF
--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -83,12 +83,14 @@ const DetailsView = ({
             />
           )}
           {pageData.page === ARTIFACTS_PAGE && (
-            <Download
-              fileName={selectedItem.db_key || selectedItem.key}
-              path={selectedItem.target_path.path}
-              schema={selectedItem.target_path.schema}
-              user={selectedItem.producer?.owner}
-            />
+            <Tooltip template={<TextTooltipTemplate text="Download" />}>
+              <Download
+                fileName={selectedItem.db_key || selectedItem.key}
+                path={selectedItem.target_path.path}
+                schema={selectedItem.target_path.schema}
+                user={selectedItem.producer?.owner}
+              />
+            </Tooltip>
           )}
           <TableActionsMenu item={selectedItem} time={500} menu={actionsMenu} />
           <Link


### PR DESCRIPTION
https://trello.com/c/vqO5h5xV/582-artifacts-details-download-button-missing-tooltip

**Artifacts › Details panel**: [bugfix] add missing tooltip to download action 
![image](https://user-images.githubusercontent.com/13918850/98809730-bccf6e00-2426-11eb-898c-4f0069300255.png)
