### PR TITLE
[Project Overview] Jobs: Show status of up to last 5 runs

### DIFF
--- a/src/components/ProjectTable/ProjectTable.js
+++ b/src/components/ProjectTable/ProjectTable.js
@@ -33,10 +33,8 @@ const ProjectTable = ({ match, table }) => {
                   const tableValueClassName = classnames(
                     'project-data-card__table-cell',
                     body[key].className,
-                    key === 'status' &&
-                      `status_${body[key].value.toLowerCase()} capitalize`
+                    key === 'status' && 'status-cell'
                   )
-
                   return key === 'type' ? (
                     <TableTypeCell
                       key={body[key].value + index}
@@ -83,6 +81,22 @@ const ProjectTable = ({ match, table }) => {
                             </Tooltip>
                           </Link>
                         )
+                      ) : key === 'status' ? (
+                        <>
+                          {Array.isArray(body.status.value) &&
+                            body.status.value.map((status, index) => {
+                              return (
+                                <Tooltip
+                                  key={index}
+                                  template={
+                                    <TextTooltipTemplate text={status} />
+                                  }
+                                >
+                                  <i className={`${status} status-icon`} />
+                                </Tooltip>
+                              )
+                            })}
+                        </>
                       ) : (
                         <Tooltip
                           template={

--- a/src/components/ProjectTable/projectTable.scss
+++ b/src/components/ProjectTable/projectTable.scss
@@ -48,39 +48,9 @@
       color: $primary;
       line-height: 24px;
 
-      &.status {
-        color: $supernova;
-        text-transform: none;
-
-        &_completed,
-        &_ready,
-        &_running {
-          color: $java;
-        }
-
-        &-nuclio {
-          &_ready {
-            color: $brightTurquoise;
-
-            &.disabled {
-              color: $topaz;
-            }
-          }
-
-          &_scaledToZero {
-            color: $topaz;
-          }
-        }
-
-        &_failed,
-        &_error,
-        &_unhealthy {
-          color: $amaranth;
-        }
-
-        &_imported {
-          color: $topaz;
-        }
+      .tooltip-wrapper {
+        min-width: 8px;
+        margin-right: 5px;
       }
 
       .table-body__cell {

--- a/src/elements/ProjectJobs/ProjectJobs.js
+++ b/src/elements/ProjectJobs/ProjectJobs.js
@@ -1,10 +1,15 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import ProjectDataCard from '../ProjectDataCard/ProjectDataCard'
 
-import { getJobsStatistics, getJobsTableData } from './projectJobs.utils'
+import {
+  getJobsStatistics,
+  getJobsTableData,
+  groupByName,
+  sortByDate
+} from './projectJobs.utils'
 import projectsAction from '../../actions/projects'
 
 const ProjectJobs = ({
@@ -14,6 +19,16 @@ const ProjectJobs = ({
   match,
   projectStore
 }) => {
+  const [groupedLatestItem, setGroupedLatestItem] = useState([])
+
+  useEffect(() => {
+    if (projectStore.project.jobs.data) {
+      setGroupedLatestItem(
+        sortByDate(groupByName(projectStore.project.jobs.data))
+      )
+    }
+  }, [projectStore.project.jobs.data])
+
   useEffect(() => {
     fetchProjectJobs(match.params.projectName)
     fetchProjectScheduledJobs(match.params.projectName)
@@ -32,13 +47,14 @@ const ProjectJobs = ({
       projectStore.project.scheduledJobs,
       projectStore.project.workflows
     )
-    const table = getJobsTableData(projectStore.project.jobs, match)
+    const table = getJobsTableData(groupedLatestItem, match)
 
     return {
       statistics,
       table
     }
   }, [
+    groupedLatestItem,
     match,
     projectStore.project.jobs,
     projectStore.project.scheduledJobs,

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -77,6 +77,10 @@ main {
   @include jobStatus($brightTurquoise);
 }
 
+.pending {
+  @include jobStatus($topaz);
+}
+
 .warn {
   @include jobStatus($grandis);
 }


### PR DESCRIPTION
https://trello.com/c/AbdOCo7e/713-project-overview-jobs-show-status-of-up-to-last-5-runs

- **Project Overview**: In “Status” column of the “Jobs and workflows” pane, instead of showing the status of the latest job’s run only (as a text), we’re now showing the status of the last five runs, from latest on the left to earliest on the right, as colorful indicators with the status as text in a tooltip on hover
  ![image](https://user-images.githubusercontent.com/13918850/111179052-60d34c80-85b4-11eb-90b6-51648268002b.png)
- **Jobs**: Added grey color to the colorful status indicator for “Pending” status of a job
  ![image](https://user-images.githubusercontent.com/13918850/111179322-a09a3400-85b4-11eb-8731-61a66655eb69.png)

Jira ticket 233