### PR TITLE
[Job panel] Omit `selector` when Result is empty

### DIFF
--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -489,6 +489,8 @@ export const generateRequestData = (
 
   if (jobsStore.newJob.task.spec.selector.result.length > 0) {
     spec.selector = `${jobsStore.newJob.task.spec.selector.criteria}.${jobsStore.newJob.task.spec.selector.result}`
+  } else {
+    delete spec.selector
   }
 
   return {

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -479,6 +479,18 @@ export const generateRequestData = (
     }
   }
 
+  const spec = {
+    ...jobsStore.newJob.task.spec,
+    function: func,
+    handler: panelState.currentFunctionInfo.method,
+    input_path: panelState.inputPath,
+    output_path: panelState.outputPath
+  }
+
+  if (jobsStore.newJob.task.spec.selector.result.length > 0) {
+    spec.selector = `${jobsStore.newJob.task.spec.selector.criteria}.${jobsStore.newJob.task.spec.selector.result}`
+  }
+
   return {
     ...jobsStore.newJob,
     schedule: cronString,
@@ -496,14 +508,7 @@ export const generateRequestData = (
         project,
         labels
       },
-      spec: {
-        ...jobsStore.newJob.task.spec,
-        function: func,
-        handler: panelState.currentFunctionInfo.method,
-        input_path: panelState.inputPath,
-        output_path: panelState.outputPath,
-        selector: `${jobsStore.newJob.task.spec.selector.criteria}.${jobsStore.newJob.task.spec.selector.result}`
-      }
+      spec
     }
   }
 }


### PR DESCRIPTION
https://trello.com/c/YighARU8/837-job-panel-omit-selector-when-result-is-empty

- **Job panel**: Removed `task.spec.selector` from request body when the “Result” field is empty.

Jira ticket ML-619