### PR TITLE
Fix [Config] Preserve catalog configured URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ EXPOSE 80
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
     MLRUN_BETA_MODE="${MLRUN_BETA_MODE:-enabled}" \
     MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com}" \
-    MLRUN_FUNCTION_CATALOG_URI="${MLRUN_FUNCTION_CATALOG_URI:-/mlrun/functions/master}" \
+    MLRUN_FUNCTION_CATALOG_PATH="${MLRUN_FUNCTION_CATALOG_PATH:-/mlrun/functions/master}" \
     MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://localhost:8070}" \
     MLRUN_NUCLIO_MODE="${MLRUN_NUCLIO_MODE:-disabled}" \
     MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-http://localhost:8070}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ EXPOSE 80
 
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
     MLRUN_BETA_MODE="${MLRUN_BETA_MODE:-enabled}" \
-    MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com/mlrun/functions/master}" \
+    MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com}" \
     MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://localhost:8070}" \
     MLRUN_NUCLIO_MODE="${MLRUN_NUCLIO_MODE:-disabled}" \
     MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-http://localhost:8070}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ EXPOSE 80
 ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
     MLRUN_BETA_MODE="${MLRUN_BETA_MODE:-enabled}" \
     MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com}" \
+    MLRUN_FUNCTION_CATALOG_URI="${MLRUN_FUNCTION_CATALOG_URI:-/mlrun/functions/master}" \
     MLRUN_NUCLIO_API_URL="${MLRUN_NUCLIO_API_URL:-http://localhost:8070}" \
     MLRUN_NUCLIO_MODE="${MLRUN_NUCLIO_MODE:-disabled}" \
     MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-http://localhost:8070}" \

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ You can pass the following environment variables to the `docker run` command to 
 | `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_V3IO_ACCESS_KEY` | Sets the V3IO access key to use for accessing V3IO containers<br />Example: `a7097c94-6e8f-436d-9717-a84abe2861d1` |
-| `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com/mlrun/functions/master` |
+| `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com` |
+| `MLRUN_FUNCTION_CATALOG_URI` | Sets the base URI of the function-template catalog <br />Default: `/mlrun/functions/master` |
 
 Example:
 
-`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
+`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com -e MLRUN_FUNCTION_CATALOG_URI=/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
 
 ### Docker container contents
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ You can pass the following environment variables to the `docker run` command to 
 | `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_V3IO_ACCESS_KEY` | Sets the V3IO access key to use for accessing V3IO containers<br />Example: `a7097c94-6e8f-436d-9717-a84abe2861d1` |
 | `MLRUN_FUNCTION_CATALOG_URL` | Sets the base URL of the function-template catalog <br />Default: `https://raw.githubusercontent.com` |
-| `MLRUN_FUNCTION_CATALOG_URI` | Sets the base URI of the function-template catalog <br />Default: `/mlrun/functions/master` |
+| `MLRUN_FUNCTION_CATALOG_PATH` | Sets the base URI of the function-template catalog <br />Default: `/mlrun/functions/master` |
 
 Example:
 
-`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com -e MLRUN_FUNCTION_CATALOG_URI=/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
+`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com -e MLRUN_FUNCTION_CATALOG_PATH=/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
 
 ### Docker container contents
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -12,7 +12,7 @@ server {
   # https://raw.githubusercontent.com
   set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
-    rewrite /function-catalog/(.*) ${MLRUN_FUNCTION_CATALOG_URI}/$1 break;
+    rewrite /function-catalog/(.*) ${MLRUN_FUNCTION_CATALOG_PATH}/$1 break;
     proxy_pass $function_catalog;
   }
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -9,7 +9,7 @@ server {
 
   include resolvers.conf;
 
-  # https://raw.githubusercontent.com/mlrun/functions/master
+  # https://raw.githubusercontent.com
   set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
     rewrite /function-catalog/(.*) ${MLRUN_FUNCTION_CATALOG_URI}/$1 break;

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -12,7 +12,8 @@ server {
   # https://raw.githubusercontent.com/mlrun/functions/master
   set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
-    proxy_pass $function_catalog/mlrun/functions/master;
+    rewrite /function-catalog/(.*) /${MLRUN_FUNCTION_CATALOG_URI}/$1  break;
+    proxy_pass $function_catalog;
   }
 
   location /mlrun {

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -12,7 +12,7 @@ server {
   # https://raw.githubusercontent.com/mlrun/functions/master
   set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
-    proxy_pass $function_catalog;
+    proxy_pass $function_catalog/mlrun/functions/master;
   }
 
   location /mlrun {

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -12,7 +12,7 @@ server {
   # https://raw.githubusercontent.com/mlrun/functions/master
   set $function_catalog ${MLRUN_FUNCTION_CATALOG_URL};
   location /function-catalog {
-    rewrite /function-catalog/(.*) /${MLRUN_FUNCTION_CATALOG_URI}/$1  break;
+    rewrite /function-catalog/(.*) ${MLRUN_FUNCTION_CATALOG_URI}/$1 break;
     proxy_pass $function_catalog;
   }
 

--- a/nginx/run_nginx
+++ b/nginx/run_nginx
@@ -4,6 +4,7 @@
 envsubst '${MLRUN_API_PROXY_URL} \
           ${MLRUN_BETA_MODE} \
           ${MLRUN_FUNCTION_CATALOG_URL} \
+          ${MLRUN_FUNCTION_CATALOG_URI} \
           ${MLRUN_NUCLIO_API_URL} \
           ${MLRUN_NUCLIO_MODE} \
           ${MLRUN_NUCLIO_UI_URL} \

--- a/nginx/run_nginx
+++ b/nginx/run_nginx
@@ -4,7 +4,7 @@
 envsubst '${MLRUN_API_PROXY_URL} \
           ${MLRUN_BETA_MODE} \
           ${MLRUN_FUNCTION_CATALOG_URL} \
-          ${MLRUN_FUNCTION_CATALOG_URI} \
+          ${MLRUN_FUNCTION_CATALOG_PATH} \
           ${MLRUN_NUCLIO_API_URL} \
           ${MLRUN_NUCLIO_MODE} \
           ${MLRUN_NUCLIO_UI_URL} \


### PR DESCRIPTION
Apparently although doing something like
```
  location /function-catalog {
    proxy_pass https://raw.githubusercontent.com/mlrun/functions/master;
  }
```
works as expected, i.e. request to `https://ui.com/function-catalog/catalog.json` will be proxied to `https://raw.githubusercontent.com/mlrun/functions/master/catalog.json`
When using a variable to force nginx to do DNS resolving per request (done [here](https://github.com/mlrun/ui/pull/463)), it doesn't work and will proxy the request to `https://raw.githubusercontent.com/catalog.json`
Googling `nginx proxy pass variable with path` gave a lot of results, after some playing I succeeded to make it working using the `rewrite` directive

Fixes https://jira.iguazeng.com/browse/ML-347