### PR TITLE
[Feature vectors] List breaks on applying changes and expanding

### DIFF
--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -418,7 +418,10 @@ export const navigateToDetailsPane = (
         match.params.pageTab === FEATURE_SETS_TAB ||
         match.params.pageTab === FEATURE_VECTORS_TAB
       ) {
-        return artifact[searchKey] === name && artifact.tag === tag
+        return (
+          artifact[searchKey] === name &&
+          (artifact.tag === tag || artifact.uid === tag)
+        )
       } else if (match.params.pageTab === DATASETS_TAB) {
         return (
           artifact[searchKey] === name &&
@@ -660,6 +663,7 @@ export const fetchFeatureVectorRowData = async (
     setPageData(state => ({
       ...state,
       selectedRowData: {
+        ...state.selectedRowData,
         [item.name]: {
           content: [...parseFeatureVectors(result)],
           error: null,

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -190,6 +190,10 @@
           display: block;
           color: $topaz;
         }
+
+        .link {
+          color: $cornflowerBlue;
+        }
       }
 
       i {

--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -57,9 +57,11 @@ const ArtifactsTableRow = ({
           contentItem => {
             const key = contentItem.db_key ? 'db_key' : 'name'
 
-            return artifact.version
+            return artifact.version.value
               ? contentItem[key] === artifact.key.value &&
                   contentItem.tag === artifact.version.value
+              : contentItem.uid
+              ? contentItem.uid === artifact.uid.value
               : contentItem[key] === artifact.key.value
           }
         )
@@ -109,9 +111,10 @@ const ArtifactsTableRow = ({
               'table-body__row',
               ((selectedItem?.db_key &&
                 selectedItem?.db_key === currentItem?.db_key &&
-                selectedItem.tag === currentItem?.tag) ||
-                (selectedItem?.name &&
-                  selectedItem?.name === currentItem?.name &&
+                (selectedItem?.tag === currentItem?.tag ||
+                  selectedItem?.uid === currentItem?.uid)) ||
+                (selectedItem?.uid &&
+                  selectedItem?.uid === currentItem?.uid &&
                   selectedItem?.tag === currentItem?.tag)) &&
                 'row_active'
             )

--- a/src/elements/TableLinkCell/TableLinkCell.js
+++ b/src/elements/TableLinkCell/TableLinkCell.js
@@ -52,7 +52,7 @@ const TableLinkCell = ({
             className={itemNameCLassNames}
             template={<TextTooltipTemplate text={data.tooltip || data.value} />}
           >
-            {data.value}
+            <span className="link">{data.value}</span>
           </Tooltip>
           {link.match(/functions|feature-sets|feature-vectors/) &&
             data.value !== item.tag && (

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -182,11 +182,16 @@ const Content = ({
           }
         )
       } else {
-        artifactJson = yamlContent.allData.filter(yamlContentItem =>
+        const currentYamlContent =
+          yamlContent.selectedRowData.length > 0 ? 'selectedRowData' : 'allData'
+
+        artifactJson = yamlContent[currentYamlContent].filter(yamlContentItem =>
           match.params.pageTab === FEATURE_SETS_TAB ||
           match.params.pageTab === FEATURE_VECTORS_TAB
-            ? isEqual(yamlContentItem.metadata.name, item.name) &&
-              isEqual(yamlContentItem.metadata.tag, item.tag)
+            ? (item.tag &&
+                isEqual(yamlContentItem.metadata.name, item.name) &&
+                isEqual(yamlContentItem.metadata.tag, item.tag)) ||
+              isEqual(yamlContentItem.metadata.uid, item.uid)
             : isEqual(yamlContentItem.db_key, item.db_key)
         )
       }

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -20,7 +20,7 @@ import { formatDatetime } from './datetime'
 import { convertBytes } from './convertBytes'
 import { copyToClipboard } from './copyToClipboard'
 import { generateUri } from './generateUri'
-import { generateLinkPath, parseUri } from '../utils'
+import { generateLinkPath, parseUri, truncateUid } from '../utils'
 import { generateLinkToDetailsPanel } from './generateLinkToDetailsPanel'
 
 import { ReactComponent as SeverityOk } from '../images/severity-ok.svg'
@@ -566,11 +566,12 @@ const createFeatureVectorsRowData = (artifact, project) => ({
         FEATURE_VECTORS_TAB,
         artifact.name,
         artifact.tag,
-        tab
+        tab,
+        artifact.uid
       ),
     expandedCellContent: {
       class: 'artifacts_medium',
-      value: artifact.tag
+      value: artifact.tag || truncateUid(artifact.uid)
     }
   },
   description: {
@@ -598,6 +599,11 @@ const createFeatureVectorsRowData = (artifact, project) => ({
     class: 'artifacts_extra-small artifacts__icon',
     type: 'buttonCopyURI',
     actionHandler: (item, tab) => copyToClipboard(generateUri(item, tab))
+  },
+  uid: {
+    value: artifact.uid,
+    class: 'artifacts_small',
+    type: 'hidden'
   }
 })
 

--- a/src/utils/generateLinkToDetailsPanel.js
+++ b/src/utils/generateLinkToDetailsPanel.js
@@ -4,8 +4,9 @@ export const generateLinkToDetailsPanel = (
   tab,
   key,
   version,
-  detailsTab
+  detailsTab,
+  uid
 ) =>
   `/projects/${project}/${screen.toLowerCase()}${tab ? `/${tab}` : ''}/${key}${
-    version ? `/${version}` : ''
+    version ? `/${version}` : uid ? `/${uid}` : ''
   }/${detailsTab.toLowerCase()}`

--- a/src/utils/generateUsageSnippets.js
+++ b/src/utils/generateUsageSnippets.js
@@ -9,8 +9,12 @@ export const generateUsageSnippets = (
     featureSet =>
       featureSet.metadata.name === name && featureSet.metadata.tag === tag
   )
-  const [currentFeatureVector] = featureVectors.allData.filter(
-    featureVector => featureVector.name === name && featureVector.tag === tag
+  const currentFeatureVectorData =
+    featureVectors.selectedRowData.content[name] ?? featureVectors.allData
+  const [currentFeatureVector] = currentFeatureVectorData.filter(
+    featureVector =>
+      featureVector.name === name &&
+      (featureVector.tag === tag || featureVector.uid === tag)
   )
 
   if (pageTab === FEATURE_SETS_TAB) {


### PR DESCRIPTION
https://trello.com/c/YoTVHlXD/784-feature-vectors-list-breaks-on-applying-changes-and-expanding

- **Feature store**: Expanding grouped-by-name grouped had some empty “Name” cells for untagged versions, now the truncated UID is displayed for those
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/118102985-1880b100-b3e2-11eb-81f4-f7d36aa7acca.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/118102976-16b6ed80-b3e2-11eb-9230-6ae36c8338ca.png)

Jira ticket ML-537