### PR TITLE
[Jobs] Re-run: Added job panel for editing

### DIFF
--- a/src/components/JobsPanel/JobsPanel.js
+++ b/src/components/JobsPanel/JobsPanel.js
@@ -25,6 +25,7 @@ import {
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { initialState, panelReducer, panelActions } from './panelReducer'
 import { parseKeyValues } from '../../utils'
+import notificationActions from '../../actions/notification'
 
 import './jobsPanel.scss'
 
@@ -37,6 +38,7 @@ const JobsPanel = ({
   jobsStore,
   match,
   onEditJob,
+  onSuccessRun,
   project,
   redirectToDetailsPane,
   removeFunctionTemplate,
@@ -49,7 +51,8 @@ const JobsPanel = ({
   setNewJobInputs,
   setNewJobSecretSources,
   setNewJobVolumeMounts,
-  setNewJobVolumes
+  setNewJobVolumes,
+  withSaveChanges
 }) => {
   const [panelState, panelDispatch] = useReducer(panelReducer, initialState)
   const [openScheduleJob, setOpenScheduleJob] = useState(false)
@@ -239,9 +242,11 @@ const JobsPanel = ({
   const handleRunJob = (event, cronString) => {
     const selectedFunction = functionsStore.template.name
       ? functionsStore.template.functions[0]
-      : groupedFunctions.functions.find(
+      : groupedFunctions.functions
+      ? groupedFunctions.functions.find(
           func => func.metadata.tag === panelState.currentFunctionInfo.version
         )
+      : defaultData
     const isFunctionTemplate = !isEmpty(functionsStore.template)
     const labels = {}
 
@@ -257,7 +262,8 @@ const JobsPanel = ({
       labels,
       match,
       selectedFunction,
-      isFunctionTemplate
+      isFunctionTemplate,
+      defaultData?.task.spec.function
     )
 
     if (jobsStore.error) {
@@ -267,6 +273,7 @@ const JobsPanel = ({
     runNewJob(postData)
       .then(result => {
         removeNewJob()
+        onSuccessRun && onSuccessRun()
 
         if (redirectToDetailsPane) {
           return history.push(
@@ -335,6 +342,7 @@ const JobsPanel = ({
       setNewJobVolumeMounts={setNewJobVolumeMounts}
       setNewJobVolumes={setNewJobVolumes}
       setOpenScheduleJob={setOpenScheduleJob}
+      withSaveChanges={withSaveChanges}
     />
   )
 }
@@ -343,7 +351,8 @@ JobsPanel.defaultProps = {
   defaultData: null,
   groupedFunctions: {},
   onEditJob: () => {},
-  redirectToDetailsPane: false
+  redirectToDetailsPane: false,
+  withSaveChanges: false
 }
 
 JobsPanel.propTypes = {
@@ -354,10 +363,11 @@ JobsPanel.propTypes = {
   onEditJob: PropTypes.func,
   project: PropTypes.string.isRequired,
   redirectToDetailsPane: PropTypes.bool,
-  runNewJob: PropTypes.func.isRequired
+  runNewJob: PropTypes.func.isRequired,
+  withSaveChanges: PropTypes.bool
 }
 
 export default connect(
   ({ jobsStore, functionsStore }) => ({ jobsStore, functionsStore }),
-  { ...jobsActions, ...functionActions }
+  { ...jobsActions, ...functionActions, ...notificationActions }
 )(JobsPanel)

--- a/src/components/JobsPanel/JobsPanelView.js
+++ b/src/components/JobsPanel/JobsPanelView.js
@@ -34,7 +34,8 @@ const JobsPanelView = ({
   setNewJobSecretSources,
   setNewJobVolumeMounts,
   setNewJobVolumes,
-  setOpenScheduleJob
+  setOpenScheduleJob,
+  withSaveChanges
 }) => {
   return (
     <div className="job-panel-container">
@@ -125,7 +126,7 @@ const JobsPanelView = ({
                 className="pop-up-dialog__btn_cancel"
                 onClick={() => isTitleValid() && setOpenScheduleJob(true)}
               />
-              {defaultData ? (
+              {withSaveChanges ? (
                 <Button
                   variant="secondary"
                   label="Save"
@@ -179,7 +180,8 @@ JobsPanelView.propTypes = {
   setNewJobSecretSources: PropTypes.func.isRequired,
   setNewJobVolumeMounts: PropTypes.func.isRequired,
   setNewJobVolumes: PropTypes.func.isRequired,
-  setOpenScheduleJob: PropTypes.func.isRequired
+  setOpenScheduleJob: PropTypes.func.isRequired,
+  withSaveChanges: PropTypes.bool.isRequired
 }
 
 export default JobsPanelView

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -55,8 +55,7 @@ const Table = ({
       groupedByWorkflow,
       groupFilter,
       pageData.page,
-      match,
-      setLoading
+      match
     )
 
     if (groupFilter === 'name') {
@@ -101,12 +100,6 @@ const Table = ({
     workflows,
     pageData.mainRowItemsCount
   ])
-
-  useEffect(() => {
-    if (tableContent.content.length && setLoading) {
-      setLoading(false)
-    }
-  }, [setLoading, tableContent])
 
   return (
     <>

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -51,7 +51,7 @@ const createJobsContent = (content, groupedByWorkflow, scheduled) => {
           },
           labels: {
             value: parseKeyValues(
-              contentItem.scheduled_object.task.metadata.labels || {}
+              contentItem.scheduled_object?.task.metadata.labels || {}
             ),
             class: 'jobs_big',
             type: 'labels'

--- a/src/utils/generateTableContent.js
+++ b/src/utils/generateTableContent.js
@@ -19,12 +19,9 @@ export const generateTableContent = (
   groupedByWorkflow,
   groupFilter,
   page,
-  match,
-  setLoading
+  match
 ) => {
   if (!isEmpty(groupedByName) && groupFilter === 'name') {
-    setLoading(true)
-
     return map(groupedByName, group =>
       page === JOBS_PAGE
         ? createJobsContent(group, false)
@@ -38,12 +35,8 @@ export const generateTableContent = (
           )
     )
   } else if (!isEmpty(groupedByWorkflow) && groupFilter === 'workflow') {
-    setLoading(true)
-
     return map(groupedByWorkflow, group => createJobsContent(group, true))
   } else if (groupFilter === 'none' || !groupFilter) {
-    setLoading && setLoading(true)
-
     return page === JOBS_PAGE
       ? createJobsContent(content, false, match.params.pageTab === SCHEDULE_TAB)
       : page === ARTIFACTS_PAGE ||


### PR DESCRIPTION
https://trello.com/c/H8g2dH5Q/765-jobs-re-run-add-job-panel-for-editing

- **Jobs**: In “Monitor” tab, the “Re-run” action now does not run immediately but rather opens the job panel with all fields pre-populated with the settings from that run — allowing for the user to edit the settings before running it (or scheduling it for later!)
  ![image](https://user-images.githubusercontent.com/13918850/114524108-9a4bb600-9c4d-11eb-9afd-8e2dc108f611.png)

Jira ticket ML-340