### PR TITLE
[Artifacts] Removed Artifacts screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ import Loader from './common/Loader/Loader'
 
 import './scss/main.scss'
 
-const Artifacts = React.lazy(() => import('./components/Artifacts/Artifacts'))
 const CreateJobPage = React.lazy(() =>
   import('./components/CreateJobPage/CreateJobPage')
 )
@@ -58,16 +57,6 @@ const App = () => {
               exact
               strict
               render={routeProps => <Jobs {...routeProps} />}
-            />
-            <Route
-              exact
-              path="/projects/:projectName/artifacts/:name/:tab"
-              render={routeProps => <Artifacts {...routeProps} />}
-            />
-            <Route
-              exact
-              path="/projects/:projectName/artifacts"
-              render={routeProps => <Artifacts {...routeProps} />}
             />
             <Route
               exact

--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -74,7 +74,8 @@ const DetailsArtifacts = ({
         target_path: target_path,
         user: selectedJob?.labels
           ?.find(item => item.match(/v3io_user|owner/g))
-          .replace(/(v3io_user|owner): /, '')
+          .replace(/(v3io_user|owner): /, ''),
+        kind: artifact.kind
       }
 
       if (artifact.schema) {

--- a/src/components/DetailsArtifacts/DetailsArtifactsView.js
+++ b/src/components/DetailsArtifacts/DetailsArtifactsView.js
@@ -64,7 +64,7 @@ const DetailsArtifactsView = ({
                 <Link
                   target="_blank"
                   to={
-                    artifactScreenLinks[artifact.kind] ||
+                    artifactScreenLinks[artifact.kind] ??
                     `/projects/${
                       match.params.projectName
                     }/files/${artifact.db_key || artifact.key}/overview`

--- a/src/components/DetailsArtifacts/DetailsArtifactsView.js
+++ b/src/components/DetailsArtifacts/DetailsArtifactsView.js
@@ -24,6 +24,14 @@ const DetailsArtifactsView = ({
       const targetPath = `${
         artifact.target_path.schema ? `${artifact.target_path.schema}://` : ''
       }${artifact.target_path.path}`
+      const artifactScreenLinks = {
+        model: `/projects/${
+          match.params.projectName
+        }/models/models/${artifact.db_key || artifact.key}/overview`,
+        dataset: `/projects/${
+          match.params.projectName
+        }/feature-store/datasets/${artifact.db_key || artifact.key}/overview`
+      }
 
       return (
         <div className="item-artifacts__row-wrapper" key={index}>
@@ -55,9 +63,12 @@ const DetailsArtifactsView = ({
               <Tooltip template={<TextTooltipTemplate text="Show Details" />}>
                 <Link
                   target="_blank"
-                  to={`/projects/${
-                    match.params.projectName
-                  }/artifacts/${artifact.db_key || artifact.key}/overview`}
+                  to={
+                    artifactScreenLinks[artifact.kind] ||
+                    `/projects/${
+                      match.params.projectName
+                    }/files/${artifact.db_key || artifact.key}/overview`
+                  }
                 >
                   <DetailsIcon />
                 </Link>


### PR DESCRIPTION
https://trello.com/c/UdrUE3aa/708-artifacts-remove-artifacts-screen

- **Artifacts**: The old “Artifacts” screen is no longer accessible, even from URL path /projects/{project}/artifacts.
- **Jobs**: In “Artifacts” tab the “Show details” icon button now redirects to the specific screen according to the artifact‘s kind: Models (for `"kind": "model"`), Datasets (for `"kind": "dataset"`) or Files (for all others, including `"kind": ""`).
  ![image](https://user-images.githubusercontent.com/13918850/109514449-b71d9700-7aae-11eb-8b1c-d93d78192bd8.png)
