### PR TITLE
[General] Make entire area of tab headers clickable

### DIFF
--- a/src/elements/ContentMenu/contentMenu.scss
+++ b/src/elements/ContentMenu/contentMenu.scss
@@ -17,7 +17,6 @@
     @include resetSpaces;
 
     &_item {
-      padding: 8px 24px;
       color: $topaz;
       font-weight: bold;
       font-size: 15px;
@@ -25,7 +24,11 @@
       text-align: center;
       text-transform: capitalize;
       border-bottom: 3px solid transparent;
-      cursor: pointer;
+
+      a {
+        display: block;
+        padding: 8px 24px;
+      }
     }
 
     .active {


### PR DESCRIPTION
https://trello.com/c/Em0a97wG/647-general-make-entire-area-of-tab-headers-clickable

- **General**: Made the entire tab header area clickable (green+blue area in below image) instead of just the text area (blue area in below image):
  ![image](https://user-images.githubusercontent.com/13918850/103554767-1ba9e480-4eb8-11eb-8258-c1b79baa4243.png)
