### PR TITLE
[Feature Vectors] Delete feature pop-up isn't aligned

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -233,6 +233,10 @@
     }
 
     .pop-up-dialog {
+      position: fixed;
+      top: 50%;
+      transform: translateY(-50%);
+
       &__overlay {
         position: absolute;
       }

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -232,16 +232,6 @@
       }
     }
 
-    .pop-up-dialog {
-      position: fixed;
-      top: 50%;
-      transform: translateY(-50%);
-
-      &__overlay {
-        position: absolute;
-      }
-    }
-
     &.pop-up-dialog-opened {
       overflow-y: hidden;
     }

--- a/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
+++ b/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
@@ -247,39 +247,39 @@ const DetailsRequestedFeatures = ({
                     />
                   </Tooltip>
                 </div>
-                {confirmDialogData.feature && (
-                  <PopUpDialog
-                    headerText={`Delete feature ${confirmDialogData.feature} from vector ${match.params.name}?`}
-                    closePopUp={() => {
-                      setConfirmDialogData({ index: null, feature: null })
-                    }}
-                  >
-                    <div>The feature could be added back later.</div>
-                    <div className="pop-up-dialog__footer-container">
-                      <Button
-                        variant="tertiary"
-                        label="Cancel"
-                        className="pop-up-dialog__btn_cancel"
-                        onClick={() => {
-                          setConfirmDialogData({
-                            index: null,
-                            feature: null
-                          })
-                        }}
-                      />
-                      <Button
-                        label="Delete"
-                        onClick={() => handleDelete(confirmDialogData.index)}
-                        variant="danger"
-                      />
-                    </div>
-                  </PopUpDialog>
-                )}
               </div>
             )
           })}
         </div>
       </div>
+      {confirmDialogData.feature && (
+        <PopUpDialog
+          headerText={`Delete feature ${confirmDialogData.feature} from vector ${match.params.name}?`}
+          closePopUp={() => {
+            setConfirmDialogData({ index: null, feature: null })
+          }}
+        >
+          <div>The feature could be added back later.</div>
+          <div className="pop-up-dialog__footer-container">
+            <Button
+              variant="tertiary"
+              label="Cancel"
+              className="pop-up-dialog__btn_cancel"
+              onClick={() => {
+                setConfirmDialogData({
+                  index: null,
+                  feature: null
+                })
+              }}
+            />
+            <Button
+              label="Delete"
+              onClick={() => handleDelete(confirmDialogData.index)}
+              variant="danger"
+            />
+          </div>
+        </PopUpDialog>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
https://trello.com/c/q4ZC7t7z/834-feature-vectors-delete-feature-pop-up-isnt-aligned

- General: Pop-up dialog was mispositioned and did not cover the entire relevant area (including its backdrop overlay).
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/120002500-939ab780-bfdd-11eb-94df-9793b32bb977.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/120002509-94cbe480-bfdd-11eb-8bf4-c68dddf57d0a.png)

Jira ticket ML-621