### PR TITLE
[Datasets] Error on expanding row

### DIFF
--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -54,7 +54,7 @@ export default {
   },
   getDataSet: item => {
     return fetchArtifacts(
-      item,
+      {},
       `/artifacts?project=${item.project}&name=${item.db_key}&tag=*`
     )
   },


### PR DESCRIPTION
- **Datasets**: Sometimes expanding a grouped-by-name row would had a row which displayed an error
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/118830923-04e4b700-b8c8-11eb-947f-03712c9e96a8.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/118830938-06ae7a80-b8c8-11eb-955f-efc2cd1c28cc.png)

Jira ticket ML-565