### PR TITLE
[Monitor] Notification doesn't disappear on "Schedule" job

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -5,7 +5,6 @@ import { isEmpty, map } from 'lodash'
 
 import TableView from './TableView'
 import PreviewModal from '../../elements/PreviewModal/PreviewModal'
-import Notification from '../../common/Notification/Notification'
 
 import createJobsContent from '../../utils/createJobsContent'
 import { generateTableContent } from '../../utils/generateTableContent'
@@ -164,7 +163,6 @@ const Table = ({
         toggleConvertToYaml={toggleConvertToYaml}
         workflows={workflows}
       />
-      <Notification />
       {previewArtifact.isPreview && (
         <PreviewModal item={previewArtifact.selectedItem} />
       )}

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -11,6 +11,7 @@ import Table from '../../components/Table/Table'
 import ContentMenu from '../../elements/ContentMenu/ContentMenu'
 import NoData from '../../common/NoData/NoData'
 import PageActionsMenu from '../../common/PageActionsMenu/PageActionsMenu'
+import Notification from '../../common/Notification/Notification'
 
 import {
   ARTIFACTS_PAGE,
@@ -260,6 +261,7 @@ const Content = ({
             <NoData />
           )}
         </div>
+        <Notification />
       </div>
     </>
   )


### PR DESCRIPTION
https://trello.com/c/X1VMjPVM/831-monitor-notification-doesnt-disappear-on-schedule-job

- **Jobs**: Selecting to re-run a job and then scheduling it for later successfully ended up showing the success notification endlessly.
  ![image](https://user-images.githubusercontent.com/13918850/120218205-0d32df80-c242-11eb-8e79-df8ea7245221.png)

Jira ticket ML-641