### PR TITLE
Fix [General] Overview tab: capitalized tooltip messages

### DIFF
--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { capitalize } from 'lodash'
 
 import ArtifactInfoSources from '../ArtifactInfoSources/ArtifactInfoSources'
 import DetailsInfoItem from '../../elements/DetailsInfoItem/DetailsInfoItem'
@@ -175,7 +176,9 @@ const DetailsInfoView = React.forwardRef(
 
                     return (
                       <li className="details-item" key={key}>
-                        <div className="details-item__header">{key}</div>
+                        <div className="details-item__header">
+                          {capitalize(key)}
+                        </div>
                         <DetailsInfoItem link={url} info={value} />
                       </li>
                     )

--- a/src/components/DetailsInfo/detailsInfo.scss
+++ b/src/components/DetailsInfo/detailsInfo.scss
@@ -28,7 +28,6 @@
         font-weight: bold;
         font-size: 14px;
         line-height: 24px;
-        text-transform: capitalize;
       }
 
       &__tip {


### PR DESCRIPTION
- **General**: In “Overview” tab tooltip messages were capitalized (each word)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/110798795-2f404580-8283-11eb-9dc0-fdc660f6b494.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/110798086-7974f700-8282-11eb-8b22-add20dd4cd8b.png)