### PR TITLE
[General] View YAML dialog not closing on switching tabs

### DIFF
--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -118,6 +118,7 @@ const Content = ({
       setGroupedByName({})
       setGroupedByWorkflow({})
       setExpand(false)
+      setConvertedYaml('')
     }
   }, [groupFilter, handleGroupByName, handleGroupByWorkflow, handleGroupByNone])
 


### PR DESCRIPTION
https://trello.com/c/5AtBi6Vd/743-general-view-yaml-dialog-not-closing-on-switching-tabs

- **Jobs, Models, Feature stores**: On multi-tab screens, the “View YAML” pop-up did not close when switching to another tab in the same screen.

Jira ticket ML-318