### PR TITLE
[General] Name column: value is cropped without ellipsis 

### DIFF
--- a/src/elements/TableLinkCell/TableLinkCell.js
+++ b/src/elements/TableLinkCell/TableLinkCell.js
@@ -27,7 +27,6 @@ const TableLinkCell = ({
   const itemNameCLassNames = classnames(
     'link',
     'item-name',
-    'data-ellipsis',
     link.match(/functions/) && 'function-name'
   )
   const state = item.state || item.endpoint?.status?.state
@@ -47,12 +46,12 @@ const TableLinkCell = ({
         onClick={() => selectItem(item)}
         className="data-ellipsis"
       >
-        <div className="name-wrapper data-ellipsis">
+        <div className="name-wrapper">
           <Tooltip
             className={itemNameCLassNames}
             template={<TextTooltipTemplate text={data.tooltip || data.value} />}
           >
-            <span className="link">{data.value}</span>
+            <span className="link data-ellipsis">{data.value}</span>
           </Tooltip>
           {link.match(/functions|feature-sets|feature-vectors/) &&
             data.value !== item.tag && (


### PR DESCRIPTION
https://trello.com/c/d4yVkxdk/825-general-tables-name-is-cropped

- **General**: Values in “Name” column of various screens was cropped on overflow without an ellipsis
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/119533762-dca8fc80-bd8e-11eb-8c2d-c23fa19a3a58.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/119533768-df0b5680-bd8e-11eb-96f5-0e8f75a1ea14.png)

Jira ticket ML-601