### PR TITLE
[Feature sets] Transformations: too much zoom on init

### DIFF
--- a/src/common/LoadButton/LoadButton.js
+++ b/src/common/LoadButton/LoadButton.js
@@ -19,13 +19,13 @@ const LoadButton = ({ className, label, variant, ...restProps }) => {
 }
 
 LoadButton.defaultProps = {
-  classList: '',
+  className: '',
   label: 'Load button',
   variant: 'tertiary'
 }
 
 LoadButton.propTypes = {
-  classList: PropTypes.string,
+  className: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   variant: PropTypes.PropTypes.oneOf(['primary', 'secondary', 'tertiary'])
     .isRequired

--- a/src/components/DetailsTransformations/DetailsTransformations.js
+++ b/src/components/DetailsTransformations/DetailsTransformations.js
@@ -154,6 +154,9 @@ const DetailsTransformations = ({ selectedItem }) => {
     setTimeout(() => {
       if (reactFlowInstance) {
         reactFlowInstance.fitView()
+        const { position, zoom } = reactFlowInstance.toObject()
+
+        reactFlowInstance.setTransform({ x: position[0], y: 50, zoom: zoom })
       }
     }, 100)
   }, [reactFlowInstance])


### PR DESCRIPTION
https://trello.com/c/T9Loi4HZ/729-feature-sets-transformations-too-much-zoom-on-init

- **Feature sets**: In “Transformations” tab, improved zoom/pan on the chart when entering the tab
Before:
![transformations-before](https://user-images.githubusercontent.com/13918850/111502087-31f0de00-874e-11eb-9cd5-101a7da30b9d.png)
After:
![transformations-after](https://user-images.githubusercontent.com/13918850/111502101-34ebce80-874e-11eb-9bce-14ab6b218ed2.png)

Jira ticket ML-250