### PR TITLE
Revert [Config] Proxy to Nuclio API not working in production

### DIFF
--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -9,5 +9,5 @@ export const functionTemplatesHttpClient = axios.create({
 })
 
 export const nuclioHttpClient = axios.create({
-  baseURL: '/nuclio'
+  baseURL: `${process.env.PUBLIC_URL}/nuclio`
 })


### PR DESCRIPTION
On production, when MLRUn UI Docker container is running on some **sub-domain.domain.com/mlrun**, if a request is sent to **sub-domain.domain.com/nuclio** it will not hit the Nginx proxy in MLRun UI.
Changing it back now to become **sub-domain.domain.com/mlrun/nuclio** which will proxy properly.

Reverts PR https://github.com/mlrun/ui/pull/277