### PR TITLE
Fix [Artifacts] Preview: path inconsistently missing schema

### DIFF
--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -25,7 +25,9 @@ const PreviewModal = ({ item }) => {
             {item.db_key || item.key}
           </div>
           <div className="item-data item-data__path">
-            {item.target_path?.path}
+            {`${
+              item.target_path?.schema ? `${item.target_path?.schema}://` : ''
+            }${item.target_path?.path}`}
           </div>
           {item.size && (
             <div className="item-data">


### PR DESCRIPTION
- **Artifacts**: Added missing scheme (for example `v3io://`) to artifact path in the header of the artifact preview pop-up (which was inconsistent with the value of “Path” field in “Overview” tab that _did_ show the scheme)
Before:
![image](https://user-images.githubusercontent.com/13918850/109492174-38673080-7a93-11eb-9639-3c3432a9be08.png)
After:
![image](https://user-images.githubusercontent.com/13918850/109492182-3ac98a80-7a93-11eb-821f-c36ccf2d7c58.png)

Jira ticket ML-227