### PR TITLE
[Features] Should not have "Copy URI" action

### DIFF
--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -241,6 +241,7 @@ export const generatePageData = (
     data.tableHeaders = featureSetsTableHeaders
     data.registerArtifactDialogTitle = createFeatureSetTitle
   } else if (pageTab === FEATURES_TAB) {
+    data.actionsMenu = []
     data.filters = featuresFilters
     data.tableHeaders = featuresTableHeaders
     data.filterMenuActionButton = {


### PR DESCRIPTION
https://trello.com/c/Mppv2cnh/749-features-should-not-have-copy-uri-action

- **Features store**: In “Features” tab, the “Copy URI” appears for features after visiting in one of the other feature-store tabs — and this action is redundant for the “Features” tab (features do not have URIs, and firing this action on them resulted in an invalid URI, such as `store://feature-sets/undefined/name`)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/113012199-39b77600-9183-11eb-9312-d2d429af54ad.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/113012219-3d4afd00-9183-11eb-9423-d034ca6f6d16.png)

Jira ticket ML-356