### PR TITLE
Fix [Feature vectors] Preview: error when preview is empty

### DIFF
--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -180,7 +180,10 @@ export const getArtifactPreview = (
             )
           : setPreview(state => [...state, previewContent])
     )
-  } else if (artifact.preview?.length === 0 || !artifact.preview) {
+  } else if (
+    (artifact.preview?.length === 0 || !artifact.preview) &&
+    artifact.target_path
+  ) {
     fetchArtifactPreviewFromTargetPath(
       artifact,
       noData,


### PR DESCRIPTION
- **Feature vectors**: If feature vector has `status.preview` of `[]`, UI unexpectedly sent a request to `GET /api/files` with no parameters, which ultimately failed and the error was displayed. Now it simply shows a no-data message, as expected.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/115825974-e13a6800-a412-11eb-9a19-f6824b73ba54.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/115825981-e4355880-a412-11eb-8b6d-869103895c41.png)


Jira ticket ML-435