### PR TITLE
[Projects] Project name overflows its tile

### DIFF
--- a/src/elements/ProjectCard/ProjectCardView.js
+++ b/src/elements/ProjectCard/ProjectCardView.js
@@ -30,7 +30,11 @@ const ProjectCardView = React.forwardRef(
         }}
       >
         <div className="project-card__general-info">
-          <div className="project-card__header">{project.name}</div>
+          <div className="project-card__header">
+            <Tooltip template={<TextTooltipTemplate text={project.name} />}>
+              {project.name}
+            </Tooltip>
+          </div>
           {project?.description && (
             <Tooltip
               className="project-card_description"


### PR DESCRIPTION
https://trello.com/c/tUO2YMae/633-projects-project-name-overflows-its-tile

- **Projects**: Project name overflew its tile when it is one long word
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/101928984-ef63b680-3bde-11eb-9641-ba733a119d72.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/101928964-e96dd580-3bde-11eb-8850-36eaee93d9e0.png)