### PR TITLE
[Jobs] Start Time: Remove upper bound from "Past X" options

### DIFF
--- a/src/common/DatePicker/DatePicker.js
+++ b/src/common/DatePicker/DatePicker.js
@@ -415,6 +415,7 @@ const DatePicker = ({
   )
 }
 DatePicker.defaultProps = {
+  dateTo: new Date(),
   label: 'Date',
   splitCharacter: '/',
   type: 'date',

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -167,6 +167,17 @@ const FilterMenu = ({
     }
   }
 
+  const handleChangeDates = dates => {
+    const generatedDates = [...dates]
+
+    if (generatedDates.length === 1) {
+      generatedDates.push(new Date())
+    }
+
+    onChange({ labels, name, owner, dates })
+    setDates(generatedDates)
+  }
+
   return (
     <>
       <div className="filters">
@@ -224,10 +235,7 @@ const FilterMenu = ({
                 <DatePicker
                   key={filter.type}
                   label={filter.label}
-                  onChange={dates => {
-                    onChange({ labels, name, owner, dates })
-                    setDates(dates)
-                  }}
+                  onChange={handleChangeDates}
                   date={dates[0]}
                   dateTo={dates[1]}
                   type="date-range-time"

--- a/src/utils/datePicker.util.js
+++ b/src/utils/datePicker.util.js
@@ -81,7 +81,7 @@ const getPastDate = setDate => {
 
   setDate(fromDate, toDate)
 
-  return [fromDate, toDate]
+  return [fromDate]
 }
 
 export const formatDate = (isRange, isTime, splitCharacter, date, dateTo) => {


### PR DESCRIPTION
https://trello.com/c/5xUrlVIf/795-jobs-start-time-remove-upper-bound-from-past-x-options

- **Jobs**: In “Monitor” tab, in the “Start Time” filter, the predefined “Past X” — such as “Past hour”, “Past year” — had an upper bound (meaning both “from” and “to”) when requesting from backend, so newly-created jobs were not displayed after creation

Relates to feature https://github.com/mlrun/ui/pull/497 [v0.6.3-RC2](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc2) ML-155

Jira ticket ML-513