### PR TITLE
Impl [Jobs] Monitor: disable Abort action for Dask jobs

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -212,6 +212,10 @@ export const generateActionsMenu = (
           label: 'Abort',
           icon: <Cancel />,
           onClick: onAbortJob,
+          tooltip: job.labels?.includes('kind: dask')
+            ? 'Cannot abort dask jobs'
+            : '',
+          disabled: job.labels?.includes('kind: dask'),
           hidden: JOB_STEADY_STATES.includes(job.state)
         }
       ]


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, disable the “Abort” action for Dask jobs with the tooltip “Cannot abort Dask jobs”
  ![image](https://user-images.githubusercontent.com/13918850/116822364-208d5500-ab87-11eb-8eb6-8f99838a2d1c.png)

In-release (GA)
Continues PR https://github.com/mlrun/ui/pull/459
Jira ticket ML-409