### PR TITLE
Fix [Create Job][Functions] Fails on not-yet deployed functions

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -59,9 +59,9 @@ const Functions = ({
             hash: func.metadata.hash,
             codeOrigin: func.spec?.build?.code_origin ?? '',
             updated: new Date(func.metadata.updated),
-            command: func.spec.command,
-            image: func.spec.image,
-            description: func.spec.description,
+            command: func.spec?.command,
+            image: func.spec?.image,
+            description: func.spec?.description,
             state: func.status?.state ?? '',
             functionSourceCode: func.spec?.build?.functionSourceCode ?? ''
           }))

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -127,9 +127,7 @@ export const getVolume = selectedFunction => {
 
 export const getMethodOptions = selectedFunctions => {
   return _.chain(selectedFunctions)
-    .map(func =>
-      func.spec.entry_points ? Object.values(func.spec.entry_points) : []
-    )
+    .map(func => Object.values(func.spec?.entry_points ?? {}))
     .flatten()
     .map(entry_point => ({
       label: entry_point.name,


### PR DESCRIPTION
- **Create Job, Functions**: Fails on a not-yet deployed function (has no `spec` part in its JSON)

Jira ticket IG-17011