### PR TITLE
Fix [Models][Datasets][Files] Wrong key and iter delimiter in URI

### DIFF
--- a/src/utils/generateUri.js
+++ b/src/utils/generateUri.js
@@ -8,13 +8,15 @@ import {
 import { isNil } from 'lodash'
 
 export const generateUri = (item, tab) => {
-  let uri = `store://${tab}/${item.project}/${item.name ? item.name : item.key}`
+  let uri = `store://${tab}/${item.project}/`
 
   if (tab === MODELS_TAB || tab === DATASETS_TAB || tab === ARTIFACTS) {
-    if (!isNil(item.iter)) uri += `-${item.iter}`
+    uri += item.db_key
+    if (!isNil(item.iter)) uri += `#${item.iter}`
     if (item.tag) uri += `:${item.tag}`
     else if (item.tree) uri += `@${item.tree}`
   } else if (tab === FEATURE_SETS_TAB || tab === FEATURE_VECTORS_TAB) {
+    uri += item.name
     if (item.tag) uri += `:${item.tag}`
     else if (item.uid) uri += `@${item.uid}`
   }


### PR DESCRIPTION
- **Models, Datasets, Files**: URI was wrong (both the field value in “Overview” tab, and the value copied to clipboard on firing the “Copy URI” action):
  - Used `key` instead of `db_key` for models/datasets/files
  - Used `-` as iteration delimiter instead of `#`
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/114574869-4d360700-9c82-11eb-9527-f21f104ac1d9.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/114574859-4ad3ad00-9c82-11eb-830b-4fa8f3f48077.png)

Bug originated in PR https://github.com/mlrun/ui/pull/456

Jira ticket ML-404