### PR TITLE
[Jobs] Monitor: initially filter to last 24 hours

### DIFF
--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -22,7 +22,8 @@ import {
   FUNCTIONS_PAGE,
   JOBS_PAGE,
   KEY_CODES,
-  MODELS_PAGE
+  MODELS_PAGE,
+  MONITOR_TAB
 } from '../../constants'
 import artifactsAction from '../../actions/artifacts'
 import { selectOptions, filterTreeOptions } from './filterMenu.settings'
@@ -87,6 +88,17 @@ const FilterMenu = ({
       })
     }
   }, [dispatch, filters, match.params.projectName])
+
+  useEffect(() => {
+    if (match.params.pageTab === MONITOR_TAB) {
+      const currentDate = new Date()
+      const yesterdayDate = new Date()
+
+      yesterdayDate.setDate(currentDate.getDate() - 1)
+      onChange({ dates: [yesterdayDate, currentDate] })
+      setDates([yesterdayDate, currentDate])
+    }
+  }, [match.params.pageTab, onChange])
 
   const applyChanges = () => {
     if (match.params.jobId || match.params.name) {

--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -290,13 +290,15 @@ const Jobs = ({
   ])
 
   useEffect(() => {
-    refreshJobs()
+    if (match.params.pageTab === SCHEDULE_TAB) {
+      refreshJobs()
+    }
 
     return () => {
       setSelectedJob({})
       setJobs([])
     }
-  }, [getWorkflows, match.params.pageTab, refreshJobs])
+  }, [match.params.pageTab, refreshJobs])
 
   useEffect(() => {
     if (match.params.pageTab === SCHEDULE_TAB) {


### PR DESCRIPTION
https://trello.com/c/6c0iKJfO/777-jobs-monitor-initially-filter-to-last-24-hours

- **Jobs**: In “Monitor” tab, default the “Start time” filter to the past 24 hours when entering this tab

Jira ticket ML-460