### PR TITLE
Fix [Config] Don't fail initialization when function catalog not resolvable 

### DIFF
--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -10,8 +10,9 @@ server {
   include resolvers.conf;
 
   # https://raw.githubusercontent.com/mlrun/functions/master
+  set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
-    proxy_pass ${MLRUN_FUNCTION_CATALOG_URL};
+    proxy_pass $function_catalog;
   }
 
   location /mlrun {


### PR DESCRIPTION
Using what I did [here](https://github.com/mlrun/ui/pull/377) to make the function catalog proxy pass resolve on (every) request instead of on initialization, that way unresolvable address won't fail initialization.
It will hurt performance since we're going to resolve on every request instead of once, but that's a price we're willing to pay
Fixes https://jira.iguazeng.com/browse/ML-305