### PR TITLE
[Artifacts] Preview: add tooltip to pop-out icon button

### DIFF
--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import ArtifactsPreview from '../ArtifactsPreview/ArtifactsPreview'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+import Tooltip from '../../common/Tooltip/Tooltip'
 
 import { ReactComponent as Popout } from '../../images/popout.svg'
 
@@ -21,7 +23,9 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
     <div className="preview_container">
       {artifact.target_path && (
         <button onClick={() => handlePreview()} className="preview_popout">
-          <Popout />
+          <Tooltip template={<TextTooltipTemplate text="Pop-out" />}>
+            <Popout />
+          </Tooltip>
         </button>
       )}
       <ArtifactsPreview noData={noData} preview={preview} />


### PR DESCRIPTION
https://trello.com/c/mNxnfENG/703-artifacts-preview-incorrect-redirection-on-pop-out

- **Models,Datasets,Files**: Preview tab: Added missing tooltip to “Pop-out” icon button
  ![image](https://user-images.githubusercontent.com/13918850/109812853-3f2da900-7c35-11eb-8c4d-a5addda127a9.png)
