### PR TITLE
[Feature vectors] Requested Features: alias edit issue

### DIFF
--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -121,6 +121,12 @@ const Details = ({
         payload: '0'
       })
     }
+
+    return () => {
+      detailsDispatch({
+        type: detailsActions.RESET_CHANGES
+      })
+    }
   }, [pageData.page, selectedItem.uid])
 
   useEffect(() => {

--- a/src/components/Details/detailsReducer.js
+++ b/src/components/Details/detailsReducer.js
@@ -38,10 +38,7 @@ export const detailsReducer = (state, { type, payload }) => {
     case detailsActions.RESET_CHANGES:
       return {
         ...state,
-        changes: {
-          counter: 0,
-          data: {}
-        }
+        changes: initialState.changes
       }
     case detailsActions.SET_CHANGES_COUNTER:
       return {

--- a/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
+++ b/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
@@ -44,13 +44,22 @@ const DetailsRequestedFeatures = ({
   const [editableItem, setEditableItem] = useState(null)
 
   useEffect(() => {
+    return () => {
+      setEditableItem(null)
+    }
+  }, [selectedItem])
+
+  useEffect(() => {
     setCurrentData(changes.data.features ?? selectedItem.specFeatures)
 
     return () => {
       setConfirmDialogData({ index: null, featureName: null })
       setCurrentData([])
+      detailsRequestedFeaturesDispatch({
+        type: detailsRequestedFeaturesActions.RESET_EDIT_MODE
+      })
     }
-  }, [changes.data, detailsDispatch, selectedItem])
+  }, [changes.data.features, selectedItem.specFeatures])
 
   const handleItemClick = (field, fieldType, info, index) => {
     setEditableItem(index)

--- a/src/components/DetailsRequestedFeatures/detailsRequestedFeaturesReducer.js
+++ b/src/components/DetailsRequestedFeatures/detailsRequestedFeaturesReducer.js
@@ -7,6 +7,7 @@ export const initialState = {
 }
 
 export const detailsRequestedFeaturesActions = {
+  RESET_EDIT_MODE: 'RESET_EDIT_MODE',
   SET_EDIT_MODE: 'SET_EDIT_MODE',
   SET_EDIT_MODE_FIELD_TYPE: 'SET_EDIT_MODE_FIELD_TYPE',
   SET_FIELDS_DATA: 'SET_FIELDS_DATA'
@@ -14,6 +15,11 @@ export const detailsRequestedFeaturesActions = {
 
 export const detailsRequestedFeaturesReducer = (state, { type, payload }) => {
   switch (type) {
+    case detailsRequestedFeaturesActions.RESET_EDIT_MODE:
+      return {
+        ...state,
+        editMode: initialState.editMode
+      }
     case detailsRequestedFeaturesActions.SET_EDIT_MODE:
       return {
         ...state,


### PR DESCRIPTION
https://trello.com/c/GESIEfGN/812-feature-vectors-requested-features-alias-edit-issue

- **Feature vectors**: In “Requested features” tab, when a feature‘s alias was in edit mode, switching to another feature vector kept the edit mode instead of resetting. Demonstration of bug:
  ![feature-vector-alias-bug](https://user-images.githubusercontent.com/13918850/118632174-d340f280-b7d8-11eb-9ee8-8142e8c5a48f.gif)

Jira ticket ML-487