### PR TITLE
Impl [Feature sets] Create: hide Schedule field from Source

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSourceView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSourceView.js
@@ -32,7 +32,7 @@ const FeatureSetsPanelDataSourceView = ({
   showSchedule,
   setNewFeatureSetSchedule
 }) => {
-  const httpKind = 'http'
+  // const httpKind = 'http', disabling temporarily until backend supports scheduling
   return (
     <div className="feature-set-panel__item new-item-side-panel__item data-source">
       <FeatureSetsPanelSection title="Data Source">
@@ -98,7 +98,7 @@ const FeatureSetsPanelDataSourceView = ({
             wrapperClassName="inputs-item-wrapper"
           />
         </div>
-        {data.kind !== httpKind && (
+        {false && ( // was: data.kind !== httpKind, disabling temporarily until backend supports scheduling
           <div className="schedule-content">
             <Button
               className="schedule-tumbler"


### PR DESCRIPTION
- **Feature sets**: In “Create feature set” panel, in “Source” section, temporarily hide “Schedule” field until backend supports scheduling
Before:
![image](https://user-images.githubusercontent.com/13918850/117034961-7d664800-ad0c-11eb-8b7b-1c9d79adca93.png)
After:
![image](https://user-images.githubusercontent.com/13918850/117034975-80613880-ad0c-11eb-857f-34c84651dcde.png)

Continues feature https://github.com/mlrun/ui/pull/510 [v0.6.3-RC4](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc4) ML-231

Jira ticket ML-505