### PR TITLE
[Project Overview] Make name non-editable

### DIFF
--- a/src/components/Project/ProjectView.js
+++ b/src/components/Project/ProjectView.js
@@ -79,7 +79,6 @@ const ProjectView = React.forwardRef(
                   <div
                     data-testid="project-name"
                     className="general-info__name"
-                    onClick={() => handleEditProject('name')}
                   >
                     {editProject.name.isEdit ? (
                       <Input

--- a/src/components/Project/project.scss
+++ b/src/components/Project/project.scss
@@ -36,7 +36,6 @@
         font-weight: 300;
         font-size: 36px;
         line-height: 42px;
-        cursor: pointer;
 
         .input {
           width: 100%;


### PR DESCRIPTION
https://trello.com/c/3HNViuLw/659-project-overview-make-name-non-editable

- **Project Overview**: Name field is no longer editable (because backend does not support such operation)
  ![image](https://user-images.githubusercontent.com/13918850/104196888-00495700-542d-11eb-8f43-785a259d1d9b.png)