### PR TITLE
[Create Job] Dropdown options overlap

### DIFF
--- a/src/components/CreateJobPage/createJobPage.scss
+++ b/src/components/CreateJobPage/createJobPage.scss
@@ -179,7 +179,7 @@
 
           .select {
             &__body {
-              min-width: 135px;
+              min-width: 170px;
             }
 
             &__caret {

--- a/src/elements/SelectOption/SelectOption.js
+++ b/src/elements/SelectOption/SelectOption.js
@@ -36,7 +36,11 @@ const SelectOption = ({ disabled, item, onClick, selectType, selectedId }) => {
         </span>
       )}
       {item.status && <span className={`status ${item.status}`} />}
-      {item.label}
+      <div className="data-ellipsis">
+        <Tooltip template={<TextTooltipTemplate text={item.label} />}>
+          {item.label}
+        </Tooltip>
+      </div>
       {item.subLabel && (
         <Tooltip
           className="sub-label"


### PR DESCRIPTION
https://trello.com/c/bDsVXOD3/754-create-job-dropdown-options-overlap

- **Create Job**: The dropdown menu of the project filter broke on long project names — now the dropdown menu is wider and long project names get clipped with an ellipsis (…) and have the full name shown in a tooltip on hover
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/113331445-aa4bc780-9328-11eb-93f0-951c85d4748d.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/113331457-acae2180-9328-11eb-9148-a01013e1c164.png)

Jira ticket ML-365