### PR TITLE
[Feature vectors] Overview: Last Updated is N/A

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -303,7 +303,7 @@ export const generateFeatureVectorsOverviewContent = selectedItem => ({
     value: selectedItem.tag
   },
   updated: {
-    value: formatDatetime(selectedItem.updated, 'N/A')
+    value: formatDatetime(new Date(selectedItem.updated), 'N/A')
   },
   timestamp_key: {
     value: selectedItem.timestamp_field ?? ''


### PR DESCRIPTION
https://trello.com/c/3cmuYYSL/728-feature-vectors-overview-last-updated-is-n-a

- **Feature vectors**: “Last updated” field in “Overview” tab shows “N/A” although a valid value was provided in response from backend
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/111186974-38e7e700-85bc-11eb-9004-8328c8115c63.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/111186954-32f20600-85bc-11eb-9829-8a8be4ecc653.png)

Jira ticket ML-250