### PR TITLE
Fix [Projects] Project name overflows its tile

### DIFF
--- a/src/elements/ProjectCard/ProjectCard.js
+++ b/src/elements/ProjectCard/ProjectCard.js
@@ -2,10 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
+
 const ProjectCard = ({ project }) => {
   return (
     <div className="project_card">
-      <div className="project_card_header">{project.name}</div>
+      <div className="project_card_header">
+        <Tooltip template={<TextTooltipTemplate text={project.name} />}>
+          {project.name}
+        </Tooltip>
+      </div>
       {project?.description && (
         <div className="project_card_description">{project.description}</div>
       )}


### PR DESCRIPTION
Backports PR https://github.com/mlrun/ui/pull/317 from branch `development` to branch `0.5.x`

- **Projects**: Project name overflew its tile when it is one long word
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/104216443-bd927980-5442-11eb-827e-65a8c5916af4.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/104216461-c2efc400-5442-11eb-8054-a7780edc11f3.png)