### PR TITLE
[Jobs] Monitor: initially filter to "Any time"

### DIFF
--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -93,12 +93,8 @@ const FilterMenu = ({
 
   useEffect(() => {
     if (match.params.pageTab === MONITOR_TAB) {
-      const currentDate = new Date()
-      const yesterdayDate = new Date()
-
-      yesterdayDate.setDate(currentDate.getDate() - 1)
-      onChange({ dates: [yesterdayDate, currentDate] })
-      setDates([yesterdayDate, currentDate])
+      onChange({ dates: ['', ''] })
+      setDates(['', ''])
     }
   }, [match.params.pageTab, onChange])
 


### PR DESCRIPTION
- **Jobs**: In “Monitor” tab, default the “Start time” filter to “Any time“ instead of the past 24 hours
  ![image](https://user-images.githubusercontent.com/13918850/117126241-28294580-ada3-11eb-83ae-790793fc3a3f.png)

In-release (GA)
Modifies https://github.com/mlrun/ui/pull/516 [v0.6.3-RC5](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc5) ML-460
Continues feature https://github.com/mlrun/ui/pull/497 [v0.6.3-Rc2](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc2) ML-155

Jira ticket ML-474