### PR TITLE
Impl [Project Overview] Quick Links: rename two links

### DIFF
--- a/src/components/Project/project.utils.js
+++ b/src/components/Project/project.utils.js
@@ -30,11 +30,11 @@ export const getLinks = match => [
     link: `/projects/${match.params.projectName}/files`
   },
   {
-    label: 'Monitor jobs and workflows',
+    label: 'Jobs and workflows',
     link: `/projects/${match.params.projectName}/jobs/monitor`
   },
   {
-    label: 'Schedule jobs and workflows',
+    label: 'Schedule jobs',
     link: `/projects/${match.params.projectName}/jobs/schedule`
   },
   {


### PR DESCRIPTION
- **Project overview**: Renamed quick links:
  - from “Monitor jobs and workflows” to “Jobs and workflows”
  - from “Schedule jobs and workflows” to “Schedule Jobs”
  ![image](https://user-images.githubusercontent.com/13918850/103298451-08ec6700-4a03-11eb-8702-aa4085a978bd.png)