### PR TITLE
Impl [Details panel] Stick tab headers & actions to top on scroll

### DIFF
--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -50,61 +50,57 @@ const DetailsView = ({
 }) => {
   return (
     <div className="table__item">
-      <div className="item-header">
-        <div className="item-header__data">
-          <h3>{selectedItem.name || selectedItem.db_key}</h3>
-          <span>
-            {Object.keys(selectedItem).length > 0 && pageData.page === JOBS_PAGE
-              ? formatDatetime(selectedItem?.startTime, 'Not yet started')
-              : formatDatetime(new Date(selectedItem?.updated), 'N/A')}
-            {selectedItem.state && (
-              <Tooltip
-                template={
-                  <TextTooltipTemplate
-                    text={`${selectedItem.state[0].toUpperCase()}${selectedItem.state.slice(
-                      1
-                    )}`}
-                  />
-                }
-              >
-                <i className={selectedItem.state} />
-              </Tooltip>
-            )}
-          </span>
-        </div>
-        <div className="item-header__buttons">
-          {match.params.tab?.toUpperCase() === DETAILS_ARTIFACTS_TAB && (
-            <Select
-              options={iterationOptions}
-              label="Iteration:"
-              key="Iteration"
-              selectedId={iteration}
-              onClick={setIteration}
-            />
-          )}
-          {pageData.page === ARTIFACTS_PAGE && (
-            <Tooltip template={<TextTooltipTemplate text="Download" />}>
-              <Download
-                fileName={selectedItem.db_key || selectedItem.key}
-                path={selectedItem.target_path.path}
-                schema={selectedItem.target_path.schema}
-                user={selectedItem.producer?.owner}
-              />
+      <div className="item-header__data">
+        <h3>{selectedItem.name || selectedItem.db_key}</h3>
+        <span>
+          {Object.keys(selectedItem).length > 0 && pageData.page === JOBS_PAGE
+            ? formatDatetime(selectedItem?.startTime, 'Not yet started')
+            : formatDatetime(new Date(selectedItem?.updated), 'N/A')}
+          {selectedItem.state && (
+            <Tooltip
+              template={
+                <TextTooltipTemplate
+                  text={`${selectedItem.state[0].toUpperCase()}${selectedItem.state.slice(
+                    1
+                  )}`}
+                />
+              }
+            >
+              <i className={selectedItem.state} />
             </Tooltip>
           )}
-          <TableActionsMenu item={selectedItem} time={500} menu={actionsMenu} />
-          <Link
-            data-testid="details-close-btn"
-            to={`/projects/${match.params.projectName}/${
-              pageData.pageKind
-                ? pageData.pageKind
-                : pageData.page.toLowerCase()
-            }${pageData.page === JOBS_PAGE ? `/${match.params.jobTab}` : ''}`}
-            onClick={handleCancel}
-          >
-            <Close />
-          </Link>
-        </div>
+        </span>
+      </div>
+      <div className="item-header__buttons">
+        {match.params.tab?.toUpperCase() === DETAILS_ARTIFACTS_TAB && (
+          <Select
+            options={iterationOptions}
+            label="Iteration:"
+            key="Iteration"
+            selectedId={iteration}
+            onClick={setIteration}
+          />
+        )}
+        {pageData.page === ARTIFACTS_PAGE && (
+          <Tooltip template={<TextTooltipTemplate text="Download" />}>
+            <Download
+              fileName={selectedItem.db_key || selectedItem.key}
+              path={selectedItem.target_path.path}
+              schema={selectedItem.target_path.schema}
+              user={selectedItem.producer?.owner}
+            />
+          </Tooltip>
+        )}
+        <TableActionsMenu item={selectedItem} time={500} menu={actionsMenu} />
+        <Link
+          data-testid="details-close-btn"
+          to={`/projects/${match.params.projectName}/${
+            pageData.pageKind ? pageData.pageKind : pageData.page.toLowerCase()
+          }${pageData.page === JOBS_PAGE ? `/${match.params.jobTab}` : ''}`}
+          onClick={handleCancel}
+        >
+          <Close />
+        </Link>
       </div>
       <ul className="item-menu">
         {detailsMenu.map(link => (

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -21,9 +21,6 @@
 
     .item {
       &-header {
-        display: flex;
-        justify-content: space-between;
-
         &__data {
           h3 {
             margin: 27px 24px 10px;
@@ -45,6 +42,12 @@
         }
 
         &__buttons {
+          align-self: flex-end;
+          margin-top: -70px;
+          position: sticky;
+          top: -5px;
+          z-index: 5;
+
           display: flex;
           align-items: center;
 
@@ -62,10 +65,14 @@
       &-menu {
         display: flex;
         align-items: center;
-        margin: 0;
-        padding: 29px 0 0;
+        padding: 7px 0 0;
+        margin: 29px 0 0;
         list-style-type: none;
         border-bottom: $tableBorder;
+        position: sticky;
+        top: 0;
+        background-color: white;
+        z-index: 4;
 
         .menu-tab {
           padding: 8px 24px;


### PR DESCRIPTION
**Details panel:** Stick the tab headers and actions to the top when scrolling down
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/98826664-aa612e80-243e-11eb-8c67-762ad50a8b9e.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/98826680-ae8d4c00-243e-11eb-87f3-8cd6b1ce5d0e.png)
  In video:
  ![mlrun-details_panel-sticky_headers](https://user-images.githubusercontent.com/13918850/98827346-6de20280-243f-11eb-8a3a-afb00ec73bca.gif)

