### PR TITLE
[Feature sets] Version is disregarded on creation

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
@@ -67,7 +67,7 @@ const FeatureSetsPanelTitleView = ({
               }))
             }
             onBlur={event => {
-              if (event.target.length > 0) {
+              if (event.target.value.length > 0) {
                 setNewFeatureSetVersion(event.target.value)
               }
             }}


### PR DESCRIPTION
https://trello.com/c/H5ne1m55/826-feature-sets-version-is-disregarded-on-creation

- **Feature sets**: When creating a new feature set the “Version” field was disregarded, the request was sent with an empty string for `metadata.tag` and hence the feature set was always created with tag `latest` which is the default on backend.

Related to feature https://github.com/mlrun/ui/pull/510 [v0.6.3-RC4](https://github.com/mlrun/ui/releases/tag/v0.6.3-rc4) ML-231

Jira ticket ML-604