### PR TITLE
[Models][Datasets][Files] Overview: rename Tree to UID + info

### DIFF
--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import ArtifactInfoSources from '../ArtifactInfoSources/ArtifactInfoSources'
 import DetailsInfoItem from '../../elements/DetailsInfoItem/DetailsInfoItem'
+import Tip from '../../common/Tip/Tip'
 
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import {
@@ -126,7 +127,12 @@ const DetailsInfoView = React.forwardRef(
 
               return (
                 <li className="details-item" key={header.id}>
-                  <div className="details-item__header">{header.label}</div>
+                  <div className="details-item__header">
+                    {header.label}
+                    {header.tip && (
+                      <Tip className="details-item__tip" text={header.tip} />
+                    )}
+                  </div>
                   <DetailsInfoItem
                     chipsClassName={chipsClassName}
                     chipsData={chipsData}

--- a/src/components/DetailsInfo/detailsInfo.scss
+++ b/src/components/DetailsInfo/detailsInfo.scss
@@ -23,11 +23,16 @@
       border-bottom: $secondaryBorder;
 
       &__header {
+        display: flex;
         min-width: 100px;
         font-weight: bold;
         font-size: 14px;
         line-height: 24px;
         text-transform: capitalize;
+      }
+
+      &__tip {
+        margin-left: 5px;
       }
 
       &__data {

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -17,12 +17,22 @@ import { parseFeatures } from '../../utils/parseFeatures'
 import { parseFeatureStoreDataRequest } from '../../utils/parseFeatureStoreDataRequest'
 
 export const datasetsInfoHeaders = [
-  { label: 'Hash', id: 'hash' },
+  {
+    label: 'Hash',
+    id: 'hash',
+    tip:
+      'Represents hash of the data. when the data changes the hash would change'
+  },
   { label: 'Key', id: 'db_key' },
   { label: 'Iter', id: 'iter' },
   { label: 'Size', id: 'size' },
   { label: 'Path', id: 'target_path' },
-  { label: 'Tree', id: 'tree' },
+  {
+    label: 'UID',
+    id: 'tree',
+    tip:
+      'Unique identifier representing the job or the workflow that generated the artifact'
+  },
   { label: 'Updated', id: 'updated' },
   { label: 'Labels', id: 'labels' },
   { label: 'Sources', id: 'sources' }

--- a/src/components/Files/files.util.js
+++ b/src/components/Files/files.util.js
@@ -1,12 +1,22 @@
 import { FILES_PAGE } from '../../constants'
 
 export const infoHeaders = [
-  { label: 'Hash', id: 'hash' },
+  {
+    label: 'Hash',
+    id: 'hash',
+    tip:
+      'Represents hash of the data. when the data changes the hash would change'
+  },
   { label: 'Key', id: 'db_key' },
   { label: 'Iter', id: 'iter' },
   { label: 'Size', id: 'size' },
   { label: 'Path', id: 'target_path' },
-  { label: 'Tree', id: 'tree' },
+  {
+    label: 'UID',
+    id: 'tree',
+    tip:
+      'Unique identifier representing the job or the workflow that generated the artifact'
+  },
   { label: 'Updated', id: 'updated' },
   { label: 'Labels', id: 'labels' },
   { label: 'Sources', id: 'sources' }

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -4,14 +4,24 @@ import { generateArtifacts } from '../../utils/generateArtifacts'
 import { maxBy } from 'lodash'
 
 export const modelsInfoHeaders = [
-  { label: 'Hash', id: 'hash' },
+  {
+    label: 'Hash',
+    id: 'hash',
+    tip:
+      'Represents hash of the data. when the data changes the hash would change'
+  },
   { label: 'Key', id: 'db_key' },
   { label: 'Iter', id: 'iter' },
   { label: 'Kind', id: 'kind' },
   { label: 'Size', id: 'size' },
   { label: 'Path', id: 'target_path' },
   { label: 'Model file', id: 'model_file' },
-  { label: 'Tree', id: 'tree' },
+  {
+    label: 'UID',
+    id: 'tree',
+    tip:
+      'Unique identifier representing the job or the workflow that generated the artifact'
+  },
   { label: 'Updated', id: 'updated' },
   { label: 'Framework', id: 'framework' },
   { label: 'Labels', id: 'labels' },


### PR DESCRIPTION
https://trello.com/c/t2XHsHL0/717-modelsdatasetsfiles-overview-rename-tree-to-uid-info

- **Models, Datasets, Files**: in “Overview” tab, rename “Tree” field to “UID” and add more-info icon with a tooltip to show some info for “UID” and “Hash” fields
  ![image](https://user-images.githubusercontent.com/13918850/110798086-7974f700-8282-11eb-8b22-add20dd4cd8b.png)
  ![image](https://user-images.githubusercontent.com/13918850/110798090-7b3eba80-8282-11eb-8a3f-04c81371b1fd.png)

Jira ticket 254