### PR TITLE
Fix [Model Endpoints] Always fetching from one specific project

### DIFF
--- a/src/actions/details.js
+++ b/src/actions/details.js
@@ -35,11 +35,11 @@ const detailsActions = {
   removePods: () => ({
     type: REMOVE_JOB_PODS
   }),
-  fetchModelEndpointWithAnalysis: uid => dispatch => {
+  fetchModelEndpointWithAnalysis: (project, uid) => dispatch => {
     dispatch(detailsActions.fetchModelEndpointWithAnalysisBegin())
 
     return detailsApi
-      .getModelEndpoint(uid)
+      .getModelEndpoint(project, uid)
       .then(({ data }) => {
         dispatch(detailsActions.fetchModelEndpointWithAnalysisSuccess(data))
 

--- a/src/api/details-api.js
+++ b/src/api/details-api.js
@@ -3,8 +3,8 @@ import { mainHttpClient } from '../httpClient'
 export default {
   getJobPods: project =>
     mainHttpClient.get(`/projects/${project}/runtime-resources?group-by=job`),
-  getModelEndpoint: uid =>
+  getModelEndpoint: (project, uid) =>
     mainHttpClient.get(
-      `/projects/iris-demo-michaell/model-endpoints/${uid}?feature_analysis=true`
+      `/projects/${project}/model-endpoints/${uid}?feature_analysis=true`
     )
 }

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -247,7 +247,10 @@ export const checkForSelectedModelEndpoint = (
   } else {
     searchItem.name = searchItem.spec.model.split(':')[0]
 
-    fetchModelEndpointWithAnalysis(searchItem.metadata.uid)
+    fetchModelEndpointWithAnalysis(
+      match.params.projectName,
+      searchItem.metadata.uid
+    )
     setSelectedModel({ item: searchItem })
   }
 }


### PR DESCRIPTION
- **Model Endpoints**: On selecting model endpoints, their info was always fetched from one specific project (`iris-demo-michaell`) instead of dynamically using the project name their in

In-release (GA)
Bug originates in PR https://github.com/mlrun/ui/pull/499 [v0.6.3-RC3](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc3)

Jira ticket ML-482