### PR TITLE
Fix [Create Job] Parameters: null values are wrongly sent

### DIFF
--- a/src/components/JobsPanelParameters/JobsPanelParameters.js
+++ b/src/components/JobsPanelParameters/JobsPanelParameters.js
@@ -9,7 +9,11 @@ import {
   parametersActions,
   jobsPanelParametersReducer
 } from './jobsPanelParametersReducer'
-import { editHyperParams, generateTableData } from './jobsPanelParameters.util'
+import {
+  convertParamValue,
+  editHyperParams,
+  generateTableData
+} from './jobsPanelParameters.util'
 import { panelActions } from '../JobsPanel/panelReducer'
 
 const JobsPanelParameters = ({
@@ -115,7 +119,10 @@ const JobsPanelParameters = ({
 
     setNewJobParameters({
       ...newJobTaskSpecObj.parameters,
-      [parametersState.newParameter.name]: +parametersState.newParameter.value
+      [parametersState.newParameter.name]: convertParamValue(
+        parametersState.newParameter.value,
+        parametersState.newParameter.valueType
+      )
     })
     panelDispatch({
       type: panelActions.SET_PREVIOUS_PANEL_DATA_PARAMETERS,
@@ -175,15 +182,16 @@ const JobsPanelParameters = ({
   const handleEditParameter = () => {
     const params = { ...newJobTaskSpecObj.parameters }
     const hyperParamsObj = { ...newJobTaskSpecObj.hyperparams }
+    const convertedValue = convertParamValue(
+      parametersState.selectedParameter.data.value,
+      parametersState.selectedParameter.data.valueType
+    )
 
     if (parametersState.selectedParameter.newName) {
       delete params[parametersState.selectedParameter.data.name]
-
-      params[parametersState.selectedParameter.newName] =
-        parametersState.selectedParameter.data.value
+      params[parametersState.selectedParameter.newName] = convertedValue
     } else {
-      params[parametersState.selectedParameter.data.name] =
-        parametersState.selectedParameter.data.value
+      params[parametersState.selectedParameter.data.name] = convertedValue
     }
 
     if (
@@ -207,7 +215,6 @@ const JobsPanelParameters = ({
       parametersState.selectedParameter.isChecked
     ) {
       delete hyperParamsObj[parametersState.selectedParameter.data.name]
-
       setNewJobHyperParameters({ ...hyperParamsObj })
     }
 
@@ -218,6 +225,7 @@ const JobsPanelParameters = ({
         }
 
         param.data.value = parametersState.selectedParameter.data.value
+        param.data.valueType = parametersState.selectedParameter.data.valueType
         param.data.parameterType =
           parametersState.selectedParameter.data.parameterType
       }

--- a/src/components/JobsPanelParameters/jobsPanelParameters.util.js
+++ b/src/components/JobsPanelParameters/jobsPanelParameters.util.js
@@ -1,27 +1,33 @@
+export const convertParamValue = (value, type) =>
+  ['int', 'float', 'number'].includes(type) && Number.isFinite(Number(value))
+    ? Number(value)
+    : type === 'bool' && value.toLowerCase() === 'true'
+    ? true
+    : type === 'bool' && value.toLowerCase() === 'false'
+    ? false
+    : String(value)
+
 export const editHyperParams = (hyperParams, selectedParameter, newName) => {
   if (newName) {
     if (hyperParams[selectedParameter.name]) {
       return {
         ...hyperParams,
-        [newName]: `${selectedParameter.value}`.split(',')
+        [newName]: selectedParameter.value.split(',')
       }
     } else {
       delete hyperParams[selectedParameter.name]
-
-      hyperParams[newName] = `${selectedParameter.value}`.split(',')
+      hyperParams[newName] = selectedParameter.value.split(',')
 
       return { ...hyperParams }
     }
   } else if (hyperParams[selectedParameter.name]) {
-    hyperParams[selectedParameter.name] = `${selectedParameter.value}`.split(
-      ','
-    )
+    hyperParams[selectedParameter.name] = selectedParameter.value.split(',')
 
     return { ...hyperParams }
   } else {
     return {
       ...hyperParams,
-      [selectedParameter.name]: `${selectedParameter.value}`.split(',')
+      [selectedParameter.name]: selectedParameter.value.split(',')
     }
   }
 }
@@ -50,12 +56,20 @@ export const selectOptions = {
   ],
   parametersValueType: [
     {
-      label: 'string',
-      id: 'string'
+      label: 'str',
+      id: 'str'
     },
     {
-      label: 'number',
-      id: 'number'
+      label: 'int',
+      id: 'int'
+    },
+    {
+      label: 'float',
+      id: 'float'
+    },
+    {
+      label: 'bool',
+      id: 'bool'
     },
     {
       label: 'list',

--- a/src/components/JobsPanelParameters/jobsPanelParametersReducer.js
+++ b/src/components/JobsPanelParameters/jobsPanelParametersReducer.js
@@ -4,7 +4,7 @@ export const initialState = {
   addNewParameter: false,
   newParameter: {
     name: '',
-    valueType: 'string',
+    valueType: 'str',
     parameterType: panelData.newParameterType[0].id,
     value: ''
   },
@@ -26,12 +26,7 @@ export const jobsPanelParametersReducer = (state, { type, payload }) => {
     case parametersActions.REMOVE_NEW_PARAMETER_DATA:
       return {
         ...state,
-        newParameter: {
-          name: '',
-          value: '',
-          parameterType: panelData.newParameterType[0].id,
-          valueType: 'string'
-        }
+        newParameter: { ...initialState.newParameter }
       }
     case parametersActions.SET_ADD_NEW_PARAMETER:
       return {


### PR DESCRIPTION
### Features / Enhancements

- **Create Job**: Add “int”, “float”, & “bool” options to and remove “number” option from parameter type list, and convert the values in accordance to the type:
  - For type “bool”:
    - if value is "True" or "False" (case insensitive) — assign `true` or `false` respectively
    - otherwise stringify the given value
  - For types “int” & “float”:
    -  if value could be converted to a finite number — assign the number value
    - otherwise stringify the given value
  - For any other type — stringify the given value
  ![image](https://user-images.githubusercontent.com/13918850/107887099-53bb3300-6f0c-11eb-9db5-fb0c460f8add.png)

### Bug Fixes

- **Create Job**: `null` values were wrongly sent for non-numeric parameter values on job submission
- **Create Job**: could not change an existing parameter type, it reverted to its previous value
  ![job-create-parameters-edit-type-no-change-bug](https://user-images.githubusercontent.com/13918850/107887543-80247e80-6f0f-11eb-9c19-8f41c6d1d295.gif)

Jira ticket ML-151