### PR TITLE
[Feature store] Enrich usage snippets and allow to copy

### DIFF
--- a/src/components/DetailsInfo/detailsInfo.scss
+++ b/src/components/DetailsInfo/detailsInfo.scss
@@ -20,7 +20,15 @@
       flex-direction: row;
       align-items: center;
       padding: 18px;
+      overflow-x: auto;
       border-bottom: $secondaryBorder;
+
+      &__btn {
+        &-copy {
+          position: absolute;
+          right: 25px;
+        }
+      }
 
       &__header {
         display: flex;

--- a/src/components/DetailsInfo/detailsInfo.scss
+++ b/src/components/DetailsInfo/detailsInfo.scss
@@ -18,16 +18,13 @@
     .details-item {
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: baseline;
       padding: 18px;
       overflow-x: auto;
       border-bottom: $secondaryBorder;
 
-      &__btn {
-        &-copy {
-          position: absolute;
-          right: 25px;
-        }
+      &__btn-copy {
+        vertical-align: middle;
       }
 
       &__header {

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -439,7 +439,8 @@ export const navigateToDetailsPane = (
         match.params.pageTab === FEATURE_VECTORS_TAB
       ) {
         selectedArtifact.usage_example = generateUsageSnippets(
-          match.params.pageTab
+          match.params,
+          artifactsStore
         )
       }
 

--- a/src/elements/DetailsInfoItem/DetailsInfoItem.js
+++ b/src/elements/DetailsInfoItem/DetailsInfoItem.js
@@ -103,15 +103,17 @@ const DetailsInfoItem = React.forwardRef(
         <div className="details-item__data details-item__usage-example">
           {info.map((item, index) => (
             <div key={index}>
-              <button
-                className="details-item__btn-copy"
-                onClick={() => copyToClipboard(item.code)}
-              >
-                <Tooltip template={<TextTooltipTemplate text="copy" />}>
-                  <Copy />
-                </Tooltip>
-              </button>
-              <p>{item.title}</p>
+              <p>
+                {item.title}
+                <button
+                  className="details-item__btn-copy"
+                  onClick={() => copyToClipboard(item.code)}
+                >
+                  <Tooltip template={<TextTooltipTemplate text="copy" />}>
+                    <Copy />
+                  </Tooltip>
+                </button>
+              </p>
               <pre>
                 <code
                   dangerouslySetInnerHTML={{

--- a/src/elements/DetailsInfoItem/DetailsInfoItem.js
+++ b/src/elements/DetailsInfoItem/DetailsInfoItem.js
@@ -12,6 +12,7 @@ import { copyToClipboard } from '../../utils/copyToClipboard'
 import Input from '../../common/Input/Input'
 
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
+import { ReactComponent as Copy } from '../../images/ic_copy-to-clipboard.svg'
 
 const DetailsInfoItem = React.forwardRef(
   (
@@ -100,16 +101,28 @@ const DetailsInfoItem = React.forwardRef(
     } else if (currentField === 'usage_example') {
       return (
         <div className="details-item__data details-item__usage-example">
-          <p>{info.title}</p>
-          <pre>
-            <code
-              dangerouslySetInnerHTML={{
-                __html:
-                  info.code &&
-                  Prism.highlight(info.code, Prism.languages.py, 'py')
-              }}
-            />
-          </pre>
+          {info.map((item, index) => (
+            <div key={index}>
+              <button
+                className="details-item__btn-copy"
+                onClick={() => copyToClipboard(item.code)}
+              >
+                <Tooltip template={<TextTooltipTemplate text="copy" />}>
+                  <Copy />
+                </Tooltip>
+              </button>
+              <p>{item.title}</p>
+              <pre>
+                <code
+                  dangerouslySetInnerHTML={{
+                    __html:
+                      item.code &&
+                      Prism.highlight(item.code, Prism.languages.py, 'py')
+                  }}
+                />
+              </pre>
+            </div>
+          ))}
         </div>
       )
     } else if (state) {


### PR DESCRIPTION
https://trello.com/c/HglAHTIc/789-feature-store-enrich-usage-snippets-and-allow-to-copy

- **Feature store**: In both feature sets and vectors, in their “Overview” tab, updated the examples in the “Usage example” snippet, implanted some values in it from the selected feature set/vector, aligned the field‘s label to the the field‘s content, and added a copy-to-clipboard icon button
  ![image](https://user-images.githubusercontent.com/13918850/117164950-bf0af780-adcd-11eb-9933-3caeec5bd148.png)
  ![image](https://user-images.githubusercontent.com/13918850/117164956-c16d5180-adcd-11eb-89cf-46ed2cc1ecd3.png)

Continues feature https://github.com/mlrun/ui/pull/505 [v0.6.3-RC3](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc3) ML-309

Jira ticket ML-309