### PR TITLE
Fix [Project] Clickable area is too large

### DIFF
--- a/src/components/Project/project.scss
+++ b/src/components/Project/project.scss
@@ -161,6 +161,7 @@
       &__links {
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
 
         &-label {
           margin-bottom: 16px;


### PR DESCRIPTION
- **Project Overview**: In “Quick Links” the clickable area for each link was too large, now it is just the link itself
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/116986059-02823a80-acd6-11eb-8038-55fef70d5a3e.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/116986054-00b87700-acd6-11eb-85d6-b6e313f323aa.png)
