### PR TITLE
Fix [Jobs] Sometimes breaks when changing filters

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -167,10 +167,10 @@ export const generatePageData = (
   }
 }
 
-const isJobAbortable = (job = { labels: [] }, abortableFunctionKinds = []) =>
-  abortableFunctionKinds
+const isJobAbortable = (job, abortableFunctionKinds) =>
+  (abortableFunctionKinds ?? [])
     .map(kind => `kind: ${kind}`)
-    .some(kindLabel => job.labels.includes(kindLabel))
+    .some(kindLabel => job?.labels?.includes(kindLabel))
 
 export const generateActionsMenu = (
   scheduled,


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, breaks sometimes when assigning values to some filters

In-release (RC)
Bug originated in https://github.com/mlrun/ui/pull/535
