### PR TITLE
[General] Missing "Close" tooltip on close icon button

### DIFF
--- a/src/common/Chip/Chip.js
+++ b/src/common/Chip/Chip.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import ChipForm from '../../components/ChipForm/ChipForm'
-import Tooltip from '../Tooltip/Tooltip'
-import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
 
 import { ReactComponent as Close } from '../../images/close.svg'
 
@@ -71,9 +69,7 @@ const Chip = ({
             className="item-icon-close"
             onClick={() => handleRemoveChip(chipIndex)}
           >
-            <Tooltip template={<TextTooltipTemplate text="Close" />}>
-              <Close />
-            </Tooltip>
+            <Close />
           </button>
         )}
       </span>

--- a/src/common/Chip/Chip.js
+++ b/src/common/Chip/Chip.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import ChipForm from '../../components/ChipForm/ChipForm'
+import Tooltip from '../Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
 
 import { ReactComponent as Close } from '../../images/close.svg'
 
@@ -69,7 +71,9 @@ const Chip = ({
             className="item-icon-close"
             onClick={() => handleRemoveChip(chipIndex)}
           >
-            <Close />
+            <Tooltip template={<TextTooltipTemplate text="Close" />}>
+              <Close />
+            </Tooltip>
           </button>
         )}
       </span>

--- a/src/common/ErrorMessage/ErrorMessage.js
+++ b/src/common/ErrorMessage/ErrorMessage.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Tooltip from '../Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+
 import { ReactComponent as UnsuccessAlert } from '../../images/unsuccess_alert.svg'
 import { ReactComponent as Close } from '../../images/close.svg'
 
@@ -13,7 +16,9 @@ const ErrorMessage = ({ closeError, message }) => {
       {message}
       {closeError && (
         <button data-testid="close" onClick={closeError}>
-          <Close />
+          <Tooltip template={<TextTooltipTemplate text="Close" />}>
+            <Close />
+          </Tooltip>
         </button>
       )}
     </div>

--- a/src/common/PopUpDialog/PopUpDialog.js
+++ b/src/common/PopUpDialog/PopUpDialog.js
@@ -2,6 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
+import Tooltip from '../Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+
 import { ReactComponent as Close } from '../../images/close.svg'
 
 import './popUpDialog.scss'
@@ -26,7 +29,9 @@ const PopUpDialog = ({ children, className, closePopUp, headerText }) => {
             </div>
           )}
           <div className="pop-up-dialog__header-close">
-            <Close data-testid="pop-up-close-btn" onClick={closePopUp} />
+            <Tooltip template={<TextTooltipTemplate text="Close" />}>
+              <Close data-testid="pop-up-close-btn" onClick={closePopUp} />
+            </Tooltip>
           </div>
         </div>
         {children}

--- a/src/common/YamlModal/YamlModal.js
+++ b/src/common/YamlModal/YamlModal.js
@@ -3,6 +3,9 @@ import Prism from 'prismjs'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
+import Tooltip from '../Tooltip/Tooltip'
+import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
+
 import { ReactComponent as Close } from '../../images/close.svg'
 
 import './yamlmodal.scss'
@@ -21,7 +24,9 @@ const YamlModal = ({ convertedYaml, toggleConvertToYaml }) => {
       <pre>
         <code dangerouslySetInnerHTML={{ __html: html }} />
         <button onClick={toggleConvertToYaml}>
-          <Close />
+          <Tooltip template={<TextTooltipTemplate text="Close" />}>
+            <Close />
+          </Tooltip>
         </button>
       </pre>
     </div>

--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -148,7 +148,9 @@ const DetailsView = React.forwardRef(
               }
             }}
           >
-            <Close />
+            <Tooltip template={<TextTooltipTemplate text="Close" />}>
+              <Close />
+            </Tooltip>
           </Link>
         </div>
         <ul className="item-menu">

--- a/src/elements/JobsPanelTitle/JobsPanelTitleView.js
+++ b/src/elements/JobsPanelTitle/JobsPanelTitleView.js
@@ -8,6 +8,8 @@ import Select from '../../common/Select/Select'
 import Input from '../../common/Input/Input'
 import ChipCell from '../../common/ChipCell/ChipCell'
 import Button from '../../common/Button/Button'
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
 
 import { ReactComponent as BackArrow } from '../../images/back-arrow.svg'
 import { ReactComponent as Close } from '../../images/close.svg'
@@ -173,7 +175,9 @@ const JobsPanelTitleView = ({
         </div>
       )}
       <button onClick={() => closePanel({})} className="job-panel__btn_close">
-        <Close />
+        <Tooltip template={<TextTooltipTemplate text="Close" />}>
+          <Close />
+        </Tooltip>
       </button>
     </div>
   )

--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -4,6 +4,9 @@ import prettyBytes from 'pretty-bytes'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
 
+import Tooltip from '../../common/Tooltip/Tooltip'
+import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
+
 import ArtifactsPreview from '../../components/ArtifactsPreview/ArtifactsPreview'
 import Download from '../../common/Download/Download'
 
@@ -70,7 +73,9 @@ const PreviewModal = ({ item }) => {
               )
             }}
           >
-            <Close />
+            <Tooltip template={<TextTooltipTemplate text="Close" />}>
+              <Close />
+            </Tooltip>
           </div>
         </div>
         <div className="item-artifacts__preview">


### PR DESCRIPTION
https://trello.com/c/g7KhWKuZ/710-general-missing-close-tooltip-on-close-icon-button

- **General**: Added missing “Close” tooltip on all close icon buttons in several places
  ![image](https://user-images.githubusercontent.com/13918850/111506311-2d2e2900-8752-11eb-9c6e-d6ff583a2e97.png)
  ![image](https://user-images.githubusercontent.com/13918850/111506334-315a4680-8752-11eb-81a7-ea42548e1695.png)
  ![image](https://user-images.githubusercontent.com/13918850/111506344-34553700-8752-11eb-87b9-f3d5d66fb9d3.png)
  ![image](https://user-images.githubusercontent.com/13918850/111506358-36b79100-8752-11eb-89df-e8b5f42d47d5.png)
  ![image](https://user-images.githubusercontent.com/13918850/111506370-39b28180-8752-11eb-82e1-3e6a7aad39ea.png)
  ![image](https://user-images.githubusercontent.com/13918850/111506383-3cad7200-8752-11eb-8cde-8215396af40b.png)