### PR TITLE
[Artifacts] Wrong register dialog heading

### DIFF
--- a/src/components/Project/Project.js
+++ b/src/components/Project/Project.js
@@ -37,6 +37,7 @@ const Project = ({
       isEdit: false
     }
   })
+  const [artifactKind, setArtifactKind] = useState('')
   const history = useHistory()
   const inputRef = React.createRef(null)
 
@@ -57,9 +58,28 @@ const Project = ({
           )
       },
       {
-        label: 'Register artifact',
-        id: 'registerArtifact',
-        handler: () => setIsPopupDialogOpen(true)
+        label: 'Register File',
+        id: 'registerFile',
+        handler: () => {
+          setIsPopupDialogOpen(true)
+          setArtifactKind('file')
+        }
+      },
+      {
+        label: 'Register Model',
+        id: 'registerModel',
+        handler: () => {
+          setIsPopupDialogOpen(true)
+          setArtifactKind('model')
+        }
+      },
+      {
+        label: 'Register Dataset',
+        id: 'registerDataset',
+        handler: () => {
+          setIsPopupDialogOpen(true)
+          setArtifactKind('dataset')
+        }
       }
     ]
 
@@ -186,6 +206,7 @@ const Project = ({
 
   return (
     <ProjectView
+      artifactKind={artifactKind}
       fetchApiGateways={fetchApiGateways}
       createNewOptions={createNewOptions}
       editProject={editProject}

--- a/src/components/Project/ProjectView.js
+++ b/src/components/Project/ProjectView.js
@@ -19,6 +19,7 @@ import { ReactComponent as Settings } from '../../images/settings.svg'
 const ProjectView = React.forwardRef(
   (
     {
+      artifactKind,
       createNewOptions,
       fetchApiGateways,
       editProject,
@@ -216,12 +217,14 @@ const ProjectView = React.forwardRef(
           <RegisterArtifactPopup
             artifactFilter={{}}
             match={match}
-            pageData={{}}
+            pageData={{
+              pageKind: `${artifactKind}s`
+            }}
             refresh={() => {
               history.push(`/projects/${match.params.projectName}/artifacts`)
             }}
             setIsPopupDialogOpen={setIsPopupDialogOpen}
-            title="Register artifact"
+            title={`Register ${artifactKind}`}
           />
         )}
       </>
@@ -230,6 +233,7 @@ const ProjectView = React.forwardRef(
 )
 
 ProjectView.propTypes = {
+  artifactKind: PropTypes.string.isRequired,
   createNewOptions: PropTypes.array.isRequired,
   editProject: PropTypes.shape({}).isRequired,
   fetchProjectDataSets: PropTypes.func.isRequired,

--- a/src/components/RegisterArtifactPopup/RegisterArtifactPopup.js
+++ b/src/components/RegisterArtifactPopup/RegisterArtifactPopup.js
@@ -184,7 +184,7 @@ const RegisterArtifactPopup = ({
   return (
     <PopUpDialog
       data-testid="register-artifact"
-      headerText="Register artifact"
+      headerText={title}
       closePopUp={closePopupDialog}
     >
       <RegisterArtifactForm


### PR DESCRIPTION
https://trello.com/c/acmmF1ss/597-artifacts-wrong-register-dialog-heading

- **Project Overview**: Split “Register artifact” to “Register model”, “Register dataset”, & “Register file”
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/99559482-81f0ab80-29cd-11eb-9671-e19dfd869a47.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/99559493-861cc900-29cd-11eb-857e-e0afbb64a100.png)
- **Artifacts**: [bugfix] “Register artifact” heading was in all pop-up dialogs for registering models, files, & datasets, instead of having the respective heading: “Register model”, “Register dataset”, & “Register file”:
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/99559706-bfedcf80-29cd-11eb-999a-9d8e81249cf7.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/99559740-c5e3b080-29cd-11eb-80a4-d1b69a74397a.png)
  ![image](https://user-images.githubusercontent.com/13918850/99559752-c8dea100-29cd-11eb-93a9-da06dcc6e521.png)
  ![image](https://user-images.githubusercontent.com/13918850/99559775-cda35500-29cd-11eb-8986-09a450fbbde3.png)