### PR TITLE
Impl [StoryBook] Allow import of SVG files in stories

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,16 @@
+module.exports = ({ config }) => {
+  // Add SVGR Loader
+  const assetRule = config.module.rules.find(({ test }) => test.test('.svg'))
+
+  const assetLoader = {
+    loader: assetRule.loader,
+    options: assetRule.options || assetRule.query,
+  }
+
+  config.module.rules.unshift({
+    test: /\.svg$/,
+    use: ['@svgr/webpack', assetLoader],
+  })
+
+  return config
+}


### PR DESCRIPTION
Allows to import SVG files in `.stories.js` filesof StoryBook, like: `import { ReactComponent as Caret } from '../images/dropdown.svg'`