### PR TITLE
[Projects] Allow delete for archived projects only

### DIFF
--- a/src/components/ProjectsPage/projectsData.js
+++ b/src/components/ProjectsPage/projectsData.js
@@ -35,6 +35,7 @@ export const generateProjectActionsMenu = (
       {
         label: 'Delete',
         icon: <Delete />,
+        hidden: project.status.state !== 'archived',
         onClick: deleteProject
       }
     ]


### PR DESCRIPTION
https://trello.com/c/Dlh62nd1/664-projects-allow-delete-for-archived-projects-only

- **Projects**: Removed the “Delete” action from action menu for unarchived projects.