### PR TITLE
Fix [Models][Datasets][Files] Overview: crashes on malformed URI

### DIFF
--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -173,8 +173,10 @@ const DetailsInfoView = React.forwardRef(
                     if (key === 'uri') {
                       // value is in the form of: project/uid-iteration
                       const [project, rest] = value.split('/')
-                      const [uid] = rest.split('-')
-                      url = `/projects/${project}/jobs/monitor/${uid}/overview`
+                      const [uid] = rest?.split('-') ?? []
+                      if (uid) {
+                        url = `/projects/${project}/jobs/monitor/${uid}/overview`
+                      }
                     }
 
                     return (


### PR DESCRIPTION
- **Models, Datasets, Files**: In “Overview” tab, an error occurs when the producer URI is malformed (not in the form of `{project}/{uid}[-{iteration}]`)

Bug originated in PR https://github.com/mlrun/ui/pull/418