### PR TITLE
Fix [Jobs] Artifacts: preview is broken for nested objects

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -41,19 +41,18 @@ const ArtifactsPreviewView = ({ preview, setShowErrorBody, showErrorBody }) => (
               })}
             </div>
             <div className="artifact-preview__table-body">
-              {preview.data.content.map(contentItem => (
-                <div
-                  key={contentItem + Math.random()}
-                  className="artifact-preview__table-row"
-                >
+              {preview.data.content.map((contentItem, index) => (
+                <div key={index} className="artifact-preview__table-row">
                   {Array.isArray(contentItem) ? (
                     contentItem.map(value => (
                       <Tooltip
                         className="artifact-preview__table-content"
-                        key={value + Math.random()}
+                        key={`${value}${Math.random()}`}
                         template={<TextTooltipTemplate text={`${value}`} />}
                       >
-                        {value}
+                        {typeof value === 'object' && value !== null
+                          ? JSON.stringify(value)
+                          : value}
                       </Tooltip>
                     ))
                   ) : (

--- a/src/components/ArtifactsPreview/artifactaPreview.scss
+++ b/src/components/ArtifactsPreview/artifactaPreview.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  overflow-x: auto;
 
   &__header {
     margin: 30px 0;

--- a/src/components/DetailsArtifacts/detailsArtifacts.scss
+++ b/src/components/DetailsArtifacts/detailsArtifacts.scss
@@ -51,9 +51,7 @@
     }
 
     &-popout {
-      position: absolute;
-      top: 15px;
-      right: 25px;
+      text-align: end;
       cursor: pointer;
     }
   }

--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -37,11 +37,7 @@ const PreviewModal = ({ item }) => {
           <div className="item-data item-data__name">
             {item.db_key || item.key}
           </div>
-          <div className="item-data item-data__path">
-            {`${
-              item.target_path?.schema ? `${item.target_path?.schema}://` : ''
-            }${item.target_path?.path}`}
-          </div>
+          <div className="item-data item-data__path">{item.target_path}</div>
           {item.size && (
             <div className="item-data">
               size:
@@ -55,10 +51,9 @@ const PreviewModal = ({ item }) => {
           </div>
           <div className="preview-body__download">
             <Download
-              path={`${item.target_path?.path}${
+              path={`${item.target_path}${
                 item.model_file ? item.model_file : ''
               }`}
-              schema={item.target_path?.schema}
               user={item.user ?? item.producer?.owner}
             />
           </div>


### PR DESCRIPTION
- **Jobs**: In “Artifacts” tab of a selected job, an error occurred when previewing an artifact with tabular data where one of its data cells consisted of a composite object, for example:
  ```js
  {
    "runs": [
      {
        "kind": "run",
        "status": {
          "artifacts": [
            {
              "preview": [
                [
                  "value1",
                  "value2",
                  [ // <-- a value of type: list of dictionaries
                    {
                      "foo": "bar"
                    }
                  ]
                ]
              ]
            }
          ]
        }
      }
    ]
  }
  ```
- **Jobs**: In “Artifacts” tab of a selected job, the “Artifacts Preview” icon was obstructed by preview content.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116782678-3ae60680-aa93-11eb-8ec0-3f67e2d5d5cd.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116782674-37527f80-aa93-11eb-9071-983dd0bed968.png)
- **Jobs**: In “Artifacts” tab of a selected job, the “Artifacts Preview” icon button was moving when scrolling preview content horizontally, instead of staying in the same place.
  Before:
![before-fix](https://user-images.githubusercontent.com/13918850/116782682-40dbe780-aa93-11eb-9417-0787bd15bb16.gif)
  After:
![after-fix](https://user-images.githubusercontent.com/13918850/116782685-446f6e80-aa93-11eb-87d8-579c7a651bfb.gif)
- **Jobs**: In “Artifacts” tab of a selected job, in the artifact preview modal: “undefined” was displayed instead of the path, and the “Download action” didn't work
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116789083-ccff0680-aab5-11eb-90eb-51b9bf95c2ca.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116789087-d0928d80-aab5-11eb-8d52-7565dc185619.png)

In-release (RC).