### PR TITLE
[Projects] Create new project: buttons distorted

### DIFF
--- a/src/components/ProjectsPage/CreateProjectDialog/CreateProjectDialog.js
+++ b/src/components/ProjectsPage/CreateProjectDialog/CreateProjectDialog.js
@@ -7,6 +7,8 @@ import ErrorMessage from '../../../common/ErrorMessage/ErrorMessage'
 import PopUpDialog from '../../../common/PopUpDialog/PopUpDialog'
 import Button from '../../../common/Button/Button'
 
+import './createProjectDialog.scss'
+
 const CreateProjectDialog = ({
   closeNewProjectPopUp,
   handleCreateProject,
@@ -20,6 +22,7 @@ const CreateProjectDialog = ({
   return (
     <PopUpDialog
       headerText="Create new project"
+      className="create-project-dialog"
       closePopUp={closeNewProjectPopUp}
     >
       <form noValidate>

--- a/src/components/ProjectsPage/CreateProjectDialog/createProjectDialog.scss
+++ b/src/components/ProjectsPage/CreateProjectDialog/createProjectDialog.scss
@@ -1,0 +1,11 @@
+.create-project-dialog {
+  .pop-up-dialog {
+    &__footer-container {
+      align-items: center;
+    }
+  }
+
+  .error-message {
+    max-width: 235px;
+  }
+}


### PR DESCRIPTION
https://trello.com/c/84hVF1gz/763-projects-create-new-project-buttons-distorted

- **Projects**: In “Create new project” pop-up, when an error message is shown, the buttons are distorted
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/113842091-05ebda00-979b-11eb-8dd7-006869850c4b.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/113842311-37fd3c00-979b-11eb-953d-757d9d846eea.png)

Jira ticket ML-378