### PR TITLE
Fix [Jobs] Error when a job has a parameter with `null` value

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -9,7 +9,7 @@ export const parseKeyValues = (object = {}) =>
                   ` ${arrayItemKey}: ${arrayItemValue} `
               )}} `
             })}]`
-          : typeof value === 'object'
+          : typeof value === 'object' && value !== null
           ? `${key}: {${Object.entries(value).map(
               ([valueKey, valueContent]) => ` ${valueKey}: ${valueContent} `
             )}}`


### PR DESCRIPTION
- **Jobs**: List of jobs failed to load when a job had a parameter with the value `null`.