### PR TITLE
Fix [Filters] Inconsistent order of filters across screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pretty-bytes": "^5.3.0",
     "prismjs": "^1.19.0",
     "prop-types": "^15.7.2",
+    "qs": "^6.9.6",
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.4",
     "react-dev-utils": "^9.1.0",

--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -6,33 +6,28 @@ import {
 } from '../constants'
 
 const fetchArtifacts = (item, path) => {
-  let url = path
+  const params = {}
 
   if (item?.labels) {
-    let labels = item?.labels
-      ?.split(',')
-      .map(item => `label=${item}`)
-      .join('&')
-
-    url = `${url}&${labels}`
+    params.label = item.labels?.split(',')
   }
 
   if (item?.tag && !/latest/i.test(item.tag)) {
-    url = `${url}&tag=${item.tag}`
+    params.tag = item.tag
   }
 
   if (item?.name) {
-    url = `${url}&name=${item.name}`
+    params.name = item.name
   }
 
-  return mainHttpClient.get(url)
+  return mainHttpClient.get(path, { params })
 }
 
 const fetchFeatureStoreData = (item, tab, config) => {
   const params = {}
 
   if (item?.labels) {
-    params.labels = item.labels
+    params.label = item.labels?.split(',')
   }
 
   if (item?.tag && !/latest/i.test(item.tag)) {
@@ -88,7 +83,7 @@ export default {
     const params = {}
 
     if (item?.labels) {
-      params.labels = item.labels
+      params.label = item.labels?.split(',')
     }
 
     if (item?.tag) {
@@ -113,7 +108,7 @@ export default {
     const params = {}
 
     if (item?.labels) {
-      params.labels = item.labels
+      params.label = item.labels?.split(',')
     }
 
     return mainHttpClient.get(`/projects/${item.project}/model-endpoints`, {

--- a/src/api/jobs-api.js
+++ b/src/api/jobs-api.js
@@ -4,22 +4,19 @@ export default {
   filterByStatus: (project, state) =>
     mainHttpClient.get(`/runs?project=${project}&state=${state}`),
   getAll: (project, state, event) => {
-    let url = `/runs?project=${project}`
+    const params = {
+      project
+    }
 
     if (event?.labels) {
-      let labels = event?.labels
-        ?.split(',')
-        .map(item => `label=${item}`)
-        .join('&')
-
-      url = `${url}&${labels}`
+      params.label = event.labels.split(',')
     }
 
     if (event?.name) {
-      url = `${url}&name=${event.name}`
+      params.name = event.name
     }
 
-    return mainHttpClient.get(url)
+    return mainHttpClient.get('/runs', { params })
   },
   getJobLogs: (id, project) => mainHttpClient.get(`/log/${project}/${id}`),
   getScheduled: (project, status, event) => {
@@ -36,7 +33,7 @@ export default {
     }
 
     if (event?.labels) {
-      params.labels = event?.labels
+      params.labels = event.labels?.split(',')
     }
 
     return mainHttpClient.get(`/projects/${project}/schedules`, { params })

--- a/src/common/Input/input.scss
+++ b/src/common/Input/input.scss
@@ -55,7 +55,7 @@
 
   &__label {
     position: absolute;
-    top: 9px;
+    top: 10px;
     left: 10px;
     color: $topaz;
     text-transform: capitalize;

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -133,7 +133,7 @@ const FilterMenu = ({
                 <Input
                   type="text"
                   label={filter.label}
-                  placeholder="key or key=value"
+                  placeholder="key1,key2=value,..."
                   key={filter.type}
                   onChange={setLabels}
                   value={labels}

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -101,8 +101,8 @@ export const filters = [
   { type: 'period', label: 'Period:' },
   { type: 'status', label: 'Status:' },
   { type: 'groupBy', label: 'Group by:' },
-  { type: 'labels', label: 'Labels:' },
-  { type: 'name', label: 'Name:' }
+  { type: 'name', label: 'Name:' },
+  { type: 'labels', label: 'Labels:' }
 ]
 export const initialStateFilter = 'all'
 export const initialGroupFilter = 'name'

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -20,8 +20,8 @@ export const modelsDetailsMenu = ['overview', 'preview']
 export const modelEndpointsDetailsMenu = ['overview']
 export const modelsFilters = [
   { type: 'tree', label: 'Tree:' },
-  { type: 'labels', label: 'Labels:' },
-  { type: 'name', label: 'Name:' }
+  { type: 'name', label: 'Name:' },
+  { type: 'labels', label: 'Labels:' }
 ]
 export const modelEndpointsFilters = [{ type: 'labels', label: 'Labels:' }]
 export const page = MODELS_PAGE

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -1,7 +1,12 @@
 import axios from 'axios'
+import qs from 'qs'
 
 export const mainHttpClient = axios.create({
-  baseURL: `${process.env.PUBLIC_URL}/api`
+  baseURL: `${process.env.PUBLIC_URL}/api`,
+
+  // serialize a param with an array value as a repeated param, for example:
+  // { label: ['host', 'owner=admin'] } => 'label=host&label=owner%3Dadmin'
+  paramsSerializer: params => qs.stringify(params, { arrayFormat: 'repeat' })
 })
 
 export const functionTemplatesHttpClient = axios.create({


### PR DESCRIPTION
- **General**: Fixed a few issues with “Labels” filters in all screens:
  - Put Name filter before Labels filter in all screens with these filters.
  - Rename all "Label" filter to "Labels" and reword its placeholder from "key or key-value" to "key1,key2=value,...".
  - Fix some failed filtering by labels which was caused by sending `labels` URL param instead of `label`, and sending a single value with a comma-delimited list (for example: `label=a=b,c=d`) instead of repeating the `label` param for each list item (for example: `label=a=b&label=c=d`).
  ![image](https://user-images.githubusercontent.com/13918850/110252552-ada09d00-7f8e-11eb-842b-7b7dfdf701ee.png)

Jira ticket ML-214
