### PR TITLE
[General] Name filter should not use exact match

### DIFF
--- a/src/actions/artifacts.js
+++ b/src/actions/artifacts.js
@@ -259,11 +259,11 @@ const artifactsAction = {
     type: FETCH_FEATURE_VECTOR_SUCCESS,
     payload: featureSets
   }),
-  fetchFeatureVectors: (item, project) => dispatch => {
+  fetchFeatureVectors: (item, project, config) => dispatch => {
     dispatch(artifactsAction.fetchFeatureVectorsBegin())
 
     return artifactsApi
-      .getFeatureVectors(item, project)
+      .getFeatureVectors(item, project, config)
       .then(response => {
         let featureVectors = parseFeatureVectors(response.data.feature_vectors)
 

--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -21,7 +21,7 @@ const fetchArtifacts = (item, path, config, withLatestTag) => {
   }
 
   if (item?.name) {
-    params.name = item.name
+    params.name = `~${item.name}`
   }
 
   return mainHttpClient.get(path, { ...config, params })

--- a/src/api/functions-api.js
+++ b/src/api/functions-api.js
@@ -16,7 +16,7 @@ export default {
     }
 
     if (name) {
-      params.name = name
+      params.name = `~${name}`
     }
 
     return mainHttpClient.get('/funcs', { params })

--- a/src/api/jobs-api.js
+++ b/src/api/jobs-api.js
@@ -31,7 +31,7 @@ export default {
     }
 
     if (filters?.name) {
-      params.name = filters.name
+      params.name = `~${filters.name}`
     }
 
     if (filters?.state) {
@@ -63,7 +63,7 @@ export default {
     }
 
     if (filters?.name) {
-      params.name = filters.name
+      params.name = `~${filters.name}`
     }
 
     if (filters?.labels) {

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -84,7 +84,7 @@ const FeatureStore = ({
         match.params.pageTab
       )
 
-      if (data.content?.length > 0) {
+      if (data.content) {
         setContent(data.content)
         setYamlContent(state => ({ ...state, allData: data.yamlContent }))
       }

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -373,6 +373,9 @@ export const handleFetchData = async (
     if (result) {
       data.content = parseFeatureVectors(result)
       data.yamlContent = result
+    } else {
+      data.content = null
+      data.yamlContent = null
     }
   }
 


### PR DESCRIPTION
https://trello.com/c/Hngajfj0/820-general-name-filter-should-not-use-exact-match

- **General**: Changed the “Name” filter in various screen to use **non**-exact match (`name=~value` instead of `name=value`)

Relates to backend PR https://github.com/mlrun/mlrun/pull/923 [v0.6.3-RC11](https://github.com/mlrun/mlrun/releases/tag/v0.6.3-rc11)

Jira ticket ML-573