### PR TITLE
Fix [Config] Resolve proxy passes hosts on every request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,6 @@ ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
     MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-http://localhost:8070}" \
     MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 
-CMD ["/bin/sh", "-c", "/etc/nginx/run_nginx"]
+CMD echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf && /etc/nginx/run_nginx
+#CMD ["echo", "resolver", "$(awk", "'BEGIN{ORS=\"", "\"}", "$1==\"nameserver\"", "{print $2}'", "/etc/resolv.conf)", "\";\"", ">", "/etc/nginx/resolvers.conf"]
+#CMD ["/bin/sh", "-c", "/etc/nginx/run_nginx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,3 @@ ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
     MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 
 CMD echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf && /etc/nginx/run_nginx
-#CMD ["echo", "resolver", "$(awk", "'BEGIN{ORS=\"", "\"}", "$1==\"nameserver\"", "{print $2}'", "/etc/resolv.conf)", "\";\"", ">", "/etc/nginx/resolvers.conf"]
-#CMD ["/bin/sh", "-c", "/etc/nginx/run_nginx"]

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -25,12 +25,14 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
+    resolver 127.0.0.1;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
+    resolver 127.0.0.1;
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -7,7 +7,7 @@ server {
 
   listen 80;
 
-  resolver kube-dns.kube-system.svc.cluster.local;
+  resolver 127.0.0.1;
 
   # https://raw.githubusercontent.com/mlrun/functions/master
   location /function-catalog {

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -7,7 +7,7 @@ server {
 
   listen 80;
 
-  resolver 127.0.0.1;
+  include resolvers.conf;
 
   # https://raw.githubusercontent.com/mlrun/functions/master
   location /function-catalog {

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -24,12 +24,14 @@ server {
 
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    proxy_pass ${MLRUN_API_PROXY_URL};
+    set $backend ${MLRUN_API_PROXY_URL};
+    proxy_pass $backend;
   }
 
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    proxy_pass ${MLRUN_NUCLIO_API_URL};
+    set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
+    proxy_pass $nuclio_backend;
   }
 
   error_page   500 502 503 504  /50x.html;

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -25,14 +25,14 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    resolver 127.0.0.11;
+    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    resolver 127.0.0.11;
+    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -25,14 +25,14 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    resolver kube-dns.kube-system.svc.cluster.local;
+    resolver 169.254.25.10;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    resolver kube-dns.kube-system.svc.cluster.local;
+    resolver 169.254.25.10;
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -25,14 +25,14 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    resolver 127.0.0.1;
+    resolver 127.0.0.11;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    resolver 127.0.0.1;
+    resolver 127.0.0.11;
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -25,14 +25,14 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    resolver 169.254.25.10;
+    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    resolver 169.254.25.10;
+    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -22,15 +22,15 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    set $backend ${MLRUN_API_PROXY_URL};
     proxy_pass $backend;
   }
 
+  set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
     proxy_pass $nuclio_backend;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -7,6 +7,8 @@ server {
 
   listen 80;
 
+  resolver kube-dns.kube-system.svc.cluster.local;
+
   # https://raw.githubusercontent.com/mlrun/functions/master
   location /function-catalog {
     proxy_pass ${MLRUN_FUNCTION_CATALOG_URL};
@@ -25,14 +27,12 @@ server {
   set $backend ${MLRUN_API_PROXY_URL};
   location /api {
     proxy_set_header x-v3io-session-key $v3io_session_key;
-    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $backend;
   }
 
   set $nuclio_backend ${MLRUN_NUCLIO_API_URL};
   location /nuclio {
     rewrite ^/nuclio(/|$)(.*) /$2 break;
-    resolver kube-dns.kube-system.svc.cluster.local;
     proxy_pass $nuclio_backend;
   }
 


### PR DESCRIPTION
The bug was that if nuclio service got recreated for some reason (happens on Iguazio system when restarting the nuclio app service) it means its IP were changed, before this PR the proxy was defined like:
`proxy_pass ${MLRUN_NUCLIO_API_URL};` which means that nginx does the DNS resolution only once on initialization, so if the IP changed mid run, further requests to Nuclio will fail.
In order to make nginx resolve on every request we need to set a variable to the `proxy_pass`.
But when you use a variable you also must define the resolver (see https://serverfault.com/a/593003)
It looked like our best "generic" solution for the value for the resolver is to do the first suggestion [here](https://serverfault.com/a/638855)
I did the same also for the MLRun API proxy pass.
The above add the requirement that the URLs will be fully qualified domain name (FQDN) (https://stackoverflow.com/questions/51090684/nginx-wont-resolve-hostname-in-k8s), so in order for this to work these 2 were needed:
https://github.com/v3io/helm-charts/pull/549
https://github.com/iguazio/provazio/pull/1751