### PR TITLE
[Jobs] Monitor: hidden checkboxes from status filter

### DIFF
--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -159,7 +159,6 @@ const FilterMenu = ({
                     (filter === 'status' && stateFilter) ||
                     (filter === 'groupBy' && groupFilter)
                   }
-                  selectType={filter === 'status' ? 'checkbox' : ''}
                   onClick={item => handleSelectOption(item, filter)}
                 />
               )

--- a/src/components/FilterMenu/filterMenu.settings.js
+++ b/src/components/FilterMenu/filterMenu.settings.js
@@ -6,10 +6,10 @@ export const selectOptions = {
     { label: 'Last 6 months', id: 'last6Months' }
   ],
   status: [
-    { label: 'All', id: 'all' },
-    { label: 'Completed', id: 'completed' },
-    { label: 'Running', id: 'running' },
-    { label: 'Error', id: 'error' }
+    { label: 'All', id: 'all', status: 'all' },
+    { label: 'Completed', id: 'completed', status: 'completed' },
+    { label: 'Running', id: 'running', status: 'running' },
+    { label: 'Error', id: 'error', status: 'error' }
   ],
   groupBy: [
     { label: 'None', id: 'none' },

--- a/src/elements/SelectOption/SelectOption.js
+++ b/src/elements/SelectOption/SelectOption.js
@@ -9,17 +9,18 @@ import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
 import './selectOption.scss'
 
 const SelectOption = ({ disabled, item, onClick, selectType, selectedId }) => {
+  const selectClassName = classnames('select__item', disabled && 'disabled')
+
   if (selectType === 'checkbox') {
     return (
       <div data-testid="select-checkbox" className="select__item">
         <CheckBox item={item} selectedId={selectedId} onChange={onClick}>
-          <span className={`status ${item.id}`} /> {item.label}
+          {item.status && <span className={`status ${item.status}`} />}
+          {item.label}
         </CheckBox>
       </div>
     )
   }
-
-  const selectClassName = classnames('select__item', disabled && 'disabled')
 
   return (
     <div
@@ -34,6 +35,7 @@ const SelectOption = ({ disabled, item, onClick, selectType, selectedId }) => {
           {item.icon}
         </span>
       )}
+      {item.status && <span className={`status ${item.status}`} />}
       {item.label}
       {item.subLabel && (
         <Tooltip


### PR DESCRIPTION
https://trello.com/c/15W7heRX/629-jobs-monitor-hide-checkboxes-from-status-filter

- **Jobs**: Remove checkboxes from the “Status” filter (as it does not really allow for multiple selection)
  ![image](https://user-images.githubusercontent.com/13918850/101790525-38e2d180-3b0b-11eb-9b46-ed80126aa4ba.png)