### PR TITLE
Fix [Breadcrumbs] Links to Nuclio are static instead of dynamic

### DIFF
--- a/src/common/Breadcrumbs/breadcrumbs.util.js
+++ b/src/common/Breadcrumbs/breadcrumbs.util.js
@@ -7,12 +7,12 @@ export const generateProjectScreens = match => [
   {
     label: 'Real-time functions',
     id: 'Real-time functions',
-    link: `${process.env.REACT_APP_NUCLIO_UI_URL}/projects/${match.params.projectName}/functions`
+    link: `${window.mlrunConfig.nuclioUiUrl}/projects/${match.params.projectName}/functions`
   },
   {
     label: 'API gateways',
     id: 'API gateways',
-    link: `${process.env.REACT_APP_NUCLIO_UI_URL}/projects/${match.params.projectName}/api-gateways`
+    link: `${window.mlrunConfig.nuclioUiUrl}/projects/${match.params.projectName}/api-gateways`
   }
 ]
 


### PR DESCRIPTION
- **Breadcrumbs**: The links “Real-time functions” and “API gateways” were statically set on build (`npm run build`). Using Docker you couldn't change them once the Docker image was ready.
  Now they are dynamic: they could be set on runtime, using `docker run` and passing the environment variable `MLRUN_NUCLIO_UI_URL`.
  ![image](https://user-images.githubusercontent.com/13918850/108984217-59491380-7698-11eb-876d-f8814cc0dd21.png)