### PR TITLE
Impl [Jobs] Monitor: use abortable function-kind list from BE

### DIFF
--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -201,7 +201,8 @@ const Jobs = ({
       handleRerunJob,
       handleMonitoring,
       appStore.frontendSpec.jobs_dashboard_url,
-      onAbortJob
+      onAbortJob,
+      appStore.frontendSpec.abortable_function_kinds
     ),
     [match.params.pageTab, appStore.frontendSpec.jobs_dashboard_url]
   )

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -124,7 +124,8 @@ export const generatePageData = (
   handleRerunJob,
   handleMonitoring,
   jobsDashboardUrl,
-  onAbortJob
+  onAbortJob,
+  abortableFunctionKinds
 ) => {
   let jobFilters = []
   let filterMenuActionButton = {
@@ -153,7 +154,8 @@ export const generatePageData = (
       handleRerunJob,
       handleMonitoring,
       jobsDashboardUrl,
-      onAbortJob
+      onAbortJob,
+      abortableFunctionKinds
     ),
     detailsMenu,
     filterMenuActionButton,
@@ -164,6 +166,12 @@ export const generatePageData = (
     infoHeaders
   }
 }
+
+const isJobAbortable = (job = { labels: [] }, abortableFunctionKinds = []) =>
+  abortableFunctionKinds
+    .map(kind => `kind: ${kind}`)
+    .some(kindLabel => job.labels.includes(kindLabel))
+
 export const generateActionsMenu = (
   scheduled,
   removeScheduledJob,
@@ -172,7 +180,8 @@ export const generateActionsMenu = (
   handleRerunJob,
   handleMonitoring,
   jobsDashboardUrl,
-  onAbortJob
+  onAbortJob,
+  abortableFunctionKinds
 ) => job =>
   scheduled
     ? [
@@ -212,10 +221,10 @@ export const generateActionsMenu = (
           label: 'Abort',
           icon: <Cancel />,
           onClick: onAbortJob,
-          tooltip: job.labels?.includes('kind: dask')
-            ? 'Cannot abort dask jobs'
-            : '',
-          disabled: job.labels?.includes('kind: dask'),
+          tooltip: isJobAbortable(job, abortableFunctionKinds)
+            ? ''
+            : 'Cannot abort jobs of this kind',
+          disabled: !isJobAbortable(job, abortableFunctionKinds),
           hidden: JOB_STEADY_STATES.includes(job.state)
         }
       ]


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, in action menu, enable the “Abort” action only for jobs of kind that is included in the new `abortable_function_kinds` list from backend API‘s `GET /api/frontend-spec` endpoint
  ![image](https://user-images.githubusercontent.com/13918850/116898002-8daff180-ac3e-11eb-928b-40a00f373857.png)

In-release (GA)
Modifies https://github.com/mlrun/ui/pull/530 [v0.6.3-RC7](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc7)
Continues https://github.com/mlrun/ui/pull/459 [v0.6.3-RC1](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc1)

Jira ticket ML-486