### PR TITLE
[Project] Avoid having ellipsis on counter label

### DIFF
--- a/src/components/Project/project.scss
+++ b/src/components/Project/project.scss
@@ -261,6 +261,10 @@
             font-size: 20px;
             line-height: 23px;
           }
+
+          &.table-header {
+            min-height: 180px;
+          }
         }
 
         &_small {

--- a/src/components/ProjectTable/projectTable.scss
+++ b/src/components/ProjectTable/projectTable.scss
@@ -9,7 +9,7 @@
 
   &_medium {
     flex: 0.7;
-    min-width: 100px;
+    min-width: 75px;
   }
 
   &_small {

--- a/src/elements/ProjectDataCard/ProjectDataCard.js
+++ b/src/elements/ProjectDataCard/ProjectDataCard.js
@@ -19,7 +19,7 @@ const ProjectDataCard = ({
 }) => {
   return (
     <div className="project-data-card">
-      <div className="project-data-card__header">
+      <div className="project-data-card__header table-header">
         <div className="project-data-card__header-text data-ellipsis">
           {href ? (
             <a href={href} target="_top">

--- a/src/elements/ProjectJobs/projectJobs.utils.js
+++ b/src/elements/ProjectJobs/projectJobs.utils.js
@@ -87,7 +87,7 @@ export const getJobsTableData = (jobs, match) => {
             new Date(job[0].status.start_time),
             new Date(job[0].status.last_update)
           ),
-          className: 'table-cell_small'
+          className: 'table-cell_medium'
         }
       }
     })
@@ -97,7 +97,7 @@ export const getJobsTableData = (jobs, match) => {
       { value: 'Type', className: 'table-cell_small' },
       { value: 'Status', className: 'table-cell_medium' },
       { value: 'Started at', className: 'table-cell_big' },
-      { value: 'Duration', className: 'table-cell_small' }
+      { value: 'Duration', className: 'table-cell_medium' }
     ]
 
     return {

--- a/src/elements/ProjectStatistics/projectStatistics.scss
+++ b/src/elements/ProjectStatistics/projectStatistics.scss
@@ -14,6 +14,7 @@
 
     &-link {
       width: 100%;
+      min-width: 85px;
       margin: 0 6px;
       padding: 5px;
       border-radius: 5px;

--- a/src/elements/ProjectStatisticsCounter/ProjectStatisticsCounter.js
+++ b/src/elements/ProjectStatisticsCounter/ProjectStatisticsCounter.js
@@ -53,12 +53,7 @@ const ProjectStatisticsCounter = ({ counterObject }) => {
         className="project-data-card__statistics-label"
         key={counterObject.label + Math.random()}
       >
-        <Tooltip
-          className={counterObject.labelClassName || ''}
-          template={<TextTooltipTemplate text={counterObject.label} />}
-        >
-          {counterObject.label}
-        </Tooltip>
+        {counterObject.label}
       </div>
     ]
   )


### PR DESCRIPTION
https://trello.com/c/bKy7pgml/755-project-avoid-having-ellipsis-on-counter-label

- **Project Overview**: In “Jobs and workflows” pane, in the counters part, the “Running workflows” counter label was always clipped with ellipsis (…) — now it is entirely visible, taking two lines (the tooltip was also removed since it is no longer needed)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/113327498-b7b28300-9323-11eb-8afc-0d12a27d9990.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/113327171-4c68b100-9323-11eb-8ae9-54ab28459dea.png)

Jira ticket ML-363