### PR TITLE
Impl [Data inputs] Store: Remove duplicate item names

### DIFF
--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
@@ -1,6 +1,7 @@
 import React, { useReducer, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { uniqBy } from 'lodash'
 
 import JobsPanelDataInputsView from './JobsPanelDataInputsView'
 
@@ -108,12 +109,12 @@ const JobsPanelDataInputs = ({
         }).then(featureVectors => {
           inputsDispatch({
             type: inputsActions.SET_FEATURE_VECTORS,
-            payload: featureVectors.map(featureVector => {
-              return {
+            payload: uniqBy(featureVectors, 'metadata.name').map(
+              featureVector => ({
                 label: featureVector.metadata.name,
                 id: featureVector.metadata.name
-              }
-            })
+              })
+            )
           })
         })
       }

--- a/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
+++ b/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
@@ -301,6 +301,7 @@ export const storePathTypes = [
 ]
 
 export const pathPlaceholders = {
+  [MLRUN_STORAGE_INPUT_PATH_SCHEME]: 'artifacts/my-project/my-artifact:my-tag',
   [S3_INPUT_PATH_SCHEME]: 'bucket/path',
   [GOOGLE_STORAGE_INPUT_PATH_SCHEME]: 'bucket/path',
   [AZURE_STORAGE_INPUT_PATH_SCHEME]: 'container/path',


### PR DESCRIPTION
- **Data Inputs**: Names of artifacts/feature vectors in a project were duplicated (per UID they have) — now only unique names are shown (UID/tag/iteration could be then added manually, for example `:latest`, `@123456`, `#2`). Also a placeholder were added to the “MLRun store” scheme: `artifacts/my-project/my-artifact:my-tag`
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116701341-7a97ea00-a9d0-11eb-988c-14211c50fcdc.png)
  ![image](https://user-images.githubusercontent.com/13918850/116701350-7cfa4400-a9d0-11eb-9e6b-ff1b8a5883ba.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116701533-af0ba600-a9d0-11eb-865b-9897584d82cb.png)
  ![image](https://user-images.githubusercontent.com/13918850/116701385-85eb1580-a9d0-11eb-92da-3aa98aa3ceba.png)

Jira ticket ML-463