### PR TITLE
Fix [Jobs] Monitor: showing error and infinite loader on success

### DIFF
--- a/src/api/jobs-api.js
+++ b/src/api/jobs-api.js
@@ -34,7 +34,7 @@ export default {
       params.name = filters.name
     }
 
-    if (filters.state) {
+    if (filters?.state) {
       params.state = filters.state
     }
 


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, although the “Abort” action succeeded, the UI unexpectedly showed a failed notification and an infinite loader (instead of a successful notification and temporary loader)
  ![image](https://user-images.githubusercontent.com/13918850/116823645-49651880-ab8e-11eb-9458-d77f71f5246a.png)

In-release (GA)
Bug originates in PR https://github.com/mlrun/ui/pull/522 [v0.6.3-rc6](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc6)
