### PR TITLE
[Projects] Sort projects dropdown is transparent

### DIFF
--- a/src/common/Sort/sort.scss
+++ b/src/common/Sort/sort.scss
@@ -21,6 +21,7 @@
     max-height: 250px;
     overflow-y: auto;
     color: $mulledWineTwo;
+    background-color: $white;
     border: $primaryBorder;
     border-radius: 2px;
     box-shadow: $filterShadow;


### PR DESCRIPTION
https://trello.com/c/OsiNS6E4/830-projects-sort-projects-dropdown-is-transparent

- **Projects**: Sort-by dropdown menu had transparent background.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/119805926-68836b80-beea-11eb-916d-6dae082af469.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/119806040-8355e000-beea-11eb-9b52-dc4ebe8e2038.png)

Jira ticket ML-610