### PR TITLE
[Feature store][Jobs] Retain selected tab on switching items

### DIFF
--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -14,10 +14,8 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
   const [noData, setNoData] = useState(false)
 
   useEffect(() => {
-    if (preview.length === 0) {
-      getArtifactPreview(artifact, noData, setNoData, setPreview)
-    }
-  }, [artifact, noData, preview.length])
+    getArtifactPreview(artifact, noData, setNoData, setPreview)
+  }, [artifact, noData])
 
   return (
     <div className="preview_container">

--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -7,8 +7,11 @@ import TableActionsMenu from '../../common/TableActionsMenu/TableActionsMenu'
 import Loader from '../../common/Loader/Loader'
 import ErrorMessage from '../../common/ErrorMessage/ErrorMessage'
 
-import artifactsData from '../../components/Artifacts/artifactsData'
-import { FEATURES_TAB, MODEL_ENDPOINTS_TAB } from '../../constants'
+import {
+  DETAILS_OVERVIEW_TAB,
+  FEATURES_TAB,
+  MODEL_ENDPOINTS_TAB
+} from '../../constants'
 
 const ArtifactsTableRow = ({
   actionsMenu,
@@ -90,7 +93,13 @@ const ArtifactsTableRow = ({
                   selectedItem={selectedItem}
                   expandLink={index === 0}
                   firstRow={index === 0}
-                  link={data.rowExpanded?.link ? data.link && data.link : false}
+                  link={
+                    data.rowExpanded?.getLink
+                      ? data.rowExpanded.getLink(
+                          match.params.tab ?? DETAILS_OVERVIEW_TAB
+                        )
+                      : ''
+                  }
                   selectedRowId={selectedRowId}
                   setSelectedRowId={setSelectedRowId}
                   withCheckbox={withCheckbox}
@@ -143,22 +152,9 @@ const ArtifactsTableRow = ({
                               : value
                           }
                           item={currentItem}
-                          link={
-                            value.link &&
-                            (value.link === 'overview'
-                              ? `/projects/${
-                                  match.params.projectName
-                                }/${pageData.page.toLowerCase()}${
-                                  match.params.pageTab
-                                    ? `/${match.params.pageTab}`
-                                    : ''
-                                }/${rowItem.key.value}/${
-                                  match.params.tab
-                                    ? match.params.tab
-                                    : `${artifactsData.detailsMenu[0]}`
-                                }`
-                              : value.link)
-                          }
+                          link={value.getLink?.(
+                            match.params.tab ?? DETAILS_OVERVIEW_TAB
+                          )}
                           match={match}
                           key={value.value + i ?? Date.now()}
                           selectItem={handleSelectItem}
@@ -189,19 +185,9 @@ const ArtifactsTableRow = ({
                   data={value}
                   item={content[index]}
                   key={Math.random() + i}
-                  link={
-                    value.link === 'overview'
-                      ? `/projects/${
-                          match.params.projectName
-                        }/${pageData.page.toLowerCase()}${
-                          match.params.pageTab ? `/${match.params.pageTab}` : ''
-                        }/${rowItem.key.value}/${
-                          match.params.tab
-                            ? match.params.tab
-                            : `${artifactsData.detailsMenu[0]}`
-                        }`
-                      : value.link
-                  }
+                  link={value.getLink?.(
+                    match.params.tab ?? DETAILS_OVERVIEW_TAB
+                  )}
                   match={match}
                   selectedItem={selectedItem}
                   selectItem={handleSelectItem}

--- a/src/elements/JobsTableRow/JobsTableRow.js
+++ b/src/elements/JobsTableRow/JobsTableRow.js
@@ -6,8 +6,7 @@ import classnames from 'classnames'
 import TableCell from '../TableCell/TableCell'
 import TableActionsMenu from '../../common/TableActionsMenu/TableActionsMenu'
 
-import { detailsMenu } from '../../components/JobsPage/jobsData'
-import { MONITOR_TAB } from '../../constants'
+import { DETAILS_OVERVIEW_TAB, MONITOR_TAB } from '../../constants'
 
 const JobsTableRow = ({
   actionsMenu,
@@ -112,16 +111,9 @@ const JobsTableRow = ({
                             : cellContentObj
                         }
                         item={groupCurrentItem}
-                        link={
-                          index === 0 &&
-                          `/projects/${match.params.projectName}/jobs/${
-                            match.params.pageTab
-                          }/${groupCurrentItem.uid}${
-                            match.params.tab
-                              ? `/${match.params.tab}`
-                              : `/${detailsMenu[0]}`
-                          }`
-                        }
+                        link={cellContentObj.getLink?.(
+                          match.params.tab ?? DETAILS_OVERVIEW_TAB
+                        )}
                         key={`${cellContentObj.value}${index}`}
                         selectItem={handleSelectItem}
                         selectedItem={selectedItem}
@@ -150,7 +142,13 @@ const JobsTableRow = ({
                 isGroupedByWorkflow={isGroupedByWorkflow}
                 item={currentItem}
                 key={`${new Date().getTime()}${index}`}
-                link={rowItemProp.link}
+                link={
+                  rowItemProp.getLink
+                    ? rowItemProp.getLink?.(
+                        match.params.tab ?? DETAILS_OVERVIEW_TAB
+                      )
+                    : ''
+                }
                 selectItem={handleSelectItem}
                 selectedItem={selectedItem}
               />

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -4,6 +4,7 @@ import { ReactComponent as SeverityOk } from '../images/severity-ok.svg'
 import { ReactComponent as SeverityWarning } from '../images/severity-warning.svg'
 import { ReactComponent as SeverityError } from '../images/severity-error.svg'
 import { generateLinkPath, parseUri } from '../utils'
+import { generateLinkToDetailsPanel } from './generateLinkToDetailsPanel'
 
 import { parseKeyValues } from './object'
 import { formatDatetime } from './datetime'
@@ -108,13 +109,21 @@ const createModelsRowData = (artifact, project) => {
     key: {
       value: artifact.db_key,
       class: 'artifacts_medium',
-      link: `/projects/${project}/models/models/${artifact.db_key}/${artifact.tag}/overview`,
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          project,
+          MODELS_TAB,
+          MODELS_TAB,
+          artifact.db_key,
+          artifact.tag,
+          tab
+        ),
       expandedCellContent: {
         class: 'artifacts_medium',
         value: artifact.tag
       },
       rowExpanded: {
-        link: false
+        getLink: false
       }
     },
     labels: {
@@ -166,13 +175,21 @@ const createFilesRowData = (artifact, project) => {
     key: {
       value: artifact.db_key,
       class: 'artifacts_medium',
-      link: `/projects/${project}/files/${artifact.db_key}/${artifact.tag}/overview`,
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          project,
+          FILES_PAGE,
+          null,
+          artifact.db_key,
+          artifact.tag,
+          tab
+        ),
       expandedCellContent: {
         class: 'artifacts_medium',
         value: artifact.tag
       },
       rowExpanded: {
-        link: false
+        getLink: false
       }
     },
     version: {
@@ -247,7 +264,15 @@ const createModelEndpointsRowData = (artifact, project) => {
     key: {
       value: name,
       class: 'artifacts_medium',
-      link: `/projects/${project}/models/model-endpoints/${name}/${artifact.metadata?.uid}/overview`
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          project,
+          MODELS_TAB,
+          MODEL_ENDPOINTS_TAB,
+          name,
+          artifact.metadata?.uid,
+          tab
+        )
     },
     state: {
       value: artifact.status?.state,
@@ -304,13 +329,21 @@ const createDatasetsRowData = (artifact, project) => {
     key: {
       value: artifact.db_key,
       class: 'artifacts_medium',
-      link: `/projects/${project}/feature-store/datasets/${artifact.db_key}/${artifact.tag}/overview`,
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          project,
+          FEATURE_STORE_PAGE,
+          DATASETS_TAB,
+          artifact.db_key,
+          artifact.tag,
+          tab
+        ),
       expandedCellContent: {
         class: 'artifacts_medium',
         value: artifact.tag
       },
       rowExpanded: {
-        link: false
+        getLink: false
       }
     },
     labels: {
@@ -361,7 +394,15 @@ const createFeatureSetsRowData = (artifact, project) => {
     key: {
       value: artifact.name,
       class: 'artifacts_medium',
-      link: `/projects/${project}/feature-store/feature-sets/${artifact.name}/${artifact.tag}/overview`,
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          project,
+          FEATURE_STORE_PAGE,
+          FEATURE_SETS_TAB,
+          artifact.name,
+          artifact.tag,
+          tab
+        ),
       expandedCellContent: {
         class: 'artifacts_medium',
         value: artifact.tag
@@ -402,7 +443,15 @@ const createFeaturesRowData = artifact => {
     feature_set: {
       value: artifact.metadata?.name,
       class: 'artifacts_small',
-      link: `/projects/${artifact.metadata?.project}/feature-store/feature-sets/${artifact.metadata?.name}/${artifact.metadata?.tag}/overview`,
+      getLink: tab =>
+        generateLinkToDetailsPanel(
+          artifact.metadata?.project,
+          FEATURE_STORE_PAGE,
+          FEATURE_SETS_TAB,
+          artifact.metadata?.name,
+          artifact.metadata?.tag,
+          tab
+        ),
       expandedCellContent: {
         class: 'artifacts_small',
         value: ''
@@ -467,7 +516,15 @@ const createFeatureVectorsRowData = (artifact, project) => ({
   key: {
     value: artifact.name,
     class: 'artifacts_medium',
-    link: `/projects/${project}/feature-store/feature-vectors/${artifact.name}/${artifact.tag}/overview`,
+    getLink: tab =>
+      generateLinkToDetailsPanel(
+        project,
+        FEATURE_STORE_PAGE,
+        FEATURE_VECTORS_TAB,
+        artifact.name,
+        artifact.tag,
+        tab
+      ),
     expandedCellContent: {
       class: 'artifacts_medium',
       value: artifact.tag

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -2,6 +2,9 @@ import { formatDatetime } from './datetime'
 import measureTime from './measureTime'
 import cronstrue from 'cronstrue'
 import { parseKeyValues } from './object'
+import { generateLinkToDetailsPanel } from './generateLinkToDetailsPanel'
+
+import { FUNCTIONS_PAGE, JOBS_PAGE, MONITOR_TAB } from '../constants'
 
 const createJobsContent = (content, groupedByWorkflow, scheduled) => {
   return content.map(contentItem => {
@@ -9,12 +12,9 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
       if (scheduled) {
         const [, , scheduleJobFunctionUid] =
           contentItem.func?.match(/\w(?<!\d)[\w'-]*/g, '') || []
-        const nameLink = !contentItem.func?.includes('hub:')
-          ? `/projects/${contentItem.project}/functions/${scheduleJobFunctionUid}/overview`
-          : null
         const [, projectName, jobUid] =
           contentItem.lastRunUri?.match(/(.+)@(.+)#([^:]+)(?::(.+))?/) || []
-        const lastRunLink =
+        const lastRunLink = () =>
           projectName &&
           jobUid &&
           `/projects/${projectName}/jobs/monitor/${jobUid}/overview`
@@ -23,7 +23,15 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
           name: {
             value: contentItem.name,
             class: 'jobs_big',
-            link: nameLink
+            getLink: tab =>
+              generateLinkToDetailsPanel(
+                contentItem.project,
+                FUNCTIONS_PAGE,
+                null,
+                scheduleJobFunctionUid,
+                null,
+                tab
+              )
           },
           type: {
             value: contentItem.type,
@@ -51,7 +59,7 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
           lastRun: {
             value: formatDatetime(contentItem.start_time),
             class: 'jobs_big',
-            link: lastRunLink
+            getLink: lastRunLink
           },
           createdTime: {
             value: formatDatetime(contentItem.createdTime, 'Not yet started'),
@@ -72,7 +80,15 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
           name: {
             value: contentItem.name,
             class: 'jobs_medium',
-            link: `/projects/${contentItem.project}/jobs/monitor/${contentItem.uid}/overview`
+            getLink: tab =>
+              generateLinkToDetailsPanel(
+                contentItem.project,
+                JOBS_PAGE,
+                MONITOR_TAB,
+                contentItem.uid,
+                null,
+                tab
+              )
           },
           type: {
             value: typeof groupedByWorkflow !== 'boolean' ? 'workflow' : type,

--- a/src/utils/generateLinkToDetailsPanel.js
+++ b/src/utils/generateLinkToDetailsPanel.js
@@ -1,0 +1,11 @@
+export const generateLinkToDetailsPanel = (
+  project,
+  screen,
+  tab,
+  key,
+  version,
+  detailsTab
+) =>
+  `/projects/${project}/${screen.toLowerCase()}${tab ? `/${tab}` : ''}/${key}${
+    version ? `/${version}` : ''
+  }/${detailsTab.toLowerCase()}`


### PR DESCRIPTION
https://trello.com/c/E9Ddeelj/748-feature-storejobs-retain-selected-tab-on-switching-items

- **Feature store**: In screen’s tabs “Feature sets”, “Feature vectors”, & “Datasets”, when selecting an item from the list and the details panel is open, and a nested tab other than “Overview” is active, and you select another item from, the main list (feature set, feature vector, dataset) — the active tab in the details panel used to always go to “Overview” tab, and now instead the active tab remains unchanged

Jira ticket ML-381