### PR TITLE
Impl [Projects] Delete non-empty: do not rely on error text

### DIFF
--- a/src/components/ProjectsPage/Projects.js
+++ b/src/components/ProjectsPage/Projects.js
@@ -67,12 +67,7 @@ const Projects = ({
           })
         })
         .catch(error => {
-          if (
-            error.response?.status === 412 &&
-            error.response?.data?.detail?.includes(
-              'can not be deleted since related resources found'
-            )
-          ) {
+          if (error.response?.status === 412) {
             setDeleteNonEmptyProject(project)
           } else {
             setNotification({


### PR DESCRIPTION
- **Projects**: On `DELETE /api/projects/{project-name}` rely only on response error status code 412 and not on response body to determine whether to show the confirmation pop-up.

Jira ticket 17938