### PR TITLE
Fix [Jobs] Artifacts: show details link is broken

### DIFF
--- a/src/components/Artifacts/Artifacts.js
+++ b/src/components/Artifacts/Artifacts.js
@@ -65,14 +65,14 @@ const Artifacts = ({
     if (match.params.name && artifactsStore.artifacts.length !== 0) {
       const { name } = match.params
 
-      const [searchItem] = artifactsStore.artifacts.filter(
+      const searchItem = artifactsStore.artifacts.find(
         item => item.key === name
       )
 
       if (!searchItem) {
         history.push(`/projects/${match.params.projectName}/artifacts`)
       } else {
-        const [artifact] = searchItem.data.filter(item => {
+        const artifact = searchItem.data.find(item => {
           if (searchItem.link_iteration) {
             const { link_iteration } = searchItem.link_iteration
             return link_iteration === item.iter

--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -71,8 +71,10 @@ const DetailsView = React.forwardRef(
                 )
               : selectedItem?.updated
               ? formatDatetime(new Date(selectedItem?.updated), 'N/A')
-              : selectedItem?.spec?.model // 'model-key:model-tag'
+              : selectedItem?.spec?.model.includes(':') // 'model-key:model-tag'
               ? selectedItem.spec.model.replace(/^.*:/, '') // remove key
+              : selectedItem?.spec?.model
+              ? selectedItem?.metadata?.uid
               : ''}
             {state && (
               <Tooltip

--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -59,6 +59,9 @@ export const generateArtifactsContent = (
     return generateFeatureVectorsOverviewContent(selectedItem)
   } else if (pageTab === MODEL_ENDPOINTS_TAB) {
     return {
+      uid: {
+        value: selectedItem?.metadata?.uid ?? '-'
+      },
       model_class: {
         value: selectedItem?.spec?.model_class ?? '-'
       },

--- a/src/components/DetailsArtifacts/DetailsArtifactsView.js
+++ b/src/components/DetailsArtifacts/DetailsArtifactsView.js
@@ -71,7 +71,8 @@ const DetailsArtifactsView = ({
                     artifactScreenLinks[artifact.kind] ??
                     `/projects/${
                       match.params.projectName
-                    }/files/${artifact.db_key || artifact.key}/overview`
+                    }/files/${artifact.db_key || artifact.key}/${artifact.tag ||
+                      artifact.tree}/overview`
                   }
                 >
                   <DetailsIcon />

--- a/src/components/DetailsArtifacts/detailsArtifacts.util.js
+++ b/src/components/DetailsArtifacts/detailsArtifacts.util.js
@@ -54,6 +54,7 @@ export const generateContent = selectedJob => {
       preview: generatedPreviewData.preview,
       size: artifact.size ? prettyBytes(artifact.size) : 'N/A',
       target_path: target_path,
+      tree: artifact.tree,
       user: selectedJob?.labels
         ?.find(item => item.match(/v3io_user|owner/g))
         ?.replace(/(v3io_user|owner): /, '')

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -373,15 +373,19 @@ export const navigateToDetailsPane = (
   }
 
   if (match.params.name && artifacts.length !== 0) {
-    const [selectedArtifact] = artifacts.filter(artifact => {
+    const selectedArtifact = artifacts.find(artifact => {
       const searchKey = artifact.name ? 'name' : 'db_key'
 
       if (
         match.params.pageTab === FEATURE_SETS_TAB ||
-        match.params.pageTab === FEATURE_VECTORS_TAB ||
-        match.params.pageTab === DATASETS_TAB
+        match.params.pageTab === FEATURE_VECTORS_TAB
       ) {
         return artifact[searchKey] === name && artifact.tag === tag
+      } else if (match.params.pageTab === DATASETS_TAB) {
+        return (
+          artifact[searchKey] === name &&
+          (artifact.tag === tag || artifact.tree === tag)
+        )
       } else {
         return artifact[searchKey] === name
       }

--- a/src/components/Files/Files.js
+++ b/src/components/Files/Files.js
@@ -186,8 +186,9 @@ const Files = ({
         artifactsStore.files.allData
 
       if (artifacts.length !== 0) {
-        const [searchItem] = artifacts.filter(
-          item => item.db_key === name && item.tag === tag
+        const searchItem = artifacts.find(
+          item =>
+            item.db_key === name && (item.tag === tag || item.tree === tag)
         )
 
         if (!searchItem) {

--- a/src/components/Models/Models.js
+++ b/src/components/Models/Models.js
@@ -156,7 +156,13 @@ const Models = ({
         selectedRowData: []
       })
     }
-  }, [fetchData, getModelsEndpoints, match.params.projectName, removeModels])
+  }, [
+    fetchData,
+    getModelsEndpoints,
+    match.params.pageTab,
+    match.params.projectName,
+    removeModels
+  ])
 
   useEffect(() => {
     setPageData(state => ({
@@ -170,7 +176,9 @@ const Models = ({
   }, [handleRemoveModel, handleRequestOnExpand, match.params.pageTab])
 
   useEffect(() => {
-    if (artifactsStore.filter.tag === 'latest') {
+    if (match.params.pageTab === MODEL_ENDPOINTS_TAB) {
+      setGroupFilter('')
+    } else if (artifactsStore.filter.tag === 'latest') {
       setGroupFilter('name')
     } else if (groupFilter.length > 0) {
       setGroupFilter('')
@@ -180,8 +188,10 @@ const Models = ({
   useEffect(() => {
     if (
       match.params.name &&
-      (artifactsStore.models.allData.length > 0 ||
-        artifactsStore.modelEndpoints.length > 0)
+      ((match.params.pageTab === MODELS_TAB &&
+        artifactsStore.models.allData.length > 0) ||
+        (match.params.pageTab === MODEL_ENDPOINTS_TAB &&
+          artifactsStore.modelEndpoints.length > 0))
     ) {
       const { name, tag } = match.params
 
@@ -199,7 +209,7 @@ const Models = ({
           history,
           match,
           artifactsStore.modelEndpoints,
-          name,
+          tag,
           setSelectedModel
         )
       }

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -31,6 +31,7 @@ export const modelsInfoHeaders = [
   { label: 'Sources', id: 'sources' }
 ]
 export const modelEndpointsInfoHeaders = [
+  { label: 'UID', id: 'uid' },
   { label: 'Model class', id: 'model_class' },
   { label: 'Model artifact', id: 'model_artifact' },
   { label: 'Function URI', id: 'function_uri' },
@@ -219,8 +220,8 @@ export const checkForSelectedModel = (
   tag
 ) => {
   const artifacts = models.selectedRowData.content[modelName] || models.allData
-  const [searchItem] = artifacts.filter(
-    item => item.db_key === modelName && item.tag === tag
+  const searchItem = artifacts.find(
+    item => item.db_key === modelName && (item.tag === tag || item.tree === tag)
   )
 
   if (!searchItem) {
@@ -237,11 +238,11 @@ export const checkForSelectedModelEndpoint = (
   history,
   match,
   modelEndpoints,
-  modelEndpointId,
+  modelEndpointUid,
   setSelectedModel
 ) => {
-  const [searchItem] = modelEndpoints.filter(item =>
-    item.spec?.model?.includes(modelEndpointId)
+  const searchItem = modelEndpoints.find(
+    item => item.metadata?.uid === modelEndpointUid
   )
   if (!searchItem) {
     history.push(

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -148,6 +148,17 @@ const Content = ({
     let artifactJson = null
 
     if (
+      pageData.page === MODELS_PAGE &&
+      match.params.pageTab === MODEL_ENDPOINTS_TAB
+    ) {
+      const currentYamlContent =
+        yamlContent.selectedRowData.length > 0 ? 'selectedRowData' : 'allData'
+
+      artifactJson =
+        yamlContent[currentYamlContent].find(
+          yamlContentItem => yamlContentItem.metadata.uid === item.metadata.uid
+        ) ?? {}
+    } else if (
       pageData.page === FILES_PAGE ||
       pageData.page === MODELS_PAGE ||
       (pageData.page === FEATURE_STORE_PAGE &&

--- a/src/layout/Content/content.util.js
+++ b/src/layout/Content/content.util.js
@@ -16,7 +16,7 @@ export const generateGroupedItems = (content, selectedRowData) => {
     } else if (selectedRowData?.[contentItem.db_key]?.content) {
       groupedItems[contentItem.db_key] =
         selectedRowData[contentItem.db_key]?.content
-    } else if (contentItem.metadata) {
+    } else if (contentItem.metadata?.name) {
       groupedItems[`${contentItem.name}-${contentItem.metadata.name}`] ??= []
       groupedItems[`${contentItem.name}-${contentItem.metadata.name}`].push(
         contentItem

--- a/src/utils/parseUri.js
+++ b/src/utils/parseUri.js
@@ -53,4 +53,22 @@ const parseUri = (uri = '') =>
     /^store:\/\/(?<kind>.+?)\/(?<project>.+?)\/(?<key>.+?)(#(?<iteration>.+?))?(:(?<tag>.+?))?(@(?<uid>.+))?$/
   )?.groups ?? {}
 
-export { parseUri }
+const kindToScreen = {
+  artifacts: 'files',
+  datasets: 'feature-store/datasets',
+  'feature-sets': 'feature-store/feature-sets',
+  'feature-vectors': 'feature-store/feature-vectors',
+  functions: 'functions',
+  jobs: 'jobs/monitor',
+  models: 'models/models'
+}
+const generateLinkPath = (uri = '') => {
+  const { kind, project, key, tag, uid } = parseUri(uri)
+  const screen = kindToScreen[kind] ?? 'files'
+  const reference = tag ?? uid
+  return `/projects/${project}/${screen}/${key}${
+    reference ? `/${reference}` : ''
+  }`
+}
+
+export { generateLinkPath, parseUri }


### PR DESCRIPTION
- **Jobs**: In “Artifacts” tab in the details panel of a job, the link of “Show details” icon button was broken and hence the “Projects” screen was open instead of the specific artifact
- **Model endpoints**: Some items were hidden on main list. Now they are all properly listed
- **Model endpoints**: View YAML pop-up dialog always showed the YAML of the _first_ item only
- **Model endpoints**: “Name” cell was empty although name exists
- **Model endpoints**: Added “UID” field to “Overview” tab

Jira ticket 348