### PR TITLE
[Project Overview] Trim project name from Nuclio function name

### DIFF
--- a/src/components/ProjectTable/ProjectTable.js
+++ b/src/components/ProjectTable/ProjectTable.js
@@ -9,7 +9,7 @@ import Tooltip from '../../common/Tooltip/Tooltip'
 
 import './projectTable.scss'
 
-const ProjectTable = ({ table }) => {
+const ProjectTable = ({ match, table }) => {
   return (
     <>
       <div className="project-data-card__table">
@@ -58,8 +58,15 @@ const ProjectTable = ({ table }) => {
                               template={
                                 <TextTooltipTemplate text={body[key].value} />
                               }
+                              textShow={true}
                             >
-                              {body[key].value}
+                              {body[key].value.startsWith(
+                                match.params.projectName
+                              )
+                                ? body[key].value.slice(
+                                    match.params.projectName.length + 1
+                                  )
+                                : body[key].value}
                             </Tooltip>
                           </a>
                         ) : (
@@ -98,6 +105,7 @@ const ProjectTable = ({ table }) => {
 }
 
 ProjectTable.propTypes = {
+  match: PropTypes.shape({}).isRequired,
   table: PropTypes.shape({}).isRequired
 }
 

--- a/src/elements/ProjectFunctions/ProjectFunctions.js
+++ b/src/elements/ProjectFunctions/ProjectFunctions.js
@@ -82,7 +82,9 @@ const ProjectFunctions = ({
 
           return {
             name: {
-              value: func.metadata.name,
+              value: func.metadata.name.startsWith(match.params.projectName)
+                ? func.metadata.name.slice(match.params.projectName.length + 1)
+                : func.metadata.name,
               href: `${window.mlrunConfig.nuclioUiUrl}/projects/${match.params.projectName}/functions/${func.metadata.name}`,
               className: 'table-cell_big'
             },

--- a/src/elements/ProjectFunctions/ProjectFunctions.js
+++ b/src/elements/ProjectFunctions/ProjectFunctions.js
@@ -82,9 +82,7 @@ const ProjectFunctions = ({
 
           return {
             name: {
-              value: func.metadata.name.startsWith(match.params.projectName)
-                ? func.metadata.name.slice(match.params.projectName.length + 1)
-                : func.metadata.name,
+              value: func.metadata.name,
               href: `${window.mlrunConfig.nuclioUiUrl}/projects/${match.params.projectName}/functions/${func.metadata.name}`,
               className: 'table-cell_big'
             },


### PR DESCRIPTION
https://trello.com/c/5s9FSRrt/681-project-overview-trim-project-name-from-nuclio-function-name

- **Project Overview**: Trimmed project name that is prepended to Nuclio function names, in case it is the current project, and added the full name in a tooltip on hover
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/107357535-dee69400-6ada-11eb-9c0b-4b851c495aec.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/107357289-8e6f3680-6ada-11eb-80a7-54595d20c592.png)

Jira ticket ML-144