### PR TITLE
Fix [General] Details panel: actions not sticking to top on scroll

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -47,6 +47,8 @@
           align-items: center;
           align-self: flex-end;
           margin-top: -70px;
+          position: sticky;
+          top: -5px;
 
           a {
             display: inline-block;
@@ -84,7 +86,6 @@
         z-index: 4;
         display: flex;
         align-items: center;
-        margin: 29px 0 0;
         padding: 7px 0 0;
         list-style-type: none;
         background-color: $white;


### PR DESCRIPTION
- **Details panel**: Actions stopped sticking to the top on scrolling down. Now it is fixed.
  Before:
  ![no-sticky](https://user-images.githubusercontent.com/13918850/108864621-0a00d580-75fb-11eb-87fa-0023fbeb383f.gif)
  After:
  ![sticky-headers](https://user-images.githubusercontent.com/13918850/108864640-0ff6b680-75fb-11eb-8a92-631946f986d2.gif)

Bug originates in PR https://github.com/mlrun/ui/pull/395
Original implemented in PR https://github.com/mlrun/ui/pull/283