### PR TITLE
[General] Chip list pop-over stacking issues

### DIFF
--- a/src/elements/HiddenChipsBlock/HiddenChipsBlock.js
+++ b/src/elements/HiddenChipsBlock/HiddenChipsBlock.js
@@ -1,11 +1,13 @@
 import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 
 import Tooltip from '../../common/Tooltip/Tooltip'
 import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
 import Chip from '../../common/Chip/Chip'
 
 import { getChipLabelAndValue } from '../../utils/getChipLabelAndValue'
+import { getFirstScrollableParent } from '../../utils/getFirstScrollableParent'
 
 import './hiddenChipsBlock.scss'
 
@@ -22,22 +24,34 @@ const HiddenChipsBlock = ({
   setEditConfig
 }) => {
   const [isTop, setIsTop] = useState(false)
+  const [isVisible, setIsVisible] = useState(false)
   const hiddenRef = useRef()
   const offset = 28
+  const hiddenChipsBlockClassNames = classnames(
+    'chip-block-hidden',
+    isTop ? 'chip-block-hidden_top' : 'chip-block-hidden_bottom',
+    isVisible && 'chip-block-hidden_visible'
+  )
 
   useEffect(() => {
     if (hiddenRef?.current) {
-      const { height } = hiddenRef.current.getBoundingClientRect()
+      const scrollableParent = getFirstScrollableParent(
+        hiddenRef.current.offsetParent
+      )
+      const { height, top } = hiddenRef.current.getBoundingClientRect()
 
       if (
         hiddenRef.current.offsetParent.getBoundingClientRect().top -
           hiddenRef.current.offsetParent.clientHeight -
           height -
           offset <
-        0
+          0 ||
+        scrollableParent.getBoundingClientRect().top > top
       ) {
         setIsTop(true)
       }
+
+      setIsVisible(true)
     }
   }, [hiddenRef, offset])
 
@@ -48,10 +62,7 @@ const HiddenChipsBlock = ({
   })
 
   return (
-    <div
-      ref={hiddenRef}
-      className={`chip-block-hidden ${!isTop ? 'top' : 'bottom'}`}
-    >
+    <div ref={hiddenRef} className={hiddenChipsBlockClassNames}>
       {chips?.map((element, index) => {
         const { chipLabel, chipValue } = getChipLabelAndValue(element)
 

--- a/src/elements/HiddenChipsBlock/hiddenChipsBlock.scss
+++ b/src/elements/HiddenChipsBlock/hiddenChipsBlock.scss
@@ -7,19 +7,20 @@
 .chip-block-hidden {
   position: absolute;
   right: 0;
-  z-index: 4;
+  z-index: 6;
   flex-direction: column;
   width: 250px;
   padding: 10px;
   background-color: $white;
   border-radius: $mainBorderRadius;
   box-shadow: $hiddenChipsBlockShadow;
+  opacity: 0;
 
   &__chip {
     border: $parametersBorder;
   }
 
-  &.top {
+  &_bottom {
     bottom: 112%;
 
     &::after {
@@ -36,7 +37,7 @@
     }
   }
 
-  &.bottom {
+  &_top {
     top: 112%;
 
     &::before {
@@ -51,5 +52,9 @@
       transform: rotate(-45deg);
       content: '';
     }
+  }
+
+  &_visible {
+    opacity: 1;
   }
 }

--- a/src/utils/getFirstScrollableParent.js
+++ b/src/utils/getFirstScrollableParent.js
@@ -1,0 +1,18 @@
+const regex = /(auto|scroll)/
+
+const style = (node, prop) =>
+  getComputedStyle(node, null).getPropertyValue(prop)
+
+const scroll = node =>
+  regex.test(
+    style(node, 'overflow') +
+      style(node, 'overflow-y') +
+      style(node, 'overflow-x')
+  )
+
+export const getFirstScrollableParent = node =>
+  !node || node === document.body
+    ? document.body
+    : scroll(node)
+    ? node
+    : getFirstScrollableParent(node.parentNode)


### PR DESCRIPTION
https://trello.com/c/urXj73cb/709-general-chip-list-pop-over-stacking-issue

- **General**: Chip list pop-over was shown underneath some elements instead of over them
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/109820589-d1d24600-7c3d-11eb-8450-d58aaf2fc179.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/109820619-d860bd80-7c3d-11eb-992a-75def436eed2.png)
