### PR TITLE
Impl [Datasets] Preview: when no `header`, use `preview` first row

### DIFF
--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -15,8 +15,8 @@ export const setArtifactPreviewFromSchema = (
     {
       type: 'table',
       data: {
-        headers: artifact.header,
-        content: artifact.preview
+        headers: artifact.header ?? artifact.preview[0],
+        content: artifact.header ? artifact.preview : artifact.preview.slice(1)
       }
     }
   ])


### PR DESCRIPTION
- **Datasets**: In “Preview” tab, when the dataset has no `header` field, use the first row of its `preview` field as the header row of the displayed preview table.