### PR TITLE
Fix [Create Job] Crashes when adding a new label (Firefox only)

### DIFF
--- a/src/components/ChipForm/ChipForm.js
+++ b/src/components/ChipForm/ChipForm.js
@@ -82,8 +82,9 @@ const ChipForm = ({
   const outsideClick = useCallback(
     event => {
       event.stopPropagation()
+      const elementPath = event.path ?? event.composedPath?.()
 
-      if (!event.path.includes(refInputContainer.current)) {
+      if (!elementPath.includes(refInputContainer.current)) {
         onChange(chip, 'Click')
       }
     },


### PR DESCRIPTION
- **Create Job**: On Firefox when adding a new label and attempting to apply it by clicking outside of it, the UI throws an error and does nothing — as a result the job cannot be run and the dialog cannot be closed.

Jira ticket ML-123