### PR TITLE
Fix [Feature sets] Overview: remove redundant ")" in snippet

### DIFF
--- a/src/utils/generateUsageSnippets.js
+++ b/src/utils/generateUsageSnippets.js
@@ -26,7 +26,7 @@ export const generateUsageSnippets = (
 ]
 
 vector = fs.FeatureVector("<vector-name>",features=features,description="this is my vector")
-resp = fs.get_offline_features(vector))`
+resp = fs.get_offline_features(vector)`
       },
       {
         title: 'Getting online features:',


### PR DESCRIPTION
- **Feature sets**: In “Overview” tab in “Usage example” field, removed a redundant `)` symbol
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/119018661-ff10d380-b9a4-11eb-8408-9c1b8a4d3f7c.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/119018522-d4267f80-b9a4-11eb-855f-5f2a8b15a3f4.png)

Relates to feature https://github.com/mlrun/ui/pull/505 [v0.6.3-RC3](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc3) ML-309 
Originates in https://github.com/mlrun/ui/pull/546 [v0.6.3-RC11](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc11) ML-309

Jira ticket ML-570