### PR TITLE
[Feature sets] Sidebar: Wrong feature set is marked as selected

### DIFF
--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -31,9 +31,10 @@ const ArtifactsTableRow = ({
   const rowClassNames = classnames(
     'table-body__row',
     'parent-row',
-    ((selectedItem?.db_key &&
-      selectedItem?.db_key === content[index]?.db_key) ||
-      (selectedItem?.name && selectedItem?.name === content[index]?.name) ||
+    ((selectedItem?.db_key && selectedItem?.db_key === rowItem.key.value) ||
+      (selectedItem?.name &&
+        selectedItem.name === rowItem.key.value &&
+        selectedItem.tag === rowItem.version.value) ||
       (selectedItem?.metadata &&
         selectedItem?.metadata?.uid === content[index]?.metadata?.uid)) &&
       !parent.current?.classList.value.includes('parent-row-expanded') &&
@@ -110,7 +111,8 @@ const ArtifactsTableRow = ({
                 selectedItem?.db_key === currentItem?.db_key &&
                 selectedItem.tag === currentItem?.tag) ||
                 (selectedItem?.name &&
-                  selectedItem?.name === currentItem?.name)) &&
+                  selectedItem?.name === currentItem?.name &&
+                  selectedItem?.tag === currentItem?.tag)) &&
                 'row_active'
             )
 
@@ -188,7 +190,7 @@ const ArtifactsTableRow = ({
                   }
                   handleExpandRow={handleExpandRow}
                   data={value}
-                  item={content[index]}
+                  item={findCurrentItem(rowItem)}
                   key={Math.random() + i}
                   link={value.getLink?.(
                     match.params.tab ?? DETAILS_OVERVIEW_TAB

--- a/src/utils/generateGroupLatestItem.js
+++ b/src/utils/generateGroupLatestItem.js
@@ -25,6 +25,7 @@ export const generateGroupLatestItem = (page, tableContent, pageTab) =>
       : Array.isArray(group) &&
         [FEATURE_STORE_PAGE].includes(page) &&
         ![FEATURES_TAB].includes(pageTab)
-      ? group.find(groupItem => groupItem.version?.value === 'latest')
+      ? group.find(groupItem => groupItem.version?.value === 'latest') ??
+        group[0]
       : group[0]
   )


### PR DESCRIPTION
https://trello.com/c/ajHQZXMK/782-feature-sets-sidebar-wrong-feature-set-is-marked-as-selected

- **Feature sets**: Selecting one feature set marked another as selected, sometimes even more than one
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116443994-f40ecb80-a85c-11eb-900e-450c7618651d.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116444263-3c2dee00-a85d-11eb-8f20-34e83b5a8da7.png)

Jira ticket ML-467