### PR TITLE
Fix [Jobs] Monitor: group by workflow always gives an empty list

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -38,7 +38,8 @@ const Table = ({
     state => pageData.page !== FUNCTIONS_PAGE && state.artifactsStore.preview
   )
   const workflows = useSelector(
-    state => pageData.page === JOBS_PAGE && state.workflowsStore.workflows
+    state =>
+      pageData.page === JOBS_PAGE && state.projectStore.project.workflows.data
   )
 
   useEffect(() => {


### PR DESCRIPTION
- **Jobs › Monitor**: No data when grouping by workflow
  ![image](https://user-images.githubusercontent.com/13918850/103635129-bfdf6a00-4f50-11eb-87fb-23b40fb02fc5.png)

Bug originated in PR https://github.com/mlrun/ui/pull/332