### PR TITLE
Fix [Jobs] Schedule: wrong button labeled "Button" appears

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -135,7 +135,7 @@ export const generatePageData = (
       { type: 'name', label: 'Name:' },
       { type: 'labels', label: 'Labels:' }
     ]
-    filterMenuActionButton = {}
+    filterMenuActionButton = null
   } else {
     jobFilters = [...filters]
   }


### PR DESCRIPTION
- **Jobs**: In “Schedule” tab, a button labeled “Button” was displayed
  ![image](https://user-images.githubusercontent.com/13918850/112886143-34522100-90da-11eb-82e1-8a701417526e.png)

Bug originates in PR https://github.com/mlrun/ui/pull/476