### PR TITLE
Impl [Jobs] Pods: Always show pods, not only when pending

### DIFF
--- a/src/actions/details.js
+++ b/src/actions/details.js
@@ -14,7 +14,7 @@ const detailsActions = {
     return detailsApi
       .getJobPods(project)
       .then(({ data }) => {
-        let podsData = generatePods(uid, data)
+        let podsData = generatePods(project, uid, data)
 
         dispatch(detailsActions.fetchPodsSuccess(podsData))
 

--- a/src/components/DetailsDriftAnalysis/DetailsDriftAnalysis.js
+++ b/src/components/DetailsDriftAnalysis/DetailsDriftAnalysis.js
@@ -20,7 +20,7 @@ const DetailsDriftAnalysis = ({ detailsStore }) => {
       {detailsStore.modelEndpoint.loading && <Loader />}
       {detailsStore.modelEndpoint.error ? (
         <div className="drift-analysis__error">
-          Failed fetched data from model endpoint analysis. Please, try again
+          Failed to fetch data from model endpoint analysis. Please try again
           later.
         </div>
       ) : (

--- a/src/components/DetailsFeaturesAnalysis/DetailsFeaturesAnalysis.js
+++ b/src/components/DetailsFeaturesAnalysis/DetailsFeaturesAnalysis.js
@@ -22,7 +22,7 @@ const DetailsFeaturesAnalysis = ({ detailsStore }) => {
       {detailsStore.modelEndpoint.loading && <Loader />}
       {detailsStore.modelEndpoint.error ? (
         <div className="features-analysis__error">
-          Failed fetched data from model endpoint analysis. Please, try again
+          Failed to fetch data from model endpoint analysis. Please try again
           later.
         </div>
       ) : (

--- a/src/components/DetailsPods/DetailsPods.js
+++ b/src/components/DetailsPods/DetailsPods.js
@@ -34,7 +34,7 @@ const DetailsPods = ({ detailsStore, match }) => {
     <div className="pods">
       {detailsStore.pods.error ? (
         <div className="pods__error">
-          Failed fetched data. Please, try again later.
+          Failed to fetch data. Please try again later.
         </div>
       ) : table.length ? (
         <>

--- a/src/utils/generatePods.js
+++ b/src/utils/generatePods.js
@@ -1,32 +1,22 @@
 import React from 'react'
-import { map } from 'lodash'
 
-export const generatePods = (uid, pods) => {
-  let podsData = {}
-  let podsPending = []
-  let podsList = []
-  let podsTooltip = []
+export const generatePods = (project, uid, pods) => {
+  const podsList = pods?.[project]?.[uid]?.pod_resources ?? []
+  const podsTooltip = podsList.map((value, index) => (
+    <p key={index}>
+      {value?.name}
+      {value?.status?.phase?.toLowerCase?.() === 'pending'
+        ? ' (pending...)'
+        : ''}
+    </p>
+  ))
+  const podsPending = podsList.filter(
+    pod => pod?.status?.phase?.toLowerCase?.() === 'pending'
+  )
 
-  if (pods?.[uid]) {
-    podsList = pods[uid].pod_resources
-    podsTooltip = map(podsList, (value, index) => (
-      <p key={index}>
-        {value.name}
-        {value.status.phase.toLowerCase() === 'pending' ? ' (pending...)' : ''}
-      </p>
-    ))
-    podsPending = podsList.filter(
-      pod => pod.status.phase.toLowerCase() === 'pending'
-    )
+  return {
+    podsList,
+    podsPending,
+    podsTooltip
   }
-
-  if (podsPending.length > 0) {
-    podsData = {
-      podsList,
-      podsPending,
-      podsTooltip
-    }
-  }
-
-  return podsData
 }


### PR DESCRIPTION
- **Jobs**: In “Pods” tab of the selected job, switched to always show the list of pods and their statuses instead of only showing them when at least one pod is pending.

  Jira ticket ML-485
- **Jobs**: In “Pods” tab of the selected job, accommodated to API change in response to getting pods details (project level added to hierarchy)

  Jira ticket ML-397
  Relates to PR https://github.com/mlrun/mlrun/pull/910

In-release (GA)
Continues feature https://github.com/mlrun/ui/pull/511 [v0.6.3-RC6](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc6) ML-430

