### PR TITLE
Fix [Jobs] Monitor: disabled "Monitoring" action still opens link

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -198,7 +198,7 @@ export const generateActionsMenu = (
             : job.labels?.includes('kind: dask')
             ? 'Unavailable for Dask jobs'
             : '',
-          disabled: !jobsDashboardUrl,
+          disabled: !jobsDashboardUrl || job.labels?.includes('kind: dask'),
           onClick: handleMonitoring
         }
       ]


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, for jobs of kind “Dask”, the “Monitoring” action in the action menu still worked and opened the link even though it was disabled

Jira ticket ML-350