### PR TITLE
Fix [Projects] Delete non-empty project confirm: missing space

### DIFF
--- a/src/components/ProjectsPage/Projects.js
+++ b/src/components/ProjectsPage/Projects.js
@@ -76,7 +76,7 @@ const Projects = ({
               item: project,
               title: `Delete project "${project.metadata.name}"?`,
               description:
-                'The project is not empty. Deleting it will also delete all of its resources, such as jobs,' +
+                'The project is not empty. Deleting it will also delete all of its resources, such as jobs, ' +
                 'artifacts, and features.',
               btnConfirmLabel: 'Delete',
               btnConfirmClassNames: 'btn_danger',


### PR DESCRIPTION
Originates in PR https://github.com/mlrun/ui/pull/370

- **Projects**: Missing space in deleting non-empty project confirmation dialog
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/105973108-0417e300-6095-11eb-84a8-232261ed486a.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/105973126-08dc9700-6095-11eb-9b7c-be008a210fbf.png)