### PR TITLE
[Feature Store] Fix transformation tab with empty data. Fix tabs order

### DIFF
--- a/src/components/DetailsTransformations/ConfigSource/ConfigSource.js
+++ b/src/components/DetailsTransformations/ConfigSource/ConfigSource.js
@@ -44,7 +44,8 @@ const ConfigSource = ({ selectedItem }) => {
         <div className="row">
           <div className="row-label">Schedule:</div>
           <div className="row-value">
-            {cronstrue.toString(selectedItem.source?.schedule)}
+            {selectedItem.source?.schedule &&
+              cronstrue.toString(selectedItem.source?.schedule)}
           </div>
         </div>
         <div className="row">

--- a/src/components/DetailsTransformations/ConfigSteps/ConfigSteps.js
+++ b/src/components/DetailsTransformations/ConfigSteps/ConfigSteps.js
@@ -123,6 +123,7 @@ const ConfigSteps = ({
         <Select
           floatingLabel
           label="Selected step"
+          disabled={steps.length === 0}
           onClick={onSelectStep}
           options={steps}
           selectedId={selectedStep}
@@ -208,6 +209,20 @@ const ConfigSteps = ({
       </div>
     </Accordion>
   )
+}
+
+ConfigSteps.defaultProps = {
+  afterSteps: [],
+  errorSteps: [],
+  selectedAfterStep: '',
+  selectedErrorStep: '',
+  selectedStep: '',
+  setSelectedAfterStep: () => {},
+  setSelectedErrorStep: () => {},
+  setSelectedStep: () => {},
+  setStates: () => {},
+  states: {},
+  steps: []
 }
 
 ConfigSteps.propTypes = {

--- a/src/components/DetailsTransformations/ConfigTargets/ConfigTargets.js
+++ b/src/components/DetailsTransformations/ConfigTargets/ConfigTargets.js
@@ -40,6 +40,11 @@ const ConfigTargets = ({ steps, targets }) => {
   )
 }
 
+ConfigTargets.defaultProps = {
+  steps: [],
+  targets: []
+}
+
 ConfigTargets.propTypes = {
   steps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   targets: PropTypes.arrayOf(PropTypes.shape({})).isRequired

--- a/src/components/DetailsTransformations/DetailsTransformations.js
+++ b/src/components/DetailsTransformations/DetailsTransformations.js
@@ -170,7 +170,7 @@ const DetailsTransformations = ({ selectedItem }) => {
             elements={elements}
             onLoad={onLoad}
             elementsSelectable={false}
-            nodesDraggable={true}
+            nodesDraggable={false}
             nodesConnectable={false}
           />
         </ReactFlowProvider>

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -223,35 +223,24 @@ const FeatureStore = ({
     checkTabIsValid(history, match, selectedItem)
 
     setPageData(state => {
-      const newDetailsMenu = [...state.detailsMenu]
-
       if (match.params.pageTab === FEATURE_SETS_TAB) {
         return {
           ...state,
-          detailsMenu: [
-            ...generateFeatureSetsDetailsMenu(newDetailsMenu, selectedItem)
-          ]
+          detailsMenu: [...generateFeatureSetsDetailsMenu(selectedItem)]
         }
       } else if (match.params.pageTab === FEATURE_VECTORS_TAB) {
         return {
           ...state,
-          detailsMenu: [
-            ...generateFeatureVectorsDetailsMenu(newDetailsMenu, selectedItem)
-          ]
+          detailsMenu: [...generateFeatureVectorsDetailsMenu(selectedItem)]
         }
       } else if (match.params.pageTab === DATASETS_TAB) {
         return {
           ...state,
-          detailsMenu: [
-            ...generateDataSetsDetailsMenu(newDetailsMenu, selectedItem)
-          ]
+          detailsMenu: [...generateDataSetsDetailsMenu(selectedItem)]
         }
       }
 
-      return {
-        ...state,
-        detailsMenu: [...newDetailsMenu]
-      }
+      return { ...state }
     })
   }, [
     history,

--- a/src/components/FeatureStore/feaureStore.util.js
+++ b/src/components/FeatureStore/feaureStore.util.js
@@ -50,12 +50,6 @@ export const datasetsFilters = [
   { type: 'name', label: 'Name:' },
   { type: 'labels', label: 'Label:' }
 ]
-export const detailsMenu = ['overview', 'preview']
-export const featureVectorsDetailsMenu = [
-  'overview',
-  'requested features',
-  'preview'
-]
 export const featureSetsFilters = [
   { type: 'name', label: 'Name:' },
   { type: 'labels', label: 'Label:' }
@@ -213,7 +207,7 @@ export const generatePageData = (
   handleRemoveRequestData
 ) => {
   let data = {
-    detailsMenu,
+    detailsMenu: [],
     page,
     tabs
   }
@@ -235,7 +229,6 @@ export const generatePageData = (
     data.handleRequestOnExpand = handleRequestOnExpand
     data.handleRemoveRequestData = handleRemoveRequestData
     data.infoHeaders = featureVectorsInfoHeaders
-    data.detailsMenu = featureVectorsDetailsMenu
     data.registerArtifactDialogTitle = createFeatureVectorTitle
   } else {
     data.filters = datasetsFilters
@@ -456,69 +449,52 @@ export const checkTabIsValid = (history, match, selectedItem) => {
   }
 }
 
-export const generateFeatureSetsDetailsMenu = (
-  newDetailsMenu,
-  selectedItem
-) => {
-  if (!newDetailsMenu.includes('transformations')) {
-    newDetailsMenu.splice(1, 0, 'transformations')
-  }
+export const generateFeatureSetsDetailsMenu = selectedItem => {
+  const detailsMenu = [
+    { header: 'overview', visible: true },
+    {
+      header: 'features',
+      visible: Boolean(
+        selectedItem.item?.entities && selectedItem.item?.features
+      )
+    },
+    { header: 'transformations', visible: true },
+    { header: 'preview', visible: true },
+    { header: 'statistics', visible: Boolean(selectedItem.item?.stats) },
+    { header: 'analysis', visible: true }
+  ]
 
-  if (
-    selectedItem.item?.entities &&
-    selectedItem.item?.features &&
-    !newDetailsMenu.includes('features')
-  ) {
-    newDetailsMenu.splice(1, 0, 'features')
-  }
-
-  if (selectedItem.item?.stats && !newDetailsMenu.includes('statistics')) {
-    newDetailsMenu.splice(newDetailsMenu.length - 1, 0, 'statistics')
-  }
-
-  if (!newDetailsMenu.includes('analysis')) {
-    newDetailsMenu.push('analysis')
-  }
-
-  return newDetailsMenu
+  return detailsMenu.filter(item => item.visible).map(item => item.header)
 }
 
-export const generateFeatureVectorsDetailsMenu = (
-  newDetailsMenu,
-  selectedItem
-) => {
-  if (
-    selectedItem.item?.features &&
-    !newDetailsMenu.includes('returned features')
-  ) {
-    newDetailsMenu.splice(2, 0, 'returned features')
-  }
+export const generateFeatureVectorsDetailsMenu = selectedItem => {
+  const detailsMenu = [
+    { header: 'overview', visible: true },
+    { header: 'requested features', visible: true },
+    {
+      header: 'returned features',
+      visible: Boolean(selectedItem.item?.features)
+    },
+    { header: 'preview', visible: true },
+    {
+      header: 'statistics',
+      visible: Boolean(selectedItem.item?.stats && selectedItem.item?.features)
+    },
+    { header: 'analysis', visible: true }
+  ]
 
-  if (
-    selectedItem.item?.stats &&
-    selectedItem.item?.features &&
-    !newDetailsMenu.includes('statistics')
-  ) {
-    newDetailsMenu.splice(newDetailsMenu.length - 1, 0, 'statistics')
-  }
-
-  if (!newDetailsMenu.includes('analysis')) {
-    newDetailsMenu.push('analysis')
-  }
-
-  return newDetailsMenu
+  return detailsMenu.filter(item => item.visible).map(item => item.header)
 }
 
-export const generateDataSetsDetailsMenu = (newDetailsMenu, selectedItem) => {
-  if (selectedItem.item?.schema && !newDetailsMenu.includes('metadata')) {
-    newDetailsMenu.push('metadata')
-  }
+export const generateDataSetsDetailsMenu = selectedItem => {
+  const detailsMenu = [
+    { header: 'overview', visible: true },
+    { header: 'preview', visible: true },
+    { header: 'metadata', visible: Boolean(selectedItem.item?.schema) },
+    { header: 'analysis', visible: Boolean(selectedItem.item?.extra_data) }
+  ]
 
-  if (selectedItem.item?.extra_data && !newDetailsMenu.includes('analysis')) {
-    newDetailsMenu.push('analysis')
-  }
-
-  return newDetailsMenu
+  return detailsMenu.filter(item => item.visible).map(item => item.header)
 }
 
 export const fetchFeatureRowData = async (


### PR DESCRIPTION
- **Feature Store**: tab headers order in details panel is inconsistent
  ![image](https://user-images.githubusercontent.com/13918850/108225645-cd3d6600-7144-11eb-98af-11cebf248bf8.png)
  ![image](https://user-images.githubusercontent.com/13918850/108225700-d75f6480-7144-11eb-856d-2bebaeb46aab.png)
- **Feature Sets**: UI crashes when loading Transformations tab for a feature set without `spec.graph`