### PR TITLE
[Project Overview] Wrong redirection after artifact creation

### DIFF
--- a/src/components/Project/ProjectView.js
+++ b/src/components/Project/ProjectView.js
@@ -47,7 +47,13 @@ const ProjectView = React.forwardRef(
     ref
   ) => {
     const registerArtifactLink = `/projects/${match.params.projectName}/${
-      artifactKind === 'dataset' ? 'feature-store/datasets' : `${artifactKind}s`
+      artifactKind === 'model'
+        ? 'models'
+        : artifactKind === 'dataset'
+        ? 'feature-store/datasets'
+        : artifactKind === 'file'
+        ? 'files'
+        : 'artifacts'
     }`
 
     return (

--- a/src/components/Project/ProjectView.js
+++ b/src/components/Project/ProjectView.js
@@ -46,6 +46,10 @@ const ProjectView = React.forwardRef(
     },
     ref
   ) => {
+    const registerArtifactLink = `/projects/${match.params.projectName}/${
+      artifactKind === 'dataset' ? 'feature-store/datasets' : `${artifactKind}s`
+    }`
+
     return (
       <>
         <div className="project__header">
@@ -227,7 +231,7 @@ const ProjectView = React.forwardRef(
               pageKind: `${artifactKind}s`
             }}
             refresh={() => {
-              history.push(`/projects/${match.params.projectName}/artifacts`)
+              history.push(registerArtifactLink)
             }}
             setIsPopupDialogOpen={setIsPopupDialogOpen}
             title={`Register ${artifactKind}`}


### PR DESCRIPTION
https://trello.com/c/rHrxeJGX/627-project-overview-wrong-redirection-after-artifact-creation

- **Project Overview**: On the “Register Model”, “Register Dataset”, and “Register File” dialogs, after a successful registration, the user was redirected to the old general “Artifacts” screen instead of the relevant screen, Models, Datasets, or Files, respectively.