### PR TITLE
[General] Chip with count has redundant tooltip

### DIFF
--- a/src/common/ChipCell/ChipCellView.js
+++ b/src/common/ChipCell/ChipCellView.js
@@ -37,27 +37,24 @@ const ChipCellView = React.forwardRef(
             <div className={'chip-block'} key={`${chip.value}${index}`}>
               <Tooltip
                 className="tooltip-wrapper"
+                hidden={editConfig.isEdit || /^\+ [\d]+/g.test(chip.value)}
                 key={chip.value}
                 template={
-                  editConfig.isEdit ? (
-                    <span />
-                  ) : (
-                    <TextTooltipTemplate
-                      text={
-                        chip.delimiter && !chip.value.match(/^\+ [\d]+/g) ? (
-                          <span>
-                            {chipLabel}
-                            <span className="chip__delimiter">
-                              {chip.delimiter}
-                            </span>
-                            {chipValue}
+                  <TextTooltipTemplate
+                    text={
+                      chip.delimiter ? (
+                        <span>
+                          {chipLabel}
+                          <span className="chip__delimiter">
+                            {chip.delimiter}
                           </span>
-                        ) : (
-                          chip.value
-                        )
-                      }
-                    />
-                  )
+                          {chipValue}
+                        </span>
+                      ) : (
+                        chip.value
+                      )
+                    }
+                  />
                 }
               >
                 <Chip


### PR DESCRIPTION
https://trello.com/c/LL2C8OO4/731-general-chip-with-count-has-redundant-tooltip

- **General**: In chip-list component, remove the useless tooltip on hovering the chip that shows the count of hidden chips when the list overflows its container
  ![image](https://user-images.githubusercontent.com/13918850/112344325-a5ee3180-8ccc-11eb-9423-39548ec421d2.png)