### PR TITLE
Fix [Jobs] Artifacts: crashes if job has no owner/v3io_user label

### DIFF
--- a/src/components/DetailsArtifacts/detailsArtifacts.util.js
+++ b/src/components/DetailsArtifacts/detailsArtifacts.util.js
@@ -56,7 +56,7 @@ export const generateContent = selectedJob => {
       target_path: target_path,
       user: selectedJob?.labels
         ?.find(item => item.match(/v3io_user|owner/g))
-        .replace(/(v3io_user|owner): /, '')
+        ?.replace(/(v3io_user|owner): /, '')
     }
 
     if (artifact.schema) {


### PR DESCRIPTION
- **Jobs**: “Artifacts” tab crashes when the job has neither `owner` nor `v3io_user` labels.

Jira ticket ML-293