### PR TITLE
Fix [Create job] GPU: label overflows value; Error on empty values

### DIFF
--- a/src/common/Input/Input.js
+++ b/src/common/Input/Input.js
@@ -38,7 +38,7 @@ const Input = React.forwardRef(
     ref
   ) => {
     const [inputIsFocused, setInputIsFocused] = useState(false)
-    const [typedValue, setTypedValue] = useState(value ?? '')
+    const [typedValue, setTypedValue] = useState('')
     const input = React.createRef()
     const inputClassNames = classnames(
       'input',
@@ -57,6 +57,10 @@ const Input = React.forwardRef(
       infoLabel && 'input__label_info'
     )
     const wrapperClassNames = classnames(wrapperClassName, 'input-wrapper')
+
+    useEffect(() => {
+      setTypedValue(String(value ?? '')) // convert from number to string
+    }, [value])
 
     useEffect(() => {
       if (focused) {

--- a/src/common/RangeInput/RangeInput.js
+++ b/src/common/RangeInput/RangeInput.js
@@ -72,7 +72,7 @@ RangeInput.propTypes = {
   max: PropTypes.number,
   min: PropTypes.number,
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.string.isRequired
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
 }
 
 export default React.memo(RangeInput)

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -185,7 +185,10 @@ export const generateTableData = (
   const [{ limits, requests }] = getResources(selectedFunction)
   const environmentVariables = getEnvironmentVariables(selectedFunction)
 
-  if (limits?.memory.match(/[a-zA-Z]/) || requests?.memory.match(/[a-zA-Z]/)) {
+  if (
+    limits?.memory?.match(/[a-zA-Z]/) ||
+    requests?.memory?.match(/[a-zA-Z]/)
+  ) {
     const limitsMemoryUnit = limits.memory.replace(/\d+/g, '') + 'B'
     const requestsMemoryUnit = requests.memory.replace(/\d+/g, '') + 'B'
 
@@ -193,19 +196,19 @@ export const generateTableData = (
       type: panelActions.SET_MEMORY_UNIT,
       payload: limitsMemoryUnit || requestsMemoryUnit
     })
-  } else if (limits?.memory.length > 0 || requests?.memory.length > 0) {
+  } else if (limits?.memory?.length > 0 || requests?.memory?.length > 0) {
     panelDispatch({
       type: panelActions.SET_MEMORY_UNIT,
       payload: 'Bytes'
     })
   }
 
-  if (limits?.cpu.match(/m/) || requests?.cpu.match(/m/)) {
+  if (limits?.cpu?.match(/m/) || requests?.cpu?.match(/m/)) {
     panelDispatch({
       type: panelActions.SET_CPU_UNIT,
       payload: 'millicpu'
     })
-  } else if (limits?.cpu.length > 0 || requests?.cpu.length > 0) {
+  } else if (limits?.cpu?.length > 0 || requests?.cpu?.length > 0) {
     panelDispatch({
       type: panelActions.SET_CPU_UNIT,
       payload: 'cpu'


### PR DESCRIPTION
- **Create job**: In “Resources” section in “GPU” field the label was overflowing the value; also there was an error when there was GPU value set in the function, but no memory or CPU
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116238048-9483c380-a769-11eb-9400-4c7137dd67a1.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116238052-964d8700-a769-11eb-9274-70e9eb196e94.png)

Jira ticket ML-462