### PR TITLE
[Jobs] Monitor: add “Aborted” to Status filter

### DIFF
--- a/src/components/FilterMenu/filterMenu.settings.js
+++ b/src/components/FilterMenu/filterMenu.settings.js
@@ -10,7 +10,8 @@ export const selectOptions = {
     { label: 'Completed', id: 'completed', status: 'completed' },
     { label: 'Running', id: 'running', status: 'running' },
     { label: 'Pending', id: 'pending', status: 'pending' },
-    { label: 'Error', id: 'error', status: 'error' }
+    { label: 'Error', id: 'error', status: 'error' },
+    { label: 'Aborted', id: 'aborted', status: 'aborted' }
   ],
   groupBy: [
     { label: 'None', id: 'none' },


### PR DESCRIPTION
https://trello.com/c/BKY824cm/792-jobs-monitor-add-aborted-to-status-filter

- **Jobs**: In “Monitor” tab, added “Aborted” option to the dropdown menu of the “Status” filter
  ![image](https://user-images.githubusercontent.com/13918850/118629751-907e1b00-b7d6-11eb-998e-4c00b206d149.png)

Jira ticket ML-552