### PR TITLE
Impl [General] Labels filter: rename to Label, reword placeholder

### DIFF
--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -118,8 +118,8 @@ const FilterMenu = ({
               return (
                 <Input
                   type="text"
-                  label="labels:"
-                  placeholder="key1=value1,…"
+                  label="label:"
+                  placeholder="key=value"
                   key={filter}
                   onChange={setLabels}
                   value={labels}


### PR DESCRIPTION
- **General**: Rename “Labels” filter to “Label” and reword its placeholder from “key1=value1,…” to “key or key=value”, because backend does not currently support filtering by multiple labels.
  ![image](https://user-images.githubusercontent.com/13918850/105627788-9758da80-5e41-11eb-85f2-a4235401f768.png)