### PR TITLE
[Artifacts] Use best_iteration=true instead of iter=0

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -94,6 +94,11 @@ const App = () => {
               path="/projects/:projectName/feature-store/:pageTab/:name/:tag/:tab"
               render={routeProps => <FeatureStore {...routeProps} />}
             />
+            <Route
+              exact
+              path="/projects/:projectName/feature-store/:pageTab/:name/:tag/:iter/:tab"
+              render={routeProps => <FeatureStore {...routeProps} />}
+            />
             <Redirect
               exact
               from="/projects/:projectName/models"
@@ -116,12 +121,22 @@ const App = () => {
             />
             <Route
               exact
+              path="/projects/:projectName/models/:pageTab/:name/:tag/:iter/:tab"
+              render={routeProps => <Models {...routeProps} />}
+            />
+            <Route
+              exact
               path="/projects/:projectName/files"
               render={routeProps => <Files {...routeProps} />}
             />
             <Route
               exact
               path="/projects/:projectName/files/:name/:tag/:tab"
+              render={routeProps => <Files {...routeProps} />}
+            />
+            <Route
+              exact
+              path="/projects/:projectName/files/:name/:tag/:iter/:tab"
               render={routeProps => <Files {...routeProps} />}
             />
             <Redirect to="/projects" />

--- a/src/actions/artifacts.js
+++ b/src/actions/artifacts.js
@@ -165,9 +165,9 @@ const artifactsAction = {
     payload: artifactsList
   }),
   fetchArtifactTags: project => () => artifactsApi.getArtifactTag(project),
-  fetchDataSet: (project, dataSet, iter) => dispatch => {
+  fetchDataSet: (project, dataSet) => dispatch => {
     return artifactsApi
-      .getDataSet(project, dataSet, iter)
+      .getDataSet(project, dataSet)
       .then(response => {
         dispatch(
           artifactsAction.fetchDataSetSuccess({
@@ -339,9 +339,9 @@ const artifactsAction = {
     type: FETCH_FEATURES_SUCCESS,
     payload: features
   }),
-  fetchFile: (project, file, iter) => dispatch => {
+  fetchFile: (project, file) => dispatch => {
     return artifactsApi
-      .getFile(project, file, iter)
+      .getFile(project, file)
       .then(response => {
         dispatch(
           artifactsAction.fetchFileSuccess({
@@ -435,9 +435,9 @@ const artifactsAction = {
     type: FETCH_MODEL_ENDPOINTS_SUCCESS,
     payload: models
   }),
-  fetchModel: (project, model, iter) => dispatch => {
+  fetchModel: (project, model) => dispatch => {
     return artifactsApi
-      .getModel(project, model, iter)
+      .getModel(project, model)
       .then(response => {
         dispatch(
           artifactsAction.fetchModelSuccess({

--- a/src/actions/artifacts.js
+++ b/src/actions/artifacts.js
@@ -165,14 +165,15 @@ const artifactsAction = {
     payload: artifactsList
   }),
   fetchArtifactTags: project => () => artifactsApi.getArtifactTag(project),
-  fetchDataSet: (project, dataSet) => dispatch => {
+  fetchDataSet: (project, dataSet, iter) => dispatch => {
     return artifactsApi
       .getDataSet(project, dataSet)
       .then(response => {
         dispatch(
           artifactsAction.fetchDataSetSuccess({
             [dataSet]: generateArtifacts(
-              filterArtifacts(response.data.artifacts)
+              filterArtifacts(response.data.artifacts),
+              iter
             )
           })
         )
@@ -339,13 +340,16 @@ const artifactsAction = {
     type: FETCH_FEATURES_SUCCESS,
     payload: features
   }),
-  fetchFile: (project, file) => dispatch => {
+  fetchFile: (project, file, iter) => dispatch => {
     return artifactsApi
       .getFile(project, file)
       .then(response => {
         dispatch(
           artifactsAction.fetchFileSuccess({
-            [file]: generateArtifacts(filterArtifacts(response.data.artifacts))
+            [file]: generateArtifacts(
+              filterArtifacts(response.data.artifacts),
+              iter
+            )
           })
         )
 
@@ -435,13 +439,16 @@ const artifactsAction = {
     type: FETCH_MODEL_ENDPOINTS_SUCCESS,
     payload: models
   }),
-  fetchModel: (project, model) => dispatch => {
+  fetchModel: (project, model, iter) => dispatch => {
     return artifactsApi
       .getModel(project, model)
       .then(response => {
         dispatch(
           artifactsAction.fetchModelSuccess({
-            [model]: generateArtifacts(filterArtifacts(response.data.artifacts))
+            [model]: generateArtifacts(
+              filterArtifacts(response.data.artifacts),
+              iter
+            )
           })
         )
 

--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -13,7 +13,7 @@ const fetchArtifacts = (path, filters, config = {}, withLatestTag) => {
   }
 
   if (filters?.iter === 'iter') {
-    params.iter = 0
+    params['best-iteration'] = true
   }
 
   if (filters?.tag && (withLatestTag || !/latest/i.test(filters.tag))) {
@@ -66,10 +66,10 @@ export default {
       params: { project }
     })
   },
-  getDataSet: (project, dataSet, iter) => {
+  getDataSet: (project, dataSet) => {
     return fetchArtifacts(
       '/artifacts',
-      { iter },
+      {},
       { params: { project, name: dataSet, tag: '*' } }
     )
   },
@@ -107,10 +107,10 @@ export default {
     }),
   getFeatures: (project, filters) =>
     fetchArtifacts(`/projects/${project}/${FEATURES_TAB}`, filters, {}, true),
-  getFile: (project, file, iter) => {
+  getFile: (project, file) => {
     return fetchArtifacts(
       '/artifacts',
-      { iter },
+      {},
       { params: { project, name: file, tag: '*' } }
     )
   },
@@ -122,10 +122,10 @@ export default {
       true
     )
   },
-  getModel: (project, model, iter) => {
+  getModel: (project, model) => {
     return fetchArtifacts(
       '/artifacts',
-      { iter },
+      {},
       { params: { project, name: model, tag: '*' } }
     )
   },

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -65,7 +65,6 @@ const FeatureStore = ({
   })
   const [groupFilter, setGroupFilter] = useState('')
   const [selectedItem, setSelectedItem] = useState({})
-  const [iter, setIter] = useState('')
   const [isPopupDialogOpen, setIsPopupDialogOpen] = useState(false)
   const [featureSetsPanelIsOpen, setFeatureSetsPanelIsOpen] = useState(false)
   const [pageData, setPageData] = useState(pageDataInitialState)
@@ -174,12 +173,11 @@ const FeatureStore = ({
           fetchDataSet,
           item,
           setPageData,
-          setYamlContent,
-          iter
+          setYamlContent
         )
       }
     },
-    [fetchDataSet, fetchFeature, fetchFeatureVector, iter, match.params.pageTab]
+    [fetchDataSet, fetchFeature, fetchFeatureVector, match.params.pageTab]
   )
 
   const handleExpandRow = useCallback(
@@ -199,12 +197,10 @@ const FeatureStore = ({
       tag: 'latest',
       iter: match.params.pageTab === DATASETS_TAB ? 'iter' : ''
     })
-    setIter(match.params.pageTab === DATASETS_TAB ? 'iter' : '')
 
     return () => {
       setArtifactFilter({ tag: 'latest', labels: '', name: '' })
       setContent([])
-      setIter('iter')
       setYamlContent({
         allData: [],
         selectedRowData: []
@@ -391,7 +387,6 @@ const FeatureStore = ({
         pageData={pageData}
         refresh={fetchData}
         selectedItem={selectedItem.item}
-        setIter={setIter}
         yamlContent={yamlContent}
       />
       {isPopupDialogOpen && (

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -65,6 +65,7 @@ const FeatureStore = ({
   })
   const [groupFilter, setGroupFilter] = useState('')
   const [selectedItem, setSelectedItem] = useState({})
+  const [iter, setIter] = useState('')
   const [isPopupDialogOpen, setIsPopupDialogOpen] = useState(false)
   const [featureSetsPanelIsOpen, setFeatureSetsPanelIsOpen] = useState(false)
   const [pageData, setPageData] = useState(pageDataInitialState)
@@ -173,11 +174,12 @@ const FeatureStore = ({
           fetchDataSet,
           item,
           setPageData,
-          setYamlContent
+          setYamlContent,
+          iter
         )
       }
     },
-    [fetchDataSet, fetchFeature, fetchFeatureVector, match.params.pageTab]
+    [fetchDataSet, fetchFeature, fetchFeatureVector, iter, match.params.pageTab]
   )
 
   const handleExpandRow = useCallback(
@@ -387,6 +389,7 @@ const FeatureStore = ({
         pageData={pageData}
         refresh={fetchData}
         selectedItem={selectedItem.item}
+        setIter={setIter}
         yamlContent={yamlContent}
       />
       {isPopupDialogOpen && (

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -435,7 +435,7 @@ export const navigateToDetailsPane = (
         )
       } else if (match.params.pageTab === DATASETS_TAB) {
         return iter
-          ? iter === artifact.iter &&
+          ? Number(iter) === artifact.iter &&
               artifact[searchKey] === name &&
               (artifact.tag === tag || artifact.tree === tag)
           : artifact[searchKey] === name &&

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -388,7 +388,7 @@ export const navigateToDetailsPane = (
   match,
   setSelectedItem
 ) => {
-  const { name, tag } = match.params
+  const { name, tag, iter } = match.params
   let artifacts = []
 
   if (
@@ -434,10 +434,12 @@ export const navigateToDetailsPane = (
           (artifact.tag === tag || artifact.uid === tag)
         )
       } else if (match.params.pageTab === DATASETS_TAB) {
-        return (
-          artifact[searchKey] === name &&
-          (artifact.tag === tag || artifact.tree === tag)
-        )
+        return iter
+          ? iter === artifact.iter &&
+              artifact[searchKey] === name &&
+              (artifact.tag === tag || artifact.tree === tag)
+          : artifact[searchKey] === name &&
+              (artifact.tag === tag || artifact.tree === tag)
       } else {
         return artifact[searchKey] === name
       }
@@ -691,7 +693,8 @@ export const fetchDataSetRowData = async (
   fetchDataSet,
   item,
   setPageData,
-  setYamlContent
+  setYamlContent,
+  iter
 ) => {
   let result = []
 
@@ -706,7 +709,7 @@ export const fetchDataSetRowData = async (
   }))
 
   try {
-    result = await fetchDataSet(item.project, item.db_key)
+    result = await fetchDataSet(item.project, item.db_key, iter)
   } catch (error) {
     setPageData(state => ({
       ...state,
@@ -732,7 +735,7 @@ export const fetchDataSetRowData = async (
         selectedRowData: {
           ...state.selectedRowData,
           [item.db_key]: {
-            content: [...generateArtifacts(filterArtifacts(result))],
+            content: [...generateArtifacts(filterArtifacts(result), iter)],
             error: null,
             loading: false
           }

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -691,8 +691,7 @@ export const fetchDataSetRowData = async (
   fetchDataSet,
   item,
   setPageData,
-  setYamlContent,
-  iter
+  setYamlContent
 ) => {
   let result = []
 
@@ -707,7 +706,7 @@ export const fetchDataSetRowData = async (
   }))
 
   try {
-    result = await fetchDataSet(item.project, item.db_key, iter)
+    result = await fetchDataSet(item.project, item.db_key)
   } catch (error) {
     setPageData(state => ({
       ...state,

--- a/src/components/Files/Files.js
+++ b/src/components/Files/Files.js
@@ -40,7 +40,6 @@ const Files = ({
   const [groupFilter, setGroupFilter] = useState('')
   const [selectedFile, setSelectedFile] = useState({})
   const [isPopupDialogOpen, setIsPopupDialogOpen] = useState(false)
-  const [iter, setIter] = useState('')
   const [pageData, setPageData] = useState({
     detailsMenu,
     filters,
@@ -95,7 +94,7 @@ const Files = ({
       }))
 
       try {
-        result = await fetchFile(item.project, item.db_key, iter)
+        result = await fetchFile(item.project, item.db_key)
       } catch (error) {
         setPageData(state => ({
           ...state,
@@ -130,7 +129,7 @@ const Files = ({
         })
       }
     },
-    [fetchFile, iter]
+    [fetchFile]
   )
 
   const handleExpandRow = useCallback((item, isCollapse) => {
@@ -144,12 +143,10 @@ const Files = ({
 
   useEffect(() => {
     fetchData({ tag: 'latest', iter: 'iter' })
-    setIter('iter')
 
     return () => {
       setGroupFilter('')
       setFiles([])
-      setIter('iter')
       removeFiles()
       setSelectedFile({})
       setYamlContent({
@@ -235,7 +232,6 @@ const Files = ({
         pageData={pageData}
         refresh={fetchData}
         selectedItem={selectedFile.item}
-        setIter={setIter}
         yamlContent={yamlContent}
       />
       {isPopupDialogOpen && (

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -45,6 +45,7 @@ const FilterMenu = ({
   onChange,
   page,
   setGroupFilter,
+  setIteration,
   showUntagged,
   toggleShowUntagged
 }) => {
@@ -201,6 +202,7 @@ const FilterMenu = ({
       iter: iter === iteration ? 'iter' : ''
     })
     setIter(state => (state === iteration ? 'iter' : iteration))
+    setIteration(state => (state === iteration ? 'iter' : iteration))
   }
 
   return (
@@ -362,6 +364,7 @@ FilterMenu.defaultProps = {
   groupFilter: '',
   handleArtifactFilterTree: null,
   setGroupFilter: null,
+  setIteration: () => {},
   showUntagged: '',
   toggleShowUntagged: null
 }
@@ -372,6 +375,7 @@ FilterMenu.propTypes = {
   groupFilter: PropTypes.string,
   handleArtifactFilterTree: PropTypes.func,
   setGroupFilter: PropTypes.func,
+  setIteration: PropTypes.func,
   showUntagged: PropTypes.string,
   toggleShowUntagged: PropTypes.func
 }

--- a/src/components/FilterMenu/FilterMenu.js
+++ b/src/components/FilterMenu/FilterMenu.js
@@ -45,7 +45,6 @@ const FilterMenu = ({
   onChange,
   page,
   setGroupFilter,
-  setIteration,
   showUntagged,
   toggleShowUntagged
 }) => {
@@ -202,7 +201,6 @@ const FilterMenu = ({
       iter: iter === iteration ? 'iter' : ''
     })
     setIter(state => (state === iteration ? 'iter' : iteration))
-    setIteration(state => (state === iteration ? 'iter' : iteration))
   }
 
   return (
@@ -364,7 +362,6 @@ FilterMenu.defaultProps = {
   groupFilter: '',
   handleArtifactFilterTree: null,
   setGroupFilter: null,
-  setIteration: () => {},
   showUntagged: '',
   toggleShowUntagged: null
 }
@@ -375,7 +372,6 @@ FilterMenu.propTypes = {
   groupFilter: PropTypes.string,
   handleArtifactFilterTree: PropTypes.func,
   setGroupFilter: PropTypes.func,
-  setIteration: () => {},
   showUntagged: PropTypes.string,
   toggleShowUntagged: PropTypes.func
 }

--- a/src/components/Models/Models.js
+++ b/src/components/Models/Models.js
@@ -40,6 +40,7 @@ const Models = ({
     setIsRegisterArtifactPopupOpen
   ] = useState(false)
   const [isDeployPopupOpen, setIsDeployPopupOpen] = useState(false)
+  const [iter, setIter] = useState('')
   const [groupFilter, setGroupFilter] = useState('')
   const [yamlContent, setYamlContent] = useState({
     allData: [],
@@ -120,7 +121,7 @@ const Models = ({
       }))
 
       try {
-        result = await fetchModel(item.project, item.db_key)
+        result = await fetchModel(item.project, item.db_key, iter)
       } catch (error) {
         setPageData(state => ({
           ...state,
@@ -146,7 +147,7 @@ const Models = ({
             selectedRowData: {
               ...state.selectedRowData,
               [item.db_key]: {
-                content: [...generateArtifacts(filterArtifacts(result))],
+                content: [...generateArtifacts(filterArtifacts(result), iter)],
                 error: null,
                 loading: false
               }
@@ -155,7 +156,7 @@ const Models = ({
         })
       }
     },
-    [fetchModel]
+    [fetchModel, iter]
   )
 
   const handleExpandRow = useCallback((item, isCollapse) => {
@@ -220,7 +221,7 @@ const Models = ({
         (match.params.pageTab === MODEL_ENDPOINTS_TAB &&
           artifactsStore.modelEndpoints.length > 0))
     ) {
-      const { name, tag } = match.params
+      const { name, tag, iter } = match.params
 
       if (match.params.pageTab === MODELS_TAB) {
         checkForSelectedModel(
@@ -229,7 +230,8 @@ const Models = ({
           artifactsStore.models,
           name,
           setSelectedModel,
-          tag
+          tag,
+          iter
         )
       } else if (match.params.pageTab === MODEL_ENDPOINTS_TAB) {
         checkForSelectedModelEndpoint(
@@ -283,6 +285,7 @@ const Models = ({
         pageData={pageData}
         refresh={fetchData}
         selectedItem={selectedModel.item}
+        setIter={setIter}
         yamlContent={yamlContent}
       />
       {isRegisterArtifactPopupOpen && (

--- a/src/components/Models/Models.js
+++ b/src/components/Models/Models.js
@@ -40,7 +40,6 @@ const Models = ({
     setIsRegisterArtifactPopupOpen
   ] = useState(false)
   const [isDeployPopupOpen, setIsDeployPopupOpen] = useState(false)
-  const [iter, setIter] = useState('')
   const [groupFilter, setGroupFilter] = useState('')
   const [yamlContent, setYamlContent] = useState({
     allData: [],
@@ -121,7 +120,7 @@ const Models = ({
       }))
 
       try {
-        result = await fetchModel(item.project, item.db_key, iter)
+        result = await fetchModel(item.project, item.db_key)
       } catch (error) {
         setPageData(state => ({
           ...state,
@@ -156,7 +155,7 @@ const Models = ({
         })
       }
     },
-    [fetchModel, iter]
+    [fetchModel]
   )
 
   const handleExpandRow = useCallback((item, isCollapse) => {
@@ -173,7 +172,6 @@ const Models = ({
       tag: 'latest',
       iter: match.params.pageTab === MODELS_TAB ? 'iter' : ''
     })
-    setIter(match.params.pageTab === MODELS_TAB ? 'iter' : '')
 
     return () => {
       setContent([])
@@ -184,7 +182,6 @@ const Models = ({
         selectedRowData: []
       })
       setArtifactFilter({ tag: 'latest', labels: '', name: '' })
-      setIter('iter')
     }
   }, [fetchData, match.params.pageTab, removeModels, setArtifactFilter])
 
@@ -286,7 +283,6 @@ const Models = ({
         pageData={pageData}
         refresh={fetchData}
         selectedItem={selectedModel.item}
-        setIter={setIter}
         yamlContent={yamlContent}
       />
       {isRegisterArtifactPopupOpen && (

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -2,6 +2,7 @@ import { MODEL_ENDPOINTS_TAB, MODELS_PAGE, MODELS_TAB } from '../../constants'
 import { filterArtifacts } from '../../utils/filterArtifacts'
 import { generateArtifacts } from '../../utils/generateArtifacts'
 import { generateUri } from '../../utils/resources'
+import { searchArtifactItem } from '../../utils/searchArtifactItem'
 
 export const modelsInfoHeaders = [
   {
@@ -225,12 +226,11 @@ export const checkForSelectedModel = (
   models,
   modelName,
   setSelectedModel,
-  tag
+  tag,
+  iter
 ) => {
   const artifacts = models.selectedRowData.content[modelName] || models.allData
-  const searchItem = artifacts.find(
-    item => item.db_key === modelName && (item.tag === tag || item.tree === tag)
-  )
+  const searchItem = searchArtifactItem(artifacts, modelName, tag, iter)
 
   if (!searchItem) {
     history.push(

--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -9,10 +9,14 @@ import ErrorMessage from '../../common/ErrorMessage/ErrorMessage'
 
 import {
   ACTION_CELL_ID,
+  DATASETS_TAB,
   DETAILS_OVERVIEW_TAB,
   FEATURES_TAB,
-  MODEL_ENDPOINTS_TAB
+  FILES_PAGE,
+  MODEL_ENDPOINTS_TAB,
+  MODELS_TAB
 } from '../../constants'
+import { getArtifactReference } from '../../utils/resources'
 
 const ArtifactsTableRow = ({
   actionsMenu,
@@ -56,6 +60,16 @@ const ArtifactsTableRow = ({
             contentItem => {
               const key = contentItem.db_key ? 'db_key' : 'name'
 
+              if (
+                [MODELS_TAB, DATASETS_TAB].includes(match.params.pageTab) ||
+                pageData.page === FILES_PAGE
+              ) {
+                return (
+                  contentItem.db_key + getArtifactReference(contentItem) ===
+                  artifact.key.value + artifact.key.uniqueReference
+                )
+              }
+
               return artifact.version.value
                 ? contentItem[key] === artifact.key.value &&
                     contentItem.tag === artifact.version.value
@@ -76,7 +90,7 @@ const ArtifactsTableRow = ({
         })
       }
     },
-    [content, match.params.pageTab, pageData.selectedRowData]
+    [content, match.params.pageTab, pageData.page, pageData.selectedRowData]
   )
 
   useEffect(() => {
@@ -112,11 +126,16 @@ const ArtifactsTableRow = ({
           </div>
           {tableContent.map((artifact, index) => {
             const subRowCurrentItem = findCurrentItem(artifact)
+            const selectedItemReference = selectedItem.iter
+              ? getArtifactReference(selectedItem)
+              : ''
+            const subRowCurrentItemReference = getArtifactReference(
+              subRowCurrentItem ?? {}
+            )
+
             const subRowClassNames = classnames(
               'table-body__row',
-              ((selectedItem?.db_key &&
-                selectedItem?.db_key === subRowCurrentItem?.db_key &&
-                selectedItem?.tag === subRowCurrentItem?.tag) ||
+              (selectedItemReference === subRowCurrentItemReference ||
                 (selectedItem.uid &&
                   selectedItem?.uid === subRowCurrentItem?.uid &&
                   selectedItem?.tag === subRowCurrentItem?.tag)) &&

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -46,6 +46,7 @@ const Content = ({
   refresh,
   selectedItem,
   setGroupFilter,
+  setIter,
   setLoading,
   showUntagged,
   toggleShowUntagged,
@@ -228,6 +229,7 @@ const Content = ({
             onChange={refresh}
             page={pageData.page}
             setGroupFilter={setGroupFilter}
+            setIteration={setIter}
             showUntagged={showUntagged}
             toggleShowUntagged={toggleShowUntagged}
           />
@@ -272,6 +274,7 @@ Content.defaultProps = {
   handleSelectItem: () => {},
   selectedItem: {},
   setGroupFilter: () => {},
+  setIter: () => {},
   setLoading: () => {},
   showUntagged: '',
   toggleShowUntagged: null
@@ -289,6 +292,7 @@ Content.propTypes = {
   refresh: PropTypes.func.isRequired,
   selectedItem: PropTypes.shape({}),
   setGroupFilter: PropTypes.func,
+  setIter: PropTypes.func,
   setLoading: PropTypes.func,
   showUntagged: PropTypes.string,
   toggleShowUntagged: PropTypes.func,

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -46,7 +46,6 @@ const Content = ({
   refresh,
   selectedItem,
   setGroupFilter,
-  setIter,
   setLoading,
   showUntagged,
   toggleShowUntagged,
@@ -229,7 +228,6 @@ const Content = ({
             onChange={refresh}
             page={pageData.page}
             setGroupFilter={setGroupFilter}
-            setIteration={setIter}
             showUntagged={showUntagged}
             toggleShowUntagged={toggleShowUntagged}
           />
@@ -274,7 +272,6 @@ Content.defaultProps = {
   handleSelectItem: () => {},
   selectedItem: {},
   setGroupFilter: () => {},
-  setIter: () => {},
   setLoading: () => {},
   showUntagged: '',
   toggleShowUntagged: null
@@ -292,7 +289,6 @@ Content.propTypes = {
   refresh: PropTypes.func.isRequired,
   selectedItem: PropTypes.shape({}),
   setGroupFilter: PropTypes.func,
-  setIter: PropTypes.func,
   setLoading: PropTypes.func,
   showUntagged: PropTypes.string,
   toggleShowUntagged: PropTypes.func,

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -38,7 +38,18 @@ const createArtifactsContent = (
   project,
   isTablePanelOpen
 ) => {
-  return artifacts.map(artifact => {
+  let filteredArtifacts = artifacts
+
+  if (
+    filteredArtifacts.length > 1 &&
+    ([MODELS_TAB, DATASETS_TAB].includes(pageTab) || page === FILES_PAGE)
+  ) {
+    filteredArtifacts = artifacts.filter(
+      artifact => artifact.iter !== 0 && !artifact.link_iteration
+    )
+  }
+
+  return filteredArtifacts.map(artifact => {
     let rowData = []
 
     if (page === ARTIFACTS_PAGE) {

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -140,11 +140,11 @@ const createModelsRowData = (artifact, project) => {
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
-        value:
-          artifact.tag ||
-          `${truncateUid(artifact.tree)}${
-            artifact.iter ? ` #${artifact.iter}` : ''
-          }`,
+        value: artifact.tag
+          ? `${artifact.tag} #${artifact.iter}`
+          : `${truncateUid(artifact.tree)}${
+              artifact.iter ? ` #${artifact.iter}` : ''
+            }`,
         tooltip:
           artifact.tag ||
           `${artifact.tree}${artifact.iter ? ` #${artifact.iter}` : ''}`
@@ -222,11 +222,11 @@ const createFilesRowData = (artifact, project) => {
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
-        value:
-          artifact.tag ||
-          `${truncateUid(artifact.tree)}${
-            artifact.iter ? ` #${artifact.iter}` : ''
-          }`,
+        value: artifact.tag
+          ? `${artifact.tag} #${artifact.iter}`
+          : `${truncateUid(artifact.tree)}${
+              artifact.iter ? ` #${artifact.iter}` : ''
+            }`,
         tooltip:
           artifact.tag ||
           `${artifact.tree}${artifact.iter ? ` #${artifact.iter}` : ''}`
@@ -393,11 +393,11 @@ const createDatasetsRowData = (artifact, project) => {
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
-        value:
-          artifact.tag ||
-          `${truncateUid(artifact.tree)}${
-            artifact.iter ? ` #${artifact.iter}` : ''
-          }`,
+        value: artifact.tag
+          ? `${artifact.tag} #${artifact.iter}`
+          : `${truncateUid(artifact.tree)}${
+              artifact.iter ? ` #${artifact.iter}` : ''
+            }`,
         tooltip:
           artifact.tag ||
           `${artifact.tree}${artifact.iter ? ` #${artifact.iter}` : ''}`

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -19,7 +19,7 @@ import { parseKeyValues } from './object'
 import { formatDatetime } from './datetime'
 import { convertBytes } from './convertBytes'
 import { copyToClipboard } from './copyToClipboard'
-import { generateUri } from './resources'
+import { generateUri, getArtifactReference } from './resources'
 import { generateLinkPath, parseUri, truncateUid } from '../utils'
 import { generateLinkToDetailsPanel } from './generateLinkToDetailsPanel'
 
@@ -44,9 +44,7 @@ const createArtifactsContent = (
     filteredArtifacts.length > 1 &&
     ([MODELS_TAB, DATASETS_TAB].includes(pageTab) || page === FILES_PAGE)
   ) {
-    filteredArtifacts = artifacts.filter(
-      artifact => artifact.iter !== 0 && !artifact.link_iteration
-    )
+    filteredArtifacts = artifacts.filter(artifact => !artifact.link_iteration)
   }
 
   return filteredArtifacts.map(artifact => {
@@ -126,6 +124,7 @@ const createArtifactsRowData = artifact => {
 const createModelsRowData = (artifact, project) => {
   return {
     key: {
+      uniqueReference: getArtifactReference(artifact),
       value: artifact.db_key,
       class: 'artifacts_medium',
       getLink: tab =>
@@ -135,7 +134,9 @@ const createModelsRowData = (artifact, project) => {
           MODELS_TAB,
           artifact.db_key,
           artifact.tag,
-          tab
+          tab,
+          artifact.tree,
+          artifact.iter
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
@@ -205,6 +206,7 @@ const createModelsRowData = (artifact, project) => {
 const createFilesRowData = (artifact, project) => {
   return {
     key: {
+      uniqueReference: getArtifactReference(artifact),
       value: artifact.db_key,
       class: 'artifacts_medium',
       getLink: tab =>
@@ -214,7 +216,9 @@ const createFilesRowData = (artifact, project) => {
           null,
           artifact.db_key,
           artifact.tag,
-          tab
+          tab,
+          artifact.tree,
+          artifact.iter
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
@@ -373,6 +377,7 @@ const createModelEndpointsRowData = (artifact, project) => {
 const createDatasetsRowData = (artifact, project) => {
   return {
     key: {
+      uniqueReference: getArtifactReference(artifact),
       value: artifact.db_key,
       class: 'artifacts_medium',
       getLink: tab =>
@@ -382,7 +387,9 @@ const createDatasetsRowData = (artifact, project) => {
           DATASETS_TAB,
           artifact.db_key,
           artifact.tag,
-          tab
+          tab,
+          artifact.tree,
+          artifact.iter
         ),
       expandedCellContent: {
         class: 'artifacts_medium',

--- a/src/utils/generateArtifacts.js
+++ b/src/utils/generateArtifacts.js
@@ -1,12 +1,14 @@
 import { generateArtifactPreviewData } from './generateArtifactPreviewData'
 import { maxBy, flatten } from 'lodash'
 
-export const generateArtifacts = artifacts =>
+export const generateArtifacts = (artifacts, iter) =>
   flatten(
     artifacts
       .map(artifact => {
         const { link_iteration } = artifact.link_iteration ?? {}
-        let generatedArtifacts = artifact.link_iteration
+        let generatedArtifacts = iter
+          ? artifact.data
+          : artifact.link_iteration
           ? artifact.data.filter(dataItem => dataItem.iter === link_iteration)
           : [maxBy(artifact.data, 'updated')]
 

--- a/src/utils/generateLinkToDetailsPanel.js
+++ b/src/utils/generateLinkToDetailsPanel.js
@@ -5,8 +5,9 @@ export const generateLinkToDetailsPanel = (
   key,
   version,
   detailsTab,
-  uid
+  uid,
+  iter
 ) =>
   `/projects/${project}/${screen.toLowerCase()}${tab ? `/${tab}` : ''}/${key}${
     version ? `/${version}` : uid ? `/${uid}` : ''
-  }/${detailsTab.toLowerCase()}`
+  }${iter ? `/${iter}` : ''}/${detailsTab.toLowerCase()}`

--- a/src/utils/searchArtifactItem.js
+++ b/src/utils/searchArtifactItem.js
@@ -1,0 +1,8 @@
+export const searchArtifactItem = (artifacts, name, tag, iter) =>
+  artifacts.find(item =>
+    iter
+      ? item.db_key === name &&
+        (item.tag === tag || item.tree === tag) &&
+        Number(iter) === item.iter
+      : item.db_key === name && (item.tag === tag || item.tree === tag)
+  )


### PR DESCRIPTION
https://trello.com/c/FApaYCm8/846-artifacts-use-bestiterationtrue-instead-of-iter0

- **Models, Datasets, Files**: Iterations were not properly listed. Now when the “Show iterations” is checked, all iterations are listed, and when it is unchecked, only the best iterations are listed.
  ![image](https://user-images.githubusercontent.com/13918850/120660446-04374d80-c490-11eb-8997-37e4b99993b1.png)
  ![image](https://user-images.githubusercontent.com/13918850/120660457-0699a780-c490-11eb-926d-a165189ff424.png)
  ![image](https://user-images.githubusercontent.com/13918850/120660496-0f8a7900-c490-11eb-8fae-bdd83579bae3.png)
  ![image](https://user-images.githubusercontent.com/13918850/120660509-10bba600-c490-11eb-88a2-f7a55e807a24.png)

Continues feature https://github.com/mlrun/ui/pull/558 [v0.6.4-RC5](https://github.com/mlrun/ui/releases/tag/v0.6.4-rc5) ML-432

Jira ticket ML-639, ML-644, ML-645