### PR TITLE
[Jobs] Artifacts: name and target path overlap

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifactsView.js
+++ b/src/components/DetailsArtifacts/DetailsArtifactsView.js
@@ -39,12 +39,12 @@ const DetailsArtifactsView = ({
         <div className="item-artifacts__row-wrapper" key={index}>
           <div className="item-artifacts__row">
             <div className="item-artifacts__row-item">
-              <span
+              <Tooltip
                 className="item-artifacts__name"
-                onClick={() => showArtifact(index)}
+                template={<TextTooltipTemplate text={artifact.key} />}
               >
-                {artifact.key}
-              </span>
+                <span onClick={() => showArtifact(index)}>{artifact.key}</span>
+              </Tooltip>
             </div>
             <div className="item-artifacts__row-item item-artifacts__row-item_long">
               <Tooltip template={<TextTooltipTemplate text={targetPath} />}>

--- a/src/components/DetailsArtifacts/detailsArtifacts.scss
+++ b/src/components/DetailsArtifacts/detailsArtifacts.scss
@@ -60,6 +60,7 @@
   }
 
   &__name {
+    width: 100%;
     cursor: pointer;
   }
 


### PR DESCRIPTION
https://trello.com/c/mMKjSzHx/714-jobs-artifacts-name-and-target-path-overlap

- **Jobs**: Artifacts tab: long artifact names were overlapping with the target path. Now when the name is long it will be clipped with an ellipsis `…` with the full value in a tooltip
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/110794801-cc4caf80-827e-11eb-9bf2-de97a8150ff1.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/110794812-cf47a000-827e-11eb-82e1-626a4cae9092.png)

Jira ticket ML-260