### PR TITLE
[Breadcrumbs] Add full value in tooltip on menu option hover

### DIFF
--- a/src/elements/BreadcrumbsDropdown/BreadcrumbsDropdown.js
+++ b/src/elements/BreadcrumbsDropdown/BreadcrumbsDropdown.js
@@ -3,6 +3,9 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
+import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
+import Tooltip from '../../common/Tooltip/Tooltip'
+
 import { ReactComponent as SearchIcon } from '../../images/search.svg'
 
 import './breadcrumbsDropdown.scss'
@@ -52,7 +55,9 @@ const BreadcrumbsDropdown = ({
             className={dropdownItemClassNames}
             onClick={onClick}
           >
-            {listItem.label}
+            <Tooltip template={<TextTooltipTemplate text={listItem.label} />}>
+              {listItem.label}
+            </Tooltip>
           </Link>
         )
       })}


### PR DESCRIPTION
https://trello.com/c/YycvZD0M/690-breadcrumbs-add-full-value-in-tooltip-on-menu-option-hover

- **Breadcrumbs**: Added tooltip with full values of cropped text when if overflows the dropdown menu‘s width
  ![image](https://user-images.githubusercontent.com/13918850/109485893-dc001300-7a8a-11eb-8e88-13a11a36b48c.png)