### PR TITLE
[Jobs] Monitor: Add predefined options to Start From filter

### DIFF
--- a/src/common/DatePicker/DatePicker.js
+++ b/src/common/DatePicker/DatePicker.js
@@ -49,10 +49,10 @@ const DatePicker = ({
   const [isDatePickerOptionsOpened, setIsDatePickerOptionsOpened] = useState(
     false
   )
-  const [isOptionsEnabled, setIsOptionsEnabled] = useState(withOptions)
   const [isRange] = useState(type.includes('range'))
   const [isTime] = useState(type.includes('time'))
   const [isTopPosition, setIsTopPosition] = useState(false)
+  const [isValueEmpty, setIsValueEmpty] = useState(true)
   const [valueDatePickerInput, setValueDatePickerInput] = useState(
     formatDate(isRange, isTime, splitCharacter, date, dateTo)
   )
@@ -145,18 +145,16 @@ const DatePicker = ({
   }, [dateTo])
 
   useEffect(() => {
-    if (date) {
-      setValueDatePickerInput(
-        formatDate(isRange, isTime, splitCharacter, date, dateTo)
-      )
-    }
+    setValueDatePickerInput(
+      formatDate(isRange, isTime, splitCharacter, date, dateTo)
+    )
   }, [date, dateTo, isRange, isTime, splitCharacter])
 
   useEffect(() => {
-    const isValueEmpty = getInputValueValidity(valueDatePickerInput)
-    setIsOptionsEnabled(withOptions && isValueEmpty)
+    const isInputValueEmpty = getInputValueValidity(valueDatePickerInput)
+    setIsValueEmpty(withOptions && isInputValueEmpty)
 
-    isValueEmpty && setIsDatePickerOpened(false)
+    isInputValueEmpty && setIsDatePickerOpened(false)
   }, [getInputValueValidity, valueDatePickerInput, withOptions])
 
   useEffect(() => {
@@ -293,7 +291,7 @@ const DatePicker = ({
 
   const onInputDatePickerChange = event => {
     setValueDatePickerInput(event.target.value)
-    !isDatePickerOpened && setIsDatePickerOpened(true)
+    isDatePickerOptionsOpened && setIsDatePickerOptionsOpened(false)
     let isValueEmpty = getInputValueValidity(event.target.value)
 
     if (new RegExp(dateRegEx).test(event.target.value) || isValueEmpty) {
@@ -310,7 +308,7 @@ const DatePicker = ({
   }
 
   const onInputDatePickerClick = () => {
-    if (isOptionsEnabled && !isDatePickerOpened) {
+    if (withOptions && !isDatePickerOpened) {
       setIsDatePickerOptionsOpened(true)
     } else {
       setIsDatePickerOpened(true)
@@ -393,12 +391,12 @@ const DatePicker = ({
         isCalendarInvalid={isCalendarInvalid}
         isDatePickerOpened={isDatePickerOpened}
         isDatePickerOptionsOpened={isDatePickerOptionsOpened}
-        isOptionsEnabled={isOptionsEnabled}
         isRange={isRange}
         isRangeDateValid={isRangeDateValid}
         isSameDate={isSameDate}
         isTime={isTime}
         isTopPosition={isTopPosition}
+        isValueEmpty={isValueEmpty}
         label={label}
         months={months}
         onApplyChanges={onDatePickerChange}
@@ -419,7 +417,8 @@ const DatePicker = ({
 DatePicker.defaultProps = {
   label: 'Date',
   splitCharacter: '/',
-  type: 'date'
+  type: 'date',
+  withOptions: false
 }
 
 DatePicker.propTypes = {
@@ -429,7 +428,8 @@ DatePicker.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   splitCharacter: PropTypes.oneOf(['/', '.']),
-  type: PropTypes.oneOf(['date', 'date-time', 'date-range', 'date-range-time'])
+  type: PropTypes.oneOf(['date', 'date-time', 'date-range', 'date-range-time']),
+  withOptions: PropTypes.bool
 }
 
 export default React.memo(DatePicker, (prev, next) => prev.date === next.date)

--- a/src/common/DatePicker/DatePickerView.js
+++ b/src/common/DatePicker/DatePickerView.js
@@ -19,12 +19,12 @@ const DatePickerView = React.forwardRef(
       isCalendarInvalid,
       isDatePickerOpened,
       isDatePickerOptionsOpened,
-      isOptionsEnabled,
       isRange,
       isRangeDateValid,
       isSameDate,
       isTime,
       isTopPosition,
+      isValueEmpty,
       label,
       months,
       onApplyChanges,
@@ -43,12 +43,12 @@ const DatePickerView = React.forwardRef(
     const inputClassNames = classnames(
       'input',
       'date-picker__input',
-      !isOptionsEnabled && 'active-input',
+      !isValueEmpty && 'active-input',
       isRange && 'long-input'
     )
     const inputLabelClassNames = classnames(
       'input__label',
-      !isOptionsEnabled && 'active-label'
+      !isValueEmpty && 'active-label'
     )
 
     return (
@@ -62,14 +62,14 @@ const DatePickerView = React.forwardRef(
             className={inputClassNames}
             keepCharPositions={true}
             mask={dateMask}
-            disabled={isOptionsEnabled}
-            showMask={!isOptionsEnabled}
+            disabled={isValueEmpty}
+            showMask={!isValueEmpty}
             onChange={onInputChange}
             pipe={autoCorrectedDatePipe}
             value={valueDatePickerInput}
           />
           <span className={inputLabelClassNames}>
-            {isOptionsEnabled ? 'Any time' : label}
+            {isValueEmpty ? 'Any time' : label}
           </span>
         </div>
         {isDatePickerOptionsOpened && (
@@ -223,12 +223,12 @@ DatePickerView.propTypes = {
   isCalendarInvalid: PropTypes.bool.isRequired,
   isDatePickerOpened: PropTypes.bool.isRequired,
   isDatePickerOptionsOpened: PropTypes.bool.isRequired,
-  isOptionsEnabled: PropTypes.bool.isRequired,
   isRangeDateValid: PropTypes.func.isRequired,
   isRange: PropTypes.bool.isRequired,
   isSameDate: PropTypes.func.isRequired,
   isTime: PropTypes.bool.isRequired,
   isTopPosition: PropTypes.bool.isRequired,
+  isValueEmpty: PropTypes.bool.isRequired,
   label: PropTypes.string,
   months: PropTypes.array.isRequired,
   onApplyChanges: PropTypes.func.isRequired,

--- a/src/common/DatePicker/DatePickerView.js
+++ b/src/common/DatePicker/DatePickerView.js
@@ -43,13 +43,10 @@ const DatePickerView = React.forwardRef(
     const inputClassNames = classnames(
       'input',
       'date-picker__input',
-      !isValueEmpty && 'active-input',
+      'active-input',
       isRange && 'long-input'
     )
-    const inputLabelClassNames = classnames(
-      'input__label',
-      !isValueEmpty && 'active-label'
-    )
+    const inputLabelClassNames = classnames('input__label', 'active-label')
 
     return (
       <>
@@ -69,7 +66,10 @@ const DatePickerView = React.forwardRef(
             value={valueDatePickerInput}
           />
           <span className={inputLabelClassNames}>
-            {isValueEmpty ? 'Any time' : label}
+            {label}
+            {isValueEmpty && (
+              <span className="input__label-value">&nbsp;Any time</span>
+            )}
           </span>
         </div>
         {isDatePickerOptionsOpened && (

--- a/src/common/DatePicker/DatePickerView.js
+++ b/src/common/DatePicker/DatePickerView.js
@@ -7,6 +7,7 @@ import { ReactComponent as Arrow } from '../../images/arrow.svg'
 import Button from '../Button/Button'
 import ErrorMessage from '../ErrorMessage/ErrorMessage'
 import TimePicker from '../TimePicker/TimePicker'
+import SelectOption from '../../elements/SelectOption/SelectOption'
 
 const DatePickerView = React.forwardRef(
   (
@@ -14,7 +15,11 @@ const DatePickerView = React.forwardRef(
       autoCorrectedDatePipe,
       config,
       dateMask,
+      datePickerOptions,
       isCalendarInvalid,
+      isDatePickerOpened,
+      isDatePickerOptionsOpened,
+      isOptionsEnabled,
       isRange,
       isRangeDateValid,
       isSameDate,
@@ -27,8 +32,8 @@ const DatePickerView = React.forwardRef(
       onInputClick,
       onNextMonth,
       onPreviousMonth,
+      onSelectOption,
       onTimeChange,
-      openDatePicker,
       setSelectedDate,
       valueDatePickerInput,
       weekDay
@@ -38,10 +43,13 @@ const DatePickerView = React.forwardRef(
     const inputClassNames = classnames(
       'input',
       'date-picker__input',
-      'active-input',
+      !isOptionsEnabled && 'active-input',
       isRange && 'long-input'
     )
-    const inputLabelClassNames = classnames('input__label', 'active-label')
+    const inputLabelClassNames = classnames(
+      'input__label',
+      !isOptionsEnabled && 'active-label'
+    )
 
     return (
       <>
@@ -54,17 +62,37 @@ const DatePickerView = React.forwardRef(
             className={inputClassNames}
             keepCharPositions={true}
             mask={dateMask}
-            showMask={true}
+            disabled={isOptionsEnabled}
+            showMask={!isOptionsEnabled}
             onChange={onInputChange}
             pipe={autoCorrectedDatePipe}
             value={valueDatePickerInput}
           />
-          <span className={inputLabelClassNames}>{label}</span>
+          <span className={inputLabelClassNames}>
+            {isOptionsEnabled ? 'Any time' : label}
+          </span>
         </div>
-        {openDatePicker && (
+        {isDatePickerOptionsOpened && (
           <div
             ref={ref}
-            className={`date-picker ${
+            className={`date-picker__pop-up ${
+              isTopPosition ? 'positionTop' : 'positionBottom'
+            }`}
+          >
+            {datePickerOptions.map(option => (
+              <SelectOption
+                item={option}
+                key={option.id}
+                onClick={() => onSelectOption(option.handler)}
+                selectType=""
+              />
+            ))}
+          </div>
+        )}
+        {isDatePickerOpened && (
+          <div
+            ref={ref}
+            className={`date-picker__pop-up date-picker ${
               isTopPosition ? 'positionTop' : 'positionBottom'
             }`}
           >
@@ -190,8 +218,12 @@ DatePickerView.propTypes = {
   autoCorrectedDatePipe: PropTypes.func.isRequired,
   config: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   dateMask: PropTypes.array.isRequired,
+  datePickerOptions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   floatingLabel: PropTypes.bool,
   isCalendarInvalid: PropTypes.bool.isRequired,
+  isDatePickerOpened: PropTypes.bool.isRequired,
+  isDatePickerOptionsOpened: PropTypes.bool.isRequired,
+  isOptionsEnabled: PropTypes.bool.isRequired,
   isRangeDateValid: PropTypes.func.isRequired,
   isRange: PropTypes.bool.isRequired,
   isSameDate: PropTypes.func.isRequired,
@@ -204,8 +236,8 @@ DatePickerView.propTypes = {
   onInputClick: PropTypes.func.isRequired,
   onNextMonth: PropTypes.func.isRequired,
   onPreviousMonth: PropTypes.func.isRequired,
+  onSelectOption: PropTypes.func.isRequired,
   onTimeChange: PropTypes.func.isRequired,
-  openDatePicker: PropTypes.bool.isRequired,
   setSelectedDate: PropTypes.func.isRequired,
   valueDatePickerInput: PropTypes.string.isRequired,
   weekDay: PropTypes.array.isRequired

--- a/src/common/DatePicker/datePicker.scss
+++ b/src/common/DatePicker/datePicker.scss
@@ -19,16 +19,19 @@
     }
   }
 
-  .date-picker {
+  .date-picker__pop-up {
     position: absolute;
     z-index: 5;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 30px 15px;
     background-color: $white;
     border-radius: 4px;
     box-shadow: $previewBoxShadow;
+  }
+
+  .date-picker {
+    padding: 30px 15px;
 
     &.positionTop {
       bottom: calc(100% + 5px);
@@ -53,7 +56,7 @@
     align-items: center;
     justify-content: space-between;
     color: $primary;
-    font-size: 20px;
+    font-size: 17px;
 
     .date-picker__header-label {
       color: $spunPearl;
@@ -75,11 +78,11 @@
 
   .date-picker__weeks {
     display: flex;
-    flex: 1;
+    justify-content: center;
     margin: 10px 0;
 
     .date-picker__weeks-day {
-      flex: 1;
+      width: 32px;
       height: 32px;
       color: $spunPearl;
       font-size: 12px;
@@ -91,8 +94,7 @@
 
   .date-picker__week {
     display: flex;
-    flex: 1;
-    justify-content: space-around;
+    justify-content: center;
     margin: 2px 0;
 
     .date-picker__week-day-wrapper {

--- a/src/common/DatePicker/datePicker.scss
+++ b/src/common/DatePicker/datePicker.scss
@@ -19,6 +19,12 @@
     }
   }
 
+  .input__label {
+    .input__label-value {
+      font-size: 14px;
+    }
+  }
+
   .date-picker__pop-up {
     position: absolute;
     z-index: 5;

--- a/src/common/Select/select.scss
+++ b/src/common/Select/select.scss
@@ -107,6 +107,7 @@
     max-height: 250px;
     overflow-y: auto;
     color: $mulledWineTwo;
+    background-color: $white;
     border: $primaryBorder;
     border-radius: 2px;
     box-shadow: $filterShadow;

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -220,6 +220,7 @@ const FilterMenu = ({
                   date={dates[0]}
                   dateTo={dates[1]}
                   type="date-range-time"
+                  withOptions
                 />
               )
             default:

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -92,7 +92,7 @@ const FilterMenu = ({
   }, [dispatch, filters, match.params.projectName])
 
   useEffect(() => {
-    if (match.params.pageTab === MONITOR_TAB && dates[0].length === 0) {
+    if (match.params.pageTab === MONITOR_TAB) {
       const currentDate = new Date()
       const yesterdayDate = new Date()
 
@@ -100,7 +100,7 @@ const FilterMenu = ({
       onChange({ dates: [yesterdayDate, currentDate] })
       setDates([yesterdayDate, currentDate])
     }
-  }, [dates, match.params.pageTab, onChange])
+  }, [match.params.pageTab, onChange])
 
   const applyChanges = () => {
     if (match.params.jobId || match.params.name) {

--- a/src/elements/SelectOption/SelectOption.js
+++ b/src/elements/SelectOption/SelectOption.js
@@ -54,14 +54,15 @@ const SelectOption = ({ disabled, item, onClick, selectType, selectedId }) => {
 }
 
 SelectOption.defaultProps = {
-  onClick: () => {}
+  onClick: () => {},
+  selectType: ''
 }
 
 SelectOption.propTypes = {
   disabled: PropTypes.bool,
   item: PropTypes.shape({}).isRequired,
   onClick: PropTypes.func,
-  selectType: PropTypes.string.isRequired,
+  selectType: PropTypes.string,
   selectedId: PropTypes.string
 }
 

--- a/src/elements/SelectOption/selectOption.scss
+++ b/src/elements/SelectOption/selectOption.scss
@@ -12,7 +12,6 @@
     align-items: center;
     height: 49px;
     padding: 0 15px;
-    background-color: $white;
 
     .checkbox {
       flex: 1;

--- a/src/utils/datePicker.util.js
+++ b/src/utils/datePicker.util.js
@@ -17,6 +17,68 @@ export const months = [
   'December'
 ]
 
+export const datePickerOptions = [
+  {
+    id: 'pastHour',
+    label: 'Past hour',
+    handler: () => {
+      return getPastDate((fromDate, toDate) => {
+        fromDate.setHours(toDate.getHours() - 1)
+      })
+    }
+  },
+  {
+    id: 'past24hours',
+    label: 'Past 24 hours',
+    handler: () => {
+      return getPastDate((fromDate, toDate) => {
+        fromDate.setDate(toDate.getDate() - 1)
+      })
+    }
+  },
+  {
+    id: 'pastWeek',
+    label: 'Past week',
+    handler: () => {
+      return getPastDate((fromDate, toDate) => {
+        fromDate.setDate(toDate.getDate() - 7)
+      })
+    }
+  },
+  {
+    id: 'pastMonth',
+    label: 'Past month',
+    handler: () => {
+      return getPastDate((fromDate, toDate) => {
+        fromDate.setMonth(toDate.getMonth() - 1)
+      })
+    }
+  },
+  {
+    id: 'pastYear',
+    label: 'Past year',
+    handler: () => {
+      return getPastDate((fromDate, toDate) => {
+        fromDate.setFullYear(toDate.getFullYear() - 1)
+      })
+    }
+  },
+  {
+    id: 'customRange',
+    label: 'Custom range',
+    handler: null
+  }
+]
+
+const getPastDate = setDate => {
+  let fromDate = new Date()
+  let toDate = new Date()
+
+  setDate(fromDate, toDate)
+
+  return [fromDate, toDate]
+}
+
 export const formatDate = (isRange, isTime, splitCharacter, date, dateTo) => {
   if (!date) {
     return ''

--- a/src/utils/datePicker.util.js
+++ b/src/utils/datePicker.util.js
@@ -19,6 +19,11 @@ export const months = [
 
 export const datePickerOptions = [
   {
+    id: 'anyTime',
+    label: 'Any time',
+    handler: () => ['', '']
+  },
+  {
     id: 'pastHour',
     label: 'Past hour',
     handler: () => {


### PR DESCRIPTION
https://trello.com/c/LuHwisLU/786-jobs-monitor-add-predefined-options-to-start-from-filter

- **Jobs**: In “Monitor” tab, added a drop-down menu for “Start time” filter with predefined options in addition to the “Custom range…” option that opens the date-time range picker
  ![image](https://user-images.githubusercontent.com/13918850/116592383-9cd62d00-a928-11eb-854f-e7a5b9a3a6f0.png)
  ![image](https://user-images.githubusercontent.com/13918850/116592614-df980500-a928-11eb-8669-b82f419846a6.png)

In-release (GA)
Continuing PR https://github.com/mlrun/ui/pull/497

Jira ticket ML-155