### PR TITLE
[Project Overview] Layout breaks on long project name

### DIFF
--- a/src/components/Project/ProjectView.js
+++ b/src/components/Project/ProjectView.js
@@ -13,6 +13,8 @@ import RegisterArtifactPopup from '../RegisterArtifactPopup/RegisterArtifactPopu
 import Select from '../../common/Select/Select'
 import ProjectArtifacts from '../../elements/ProjectArtifacts/ProjectArtifacts'
 import TextArea from '../../common/TextArea/TextArea'
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
 
 import { ReactComponent as Settings } from '../../images/settings.svg'
 
@@ -92,7 +94,19 @@ const ProjectView = React.forwardRef(
                         }
                       />
                     ) : (
-                      editProject.name.value ?? projectStore.project.data.name
+                      <Tooltip
+                        template={
+                          <TextTooltipTemplate
+                            text={
+                              editProject.name.value ??
+                              projectStore.project.data.name
+                            }
+                          />
+                        }
+                      >
+                        {editProject.name.value ??
+                          projectStore.project.data.name}
+                      </Tooltip>
                     )}
                   </div>
                   <Settings className="general-info__settings" />

--- a/src/components/Project/project.scss
+++ b/src/components/Project/project.scss
@@ -31,6 +31,7 @@
       &__name {
         display: flex;
         flex: 2;
+        max-width: 335px;
         color: rgba($mulledWine, 0.88);
         font-weight: 300;
         font-size: 36px;


### PR DESCRIPTION
https://trello.com/c/Ca8iGmFu/634-project-overview-layout-breaks-on-long-project-name

- **Project Overview**: Layout broke when project name was one long word.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/101929327-5ed9a600-3bdf-11eb-9896-c4876b036fd9.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/101929304-571a0180-3bdf-11eb-8b99-a22ca4ccdcb0.png)