### PR TITLE
[Projects] Counter loaders in front of dialog

### DIFF
--- a/src/common/Loader/loader.scss
+++ b/src/common/Loader/loader.scss
@@ -4,7 +4,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 6;
+  z-index: 7;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -29,6 +29,7 @@
 
   &.section-loader {
     position: relative;
+    z-index: 5;
     background-color: transparent;
   }
 

--- a/src/common/PopUpDialog/popUpDialog.scss
+++ b/src/common/PopUpDialog/popUpDialog.scss
@@ -14,7 +14,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 5;
+    z-index: 6;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
https://trello.com/c/vpEy9jk4/767-projects-counter-loaders-in-front-of-dialog

- **Projects**: Loaders were displaying on top of the project creation pop-up instead of underneath it
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116272478-9b223300-a789-11eb-8d04-afba55987f60.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116272493-9eb5ba00-a789-11eb-9f41-9476080caef5.png)

Jira ticket ML-371