### PR TITLE
[Projects] Tweaked some counters

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -182,15 +182,19 @@ const projectsAction = {
   fetchProjectFunctions: project => dispatch => {
     dispatch(projectsAction.fetchProjectFunctionsBegin())
 
-    projectsApi
+    return projectsApi
       .getProjectFunctions(project)
       .then(response => {
         dispatch(
           projectsAction.fetchProjectFunctionsSuccess(response?.data.funcs)
         )
+
+        return response?.data.funcs
       })
       .catch(error => {
         dispatch(projectsAction.fetchProjectFunctionsFailure(error.message))
+
+        throw error.message
       })
   },
   fetchProjectFunctionsBegin: () => ({ type: FETCH_PROJECT_FUNCTIONS_BEGIN }),
@@ -264,6 +268,8 @@ const projectsAction = {
       })
       .catch(error => {
         dispatch(projectsAction.fetchProjectRunningJobsFailure(error.message))
+
+        throw error.message
       })
   },
   fetchProjectRunningJobsBegin: () => ({

--- a/src/components/ProjectsPage/Projects.js
+++ b/src/components/ProjectsPage/Projects.js
@@ -17,9 +17,10 @@ import projectsAction from '../../actions/projects'
 const Projects = ({
   createNewProject,
   deleteProject,
+  fetchNuclioFunctions,
   fetchProjectDataSets,
   fetchProjectFailedJobs,
-  fetchNuclioFunctions,
+  fetchProjectFunctions,
   fetchProjectModels,
   fetchProjectRunningJobs,
   fetchProjects,
@@ -117,6 +118,7 @@ const Projects = ({
       fetchNuclioFunctions={fetchNuclioFunctions}
       fetchProjectDataSets={fetchProjectDataSets}
       fetchProjectFailedJobs={fetchProjectFailedJobs}
+      fetchProjectFunctions={fetchProjectFunctions}
       fetchProjectModels={fetchProjectModels}
       fetchProjectRunningJobs={fetchProjectRunningJobs}
       handleCreateProject={handleCreateProject}

--- a/src/components/ProjectsPage/ProjectsView.js
+++ b/src/components/ProjectsPage/ProjectsView.js
@@ -26,6 +26,7 @@ const ProjectsView = ({
   fetchNuclioFunctions,
   fetchProjectDataSets,
   fetchProjectFailedJobs,
+  fetchProjectFunctions,
   fetchProjectModels,
   fetchProjectRunningJobs,
   handleCreateProject,
@@ -109,9 +110,10 @@ const ProjectsView = ({
             return (
               <ProjectCard
                 actionsMenu={actionsMenu}
+                fetchNuclioFunctions={fetchNuclioFunctions}
                 fetchProjectDataSets={fetchProjectDataSets}
                 fetchProjectFailedJobs={fetchProjectFailedJobs}
-                fetchNuclioFunctions={fetchNuclioFunctions}
+                fetchProjectFunctions={fetchProjectFunctions}
                 fetchProjectModels={fetchProjectModels}
                 fetchProjectRunningJobs={fetchProjectRunningJobs}
                 key={project.id || project.name}
@@ -141,6 +143,7 @@ ProjectsView.propTypes = {
   fetchNuclioFunctions: PropTypes.func.isRequired,
   fetchProjectDataSets: PropTypes.func.isRequired,
   fetchProjectFailedJobs: PropTypes.func.isRequired,
+  fetchProjectFunctions: PropTypes.func.isRequired,
   fetchProjectModels: PropTypes.func.isRequired,
   fetchProjectRunningJobs: PropTypes.func.isRequired,
   handleCreateProject: PropTypes.func.isRequired,

--- a/src/elements/ProjectCard/projectCard.util.js
+++ b/src/elements/ProjectCard/projectCard.util.js
@@ -1,0 +1,71 @@
+export const generateProjectStatistic = (
+  failedJobs,
+  features,
+  fetchFailedJobsFailure,
+  fetchFeaturesFailure,
+  fetchFunctionsFailure,
+  fetchModelsFailure,
+  fetchNuclioFunctionsFailure,
+  fetchRunningJobsFailure,
+  functions,
+  models,
+  nuclioFunctions,
+  runningJobs
+) => {
+  const runningNuclioFunctions = Object.values(nuclioFunctions).reduce(
+    (prev, curr) =>
+      curr.status.state === 'ready' && !curr.spec.disable ? (prev += 1) : prev,
+    0
+  )
+  const failedNuclioFunctions = Object.values(nuclioFunctions).reduce(
+    (prev, curr) => (curr.status.state === 'error' ? (prev += 1) : prev),
+    0
+  )
+
+  return {
+    runningJobs: {
+      value:
+        fetchRunningJobsFailure || fetchNuclioFunctionsFailure
+          ? 'N/A'
+          : runningJobs.length + runningNuclioFunctions,
+      label: 'Running',
+      className:
+        runningJobs.length + runningNuclioFunctions > 0 &&
+        !fetchRunningJobsFailure &&
+        !fetchNuclioFunctionsFailure
+          ? 'running'
+          : 'default',
+      counterTooltip: 'ML jobs and Nuclio functions'
+    },
+    failedJobs: {
+      value:
+        fetchFailedJobsFailure || fetchNuclioFunctionsFailure
+          ? 'N/A'
+          : failedJobs.length + failedNuclioFunctions,
+      label: 'Failed (24hrs)',
+      className:
+        failedJobs.length + failedNuclioFunctions > 0 &&
+        !fetchFailedJobsFailure &&
+        !fetchNuclioFunctionsFailure
+          ? 'failed'
+          : 'default',
+      labelClassName: 'wrap',
+      counterTooltip: 'ML jobs and Nuclio functions'
+    },
+    models: {
+      value: fetchModelsFailure ? 'N/A' : models.length,
+      label: 'Models',
+      className: 'default'
+    },
+    features: {
+      value: fetchFeaturesFailure ? 'N/A' : features.length,
+      label: 'Features',
+      className: 'default'
+    },
+    functions: {
+      value: fetchFunctionsFailure ? 'N/A' : functions.length,
+      label: 'ML functions',
+      className: 'default'
+    }
+  }
+}

--- a/src/elements/ProjectStatistics/ProjectStatistics.js
+++ b/src/elements/ProjectStatistics/ProjectStatistics.js
@@ -19,96 +19,147 @@ const ProjectStatistics = ({ statistics }) => {
             target="_top"
             className="project-data-card__statistics-link"
           >
-            <div
-              className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-            >
-              {statistics[key].counterTooltip ? (
-                <Tooltip
-                  template={
-                    <TextTooltipTemplate
-                      text={statistics[key].counterTooltip}
-                    />
-                  }
-                  textShow
+            {statistics[key].counterTooltip ? (
+              <Tooltip
+                template={
+                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
+                }
+                textShow
+              >
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
                 >
                   {statistics[key].value}
-                </Tooltip>
-              ) : (
-                statistics[key].value
-              )}
-              <Arrow className="project-data-card__statistics-arrow" />
-            </div>
-            <div className="project-data-card__statistics-label">
-              <Tooltip
-                className={statistics[key].labelClassName || ''}
-                template={<TextTooltipTemplate text={statistics[key].label} />}
-              >
-                {statistics[key].label}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
               </Tooltip>
-            </div>
+            ) : (
+              [
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
+                >
+                  {statistics[key].value}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>,
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
+              ]
+            )}
           </a>
         ) : statistics[key].link ? (
           <Link
             className="project-data-card__statistics-link"
             to={statistics[key].link}
           >
-            <div
-              className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-            >
-              {statistics[key].counterTooltip ? (
-                <Tooltip
-                  template={
-                    <TextTooltipTemplate
-                      text={statistics[key].counterTooltip}
-                    />
-                  }
-                  textShow
+            {statistics[key].counterTooltip ? (
+              <Tooltip
+                template={
+                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
+                }
+                textShow
+              >
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
                 >
                   {statistics[key].value}
-                </Tooltip>
-              ) : (
-                statistics[key].value
-              )}
-              <Arrow className="project-data-card__statistics-arrow" />
-            </div>
-            <div className="project-data-card__statistics-label">
-              <Tooltip
-                className={statistics[key].labelClassName || ''}
-                template={<TextTooltipTemplate text={statistics[key].label} />}
-              >
-                {statistics[key].label}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
               </Tooltip>
-            </div>
+            ) : (
+              [
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
+                >
+                  {statistics[key].value}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>,
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
+              ]
+            )}
           </Link>
         ) : (
           <div className="project-data-card__statistics-data">
-            <div
-              className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-            >
-              {statistics[key].counterTooltip ? (
-                <Tooltip
-                  template={
-                    <TextTooltipTemplate
-                      text={statistics[key].counterTooltip}
-                    />
-                  }
-                  textShow
+            {statistics[key].counterTooltip ? (
+              <Tooltip
+                template={
+                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
+                }
+                textShow
+              >
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
                 >
                   {statistics[key].value}
-                </Tooltip>
-              ) : (
-                statistics[key].value
-              )}
-              <Arrow className="project-data-card__statistics-arrow" />
-            </div>
-            <div className="project-data-card__statistics-label">
-              <Tooltip
-                className={statistics[key].labelClassName || ''}
-                template={<TextTooltipTemplate text={statistics[key].label} />}
-              >
-                {statistics[key].label}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
               </Tooltip>
-            </div>
+            ) : (
+              [
+                <div
+                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
+                >
+                  {statistics[key].value}
+                  <Arrow className="project-data-card__statistics-arrow" />
+                </div>,
+                <div className="project-data-card__statistics-label">
+                  <Tooltip
+                    className={statistics[key].labelClassName || ''}
+                    template={
+                      <TextTooltipTemplate text={statistics[key].label} />
+                    }
+                  >
+                    {statistics[key].label}
+                  </Tooltip>
+                </div>
+              ]
+            )}
           </div>
         )}
       </div>

--- a/src/elements/ProjectStatistics/ProjectStatistics.js
+++ b/src/elements/ProjectStatistics/ProjectStatistics.js
@@ -22,12 +22,25 @@ const ProjectStatistics = ({ statistics }) => {
             <div
               className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
             >
-              {statistics[key].value}
+              {statistics[key].counterTooltip ? (
+                <Tooltip
+                  template={
+                    <TextTooltipTemplate
+                      text={statistics[key].counterTooltip}
+                    />
+                  }
+                  textShow
+                >
+                  {statistics[key].value}
+                </Tooltip>
+              ) : (
+                statistics[key].value
+              )}
               <Arrow className="project-data-card__statistics-arrow" />
             </div>
             <div className="project-data-card__statistics-label">
               <Tooltip
-                className={statistics[key].tooltipClassName || ''}
+                className={statistics[key].labelClassName || ''}
                 template={<TextTooltipTemplate text={statistics[key].label} />}
               >
                 {statistics[key].label}
@@ -42,12 +55,25 @@ const ProjectStatistics = ({ statistics }) => {
             <div
               className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
             >
-              {statistics[key].value}
+              {statistics[key].counterTooltip ? (
+                <Tooltip
+                  template={
+                    <TextTooltipTemplate
+                      text={statistics[key].counterTooltip}
+                    />
+                  }
+                  textShow
+                >
+                  {statistics[key].value}
+                </Tooltip>
+              ) : (
+                statistics[key].value
+              )}
               <Arrow className="project-data-card__statistics-arrow" />
             </div>
             <div className="project-data-card__statistics-label">
               <Tooltip
-                className={statistics[key].tooltipClassName || ''}
+                className={statistics[key].labelClassName || ''}
                 template={<TextTooltipTemplate text={statistics[key].label} />}
               >
                 {statistics[key].label}
@@ -59,12 +85,25 @@ const ProjectStatistics = ({ statistics }) => {
             <div
               className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
             >
-              {statistics[key].value}
+              {statistics[key].counterTooltip ? (
+                <Tooltip
+                  template={
+                    <TextTooltipTemplate
+                      text={statistics[key].counterTooltip}
+                    />
+                  }
+                  textShow
+                >
+                  {statistics[key].value}
+                </Tooltip>
+              ) : (
+                statistics[key].value
+              )}
               <Arrow className="project-data-card__statistics-arrow" />
             </div>
             <div className="project-data-card__statistics-label">
               <Tooltip
-                className={statistics[key].tooltipClassName || ''}
+                className={statistics[key].labelClassName || ''}
                 template={<TextTooltipTemplate text={statistics[key].label} />}
               >
                 {statistics[key].label}

--- a/src/elements/ProjectStatistics/ProjectStatistics.js
+++ b/src/elements/ProjectStatistics/ProjectStatistics.js
@@ -2,10 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
-import Tooltip from '../../common/Tooltip/Tooltip'
-import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
-
-import { ReactComponent as Arrow } from '../../images/arrow.svg'
+import ProjectStatisticsCounter from '../ProjectStatisticsCounter/ProjectStatisticsCounter'
 
 import './projectStatistics.scss'
 
@@ -19,147 +16,18 @@ const ProjectStatistics = ({ statistics }) => {
             target="_top"
             className="project-data-card__statistics-link"
           >
-            {statistics[key].counterTooltip ? (
-              <Tooltip
-                template={
-                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
-                }
-                textShow
-              >
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              </Tooltip>
-            ) : (
-              [
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>,
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              ]
-            )}
+            <ProjectStatisticsCounter counterObject={statistics[key]} />
           </a>
         ) : statistics[key].link ? (
           <Link
             className="project-data-card__statistics-link"
             to={statistics[key].link}
           >
-            {statistics[key].counterTooltip ? (
-              <Tooltip
-                template={
-                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
-                }
-                textShow
-              >
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              </Tooltip>
-            ) : (
-              [
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>,
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              ]
-            )}
+            <ProjectStatisticsCounter counterObject={statistics[key]} />
           </Link>
         ) : (
           <div className="project-data-card__statistics-data">
-            {statistics[key].counterTooltip ? (
-              <Tooltip
-                template={
-                  <TextTooltipTemplate text={statistics[key].counterTooltip} />
-                }
-                textShow
-              >
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              </Tooltip>
-            ) : (
-              [
-                <div
-                  className={`project-data-card__statistics-value statistics_${statistics[key].className}`}
-                >
-                  {statistics[key].value}
-                  <Arrow className="project-data-card__statistics-arrow" />
-                </div>,
-                <div className="project-data-card__statistics-label">
-                  <Tooltip
-                    className={statistics[key].labelClassName || ''}
-                    template={
-                      <TextTooltipTemplate text={statistics[key].label} />
-                    }
-                  >
-                    {statistics[key].label}
-                  </Tooltip>
-                </div>
-              ]
-            )}
+            <ProjectStatisticsCounter counterObject={statistics[key]} />
           </div>
         )}
       </div>

--- a/src/elements/ProjectStatistics/projectStatistics.scss
+++ b/src/elements/ProjectStatistics/projectStatistics.scss
@@ -91,6 +91,11 @@
           color: $amaranth;
         }
       }
+
+      .tooltip {
+        font-size: 12px;
+        line-height: 16px;
+      }
     }
   }
 }

--- a/src/elements/ProjectStatisticsCounter/ProjectStatisticsCounter.js
+++ b/src/elements/ProjectStatisticsCounter/ProjectStatisticsCounter.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
+
+import { ReactComponent as Arrow } from '../../images/arrow.svg'
+
+const ProjectStatisticsCounter = ({ counterObject }) => {
+  return counterObject.counterTooltip ? (
+    <Tooltip
+      template={<TextTooltipTemplate text={counterObject.counterTooltip} />}
+      textShow
+    >
+      <div
+        className={`project-data-card__statistics-value statistics_${counterObject.className}`}
+      >
+        {counterObject.value}
+        <Arrow className="project-data-card__statistics-arrow" />
+      </div>
+      <div className="project-data-card__statistics-label">
+        <Tooltip
+          className={counterObject.labelClassName || ''}
+          template={<TextTooltipTemplate text={counterObject.label} />}
+        >
+          {counterObject.label}
+        </Tooltip>
+      </div>
+    </Tooltip>
+  ) : (
+    [
+      <div
+        key={counterObject.value + Math.random()}
+        className={`project-data-card__statistics-value statistics_${counterObject.className}`}
+      >
+        {counterObject.value}
+        <Arrow className="project-data-card__statistics-arrow" />
+      </div>,
+      <div
+        className="project-data-card__statistics-label"
+        key={counterObject.label + Math.random()}
+      >
+        <Tooltip
+          className={counterObject.labelClassName || ''}
+          template={<TextTooltipTemplate text={counterObject.label} />}
+        >
+          {counterObject.label}
+        </Tooltip>
+      </div>
+    ]
+  )
+}
+
+ProjectStatisticsCounter.propTypes = {
+  counterObject: PropTypes.shape({}).isRequired
+}
+
+export default ProjectStatisticsCounter


### PR DESCRIPTION
https://trello.com/c/yum7olBE/604-projects-tweak-some-counters

- **Projects**:
  - Rename “Running jobs” to ”Running”
  - Make “Running” and “Failed (last 24hrs)” counters count both ML jobs and Nuclio functions and add a tooltip on hover that says so, and make “Functions”
  - Rename “Functions” counter to “ML functions” and make it count ML functions rather than Nuclio functions.
  ![image](https://user-images.githubusercontent.com/13918850/100144020-da78ea80-2e9e-11eb-905f-dd9526418550.png)