### PR TITLE
[Feature Sets] Group name repeats in nested rows, selected nested row not highlighted

### DIFF
--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -42,6 +42,25 @@ const ArtifactsTableRow = ({
   )
   const mainRowData = Object.values(rowItem)
 
+  const findCurrentItem = artifact => {
+    if (match.params.pageTab === FEATURES_TAB) {
+      return content.find(
+        item =>
+          `${item.name}-${item.metadata?.name}` ===
+          `${artifact.key?.value}-${artifact.feature_set?.value}`
+      )
+    } else {
+      return content.find(contentItem => {
+        const key = contentItem.db_key ? 'db_key' : 'name'
+
+        return (
+          contentItem[key] === artifact.key.value &&
+          contentItem.tag === artifact.version?.value
+        )
+      })
+    }
+  }
+
   return (
     <div className={rowClassNames} ref={parent}>
       {parent.current?.classList.contains('parent-row-expanded') ? (
@@ -67,30 +86,15 @@ const ArtifactsTableRow = ({
             })}
           </div>
           {tableContent.map((artifact, index) => {
+            const currentItem = findCurrentItem(artifact)
             const subRowClassNames = classnames(
               'table-body__row',
               ((selectedItem?.db_key &&
-                selectedItem?.db_key === content[index]?.db_key) ||
+                selectedItem?.db_key === currentItem.db_key) ||
                 (selectedItem?.name &&
-                  selectedItem?.name === content[index]?.name)) &&
+                  selectedItem?.name === currentItem.name)) &&
                 'row_active'
             )
-            let currentItem = {}
-
-            if (match.params.pageTab === FEATURES_TAB) {
-              currentItem = content.find(
-                item =>
-                  `${item.name}-${item.metadata?.name}` ===
-                  `${artifact.key?.value}-${artifact.feature_set?.value}`
-              )
-            } else {
-              currentItem = content.find(
-                contentItem =>
-                  (contentItem.name === artifact.name ||
-                    contentItem.db_key === artifact.db_key) &&
-                  contentItem.tag === artifact.version?.value
-              )
-            }
 
             return (
               <div className={subRowClassNames} key={index}>

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -310,7 +310,11 @@ const createFeatureSetsRowData = (artifact, project) => {
     key: {
       value: artifact.name,
       class: 'artifacts_medium',
-      link: `/projects/${project}/feature-store/feature-sets/${artifact.name}/${artifact.tag}/overview`
+      link: `/projects/${project}/feature-store/feature-sets/${artifact.name}/${artifact.tag}/overview`,
+      expandedCellContent: {
+        class: 'artifacts_medium',
+        value: artifact.tag
+      }
     },
     description: {
       value: artifact.description,


### PR DESCRIPTION
https://trello.com/c/gzZFPunj/696-feature-sets-group-name-repeats-in-nested-rows

- **Feature Sets**: Removed unnecessarily-repeated name in nested rows of a group (by name)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/108842430-f137f600-75e1-11eb-83cd-e4f72a89c030.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/108842447-f72dd700-75e1-11eb-86ba-b12c5b3525a4.png)
- **Feature Sets**: Added missing highlight to selected nested row
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/108843470-6821be80-75e3-11eb-84a3-1605b48be404.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/108843475-6b1caf00-75e3-11eb-8405-0d15c5fb5480.png)
