### PR TITLE
[Feature vectors] View YAML always shows YAML of first vector

### DIFF
--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -17,6 +17,7 @@ import {
   DATASETS_TAB,
   FEATURE_SETS_TAB,
   FEATURE_STORE_PAGE,
+  FEATURE_VECTORS_TAB,
   FEATURES_TAB,
   FILES_PAGE,
   FUNCTIONS_PAGE,
@@ -174,7 +175,8 @@ const Content = ({
         )
       } else {
         artifactJson = yamlContent.allData.filter(yamlContentItem =>
-          match.params.pageTab === FEATURE_SETS_TAB
+          match.params.pageTab === FEATURE_SETS_TAB ||
+          match.params.pageTab === FEATURE_VECTORS_TAB
             ? isEqual(yamlContentItem.metadata.name, item.name) &&
               isEqual(yamlContentItem.metadata.tag, item.tag)
             : isEqual(yamlContentItem.db_key, item.db_key)


### PR DESCRIPTION
https://trello.com/c/m58naMSq/745-feature-vectors-view-yaml-always-shows-yaml-of-first-vector

- **Feature vectors**: Selecting the “View YAML” action for _any_ item on the list always showed the YAML of the *first* item.

Jira ticket ML-317