### PR TITLE
Impl [Functions] Reorder action menu: Move Delete before Run

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -41,15 +41,15 @@ const Functions = ({
   const pageData = {
     actionsMenu: item => [
       {
-        label: 'Delete',
-        icon: <Delete />,
-        onClick: func => removeFunction(func)
-      },
-      {
         label: 'Run',
         icon: <Run />,
         onClick: func => setEditableItem(func),
         hidden: FUNCTIONS_FAILED_STATES.includes(item.state)
+      },
+      {
+        label: 'Delete',
+        icon: <Delete />,
+        onClick: func => removeFunction(func)
       }
     ],
     detailsMenu,


### PR DESCRIPTION
- **Functions**: Re-ordered action menu, moved “Run” before ”Delete”, which makes more sense
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/117033026-ad145080-ad0a-11eb-8da7-5314c3e46416.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/117033036-af76aa80-ad0a-11eb-9ff5-07c4ab26c84c.png)

In-release (GA)
Continues https://github.com/mlrun/ui/pull/496 [v0.6.3-rc2](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc2) ML-258
Jira ticket ML-504