### PR TITLE
[Functions] Hide "Run" action for failed functions

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -10,6 +10,7 @@ import JobsPanel from '../JobsPanel/JobsPanel'
 import {
   detailsMenu,
   filters,
+  FUNCTIONS_FAILED_STATES,
   infoHeaders,
   initialGroupFilter,
   page,
@@ -38,7 +39,7 @@ const Functions = ({
   const [showUntagged, setShowUntagged] = useState('')
   const [taggedFunctions, setTaggedFunctions] = useState([])
   const pageData = {
-    actionsMenu: [
+    actionsMenu: item => [
       {
         label: 'Delete',
         icon: <Delete />,
@@ -47,7 +48,8 @@ const Functions = ({
       {
         label: 'Run',
         icon: <Run />,
-        onClick: func => setEditableItem(func)
+        onClick: func => setEditableItem(func),
+        hidden: FUNCTIONS_FAILED_STATES.includes(item.state)
       }
     ],
     detailsMenu,

--- a/src/components/FunctionsPage/functions.util.js
+++ b/src/components/FunctionsPage/functions.util.js
@@ -1,4 +1,5 @@
 export const detailsMenu = ['overview', 'code']
+export const FUNCTIONS_FAILED_STATES = ['failed', 'error']
 export const page = 'FUNCTIONS'
 export const tableHeaders = [
   {

--- a/src/elements/FunctionsTableRow/FunctionsTableRow.js
+++ b/src/elements/FunctionsTableRow/FunctionsTableRow.js
@@ -156,7 +156,7 @@ const FunctionsTableRow = ({
 }
 
 FunctionsTableRow.propTypes = {
-  actionsMenu: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  actionsMenu: PropTypes.func.isRequired,
   content: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   handleSelectItem: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired,


### PR DESCRIPTION
https://trello.com/c/1QWqOXt0/773-functions-hide-run-action-for-failed-functions

- **Functions**: Hide “Run” action from functions in `Error`/`Failed` state
  ![image](https://user-images.githubusercontent.com/13918850/114681445-d4cd5580-9d16-11eb-93d6-7a46dae6bdd6.png)

Continues PR https://github.com/mlrun/ui/pull/496

Jira ticket ML-258