### PR TITLE
[Jobs, Functions] Add unique validation by name

### DIFF
--- a/src/common/KeyValueTable/KeyValueTable.js
+++ b/src/common/KeyValueTable/KeyValueTable.js
@@ -37,7 +37,7 @@ const KeyValueTable = ({
   const tableClassNames = classnames('key-value-table', className)
 
   const saveNewItem = () => {
-    if (key !== '' && value !== '' && !content.find(item => item.key === key)) {
+    if (key !== '' && value !== '') {
       addNewItem({ key, value })
     }
 
@@ -53,6 +53,10 @@ const KeyValueTable = ({
 
     setEditMode(false)
     setSelectedItem(null)
+  }
+
+  const isKeyNotUnique = (newKey, keys) => {
+    return keys.some(({ key }) => newKey === key)
   }
 
   return (
@@ -88,6 +92,11 @@ const KeyValueTable = ({
                       newKey: key
                     })
                   }
+                  required={
+                    selectedItem.newKey !== selectedItem.key &&
+                    isKeyNotUnique(selectedItem.newKey, content)
+                  }
+                  requiredText="Name already exists"
                   type="text"
                   value={selectedItem.newKey ?? selectedItem.key}
                 />
@@ -108,7 +117,14 @@ const KeyValueTable = ({
               />
             </div>
             <div className="table-cell table-cell__actions">
-              <button className="delete-btn" onClick={handleEditItem}>
+              <button
+                className="delete-btn"
+                onClick={handleEditItem}
+                disabled={
+                  selectedItem.newKey !== selectedItem.key &&
+                  isKeyNotUnique(selectedItem.newKey, content)
+                }
+              >
                 <Checkmark />
               </button>
             </div>
@@ -158,6 +174,8 @@ const KeyValueTable = ({
               label={keyLabel}
               type="text"
               wrapperClassName="table-cell__key"
+              required={isKeyNotUnique(key, content)}
+              requiredText="Name already exists"
             />
           )}
 
@@ -168,7 +186,7 @@ const KeyValueTable = ({
             type="text"
             wrapperClassName="table-cell__value"
           />
-          <button onClick={saveNewItem}>
+          <button onClick={saveNewItem} disabled={isKeyNotUnique(key, content)}>
             <Tooltip template={<TextTooltipTemplate text="Add item" />}>
               <Plus />
             </Tooltip>

--- a/src/common/KeyValueTable/keyValueTable.scss
+++ b/src/common/KeyValueTable/keyValueTable.scss
@@ -75,6 +75,10 @@
         width: 100%;
         border: $primaryBorder;
       }
+
+      &_required {
+        border: $errorBorder;
+      }
     }
   }
 }

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -491,3 +491,7 @@ export const parseDefaultDataInputsContent = inputs => {
     }
   }, {})
 }
+
+export const isNameNotUnique = (newName, content) => {
+  return content.some(item => newName === item?.data.name && newName !== '')
+}

--- a/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
+++ b/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
@@ -125,11 +125,11 @@ const JobsPanelAdvanced = ({
 
   return (
     <JobsPanelAdvancedView
+      advancedDispatch={advancedDispatch}
+      advancedState={advancedState}
       handleAddNewItem={handleAddNewItem}
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
-      advancedState={advancedState}
-      advancedDispatch={advancedDispatch}
       match={match}
       panelState={panelState}
     />

--- a/src/components/JobsPanelAdvanced/JobsPanelAdvancedView.js
+++ b/src/components/JobsPanelAdvanced/JobsPanelAdvancedView.js
@@ -8,11 +8,11 @@ import panelData from '../JobsPanel/panelData'
 import { advancedActions } from './jobsPanelAdvancedReducer'
 
 const JobsPanelAdvancedView = ({
+  advancedDispatch,
+  advancedState,
   handleAddNewItem,
   handleDeleteItems,
   handleEditItems,
-  advancedDispatch,
-  advancedState,
   match,
   panelState
 }) => {
@@ -29,6 +29,7 @@ const JobsPanelAdvancedView = ({
           handleDeleteItems={handleDeleteItems}
           headers={panelData['env']['table-headers']}
           match={match}
+          newName={advancedState.newEnvironmentVariable.name}
           panelState={panelState}
           section="advanced env"
           selectedItem={advancedState.selectedEnvironmentVariable}
@@ -103,11 +104,11 @@ const JobsPanelAdvancedView = ({
 }
 
 JobsPanelAdvancedView.propTypes = {
+  advancedDispatch: PropTypes.func.isRequired,
+  advancedState: PropTypes.shape({}).isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
-  advancedDispatch: PropTypes.func.isRequired,
-  advancedState: PropTypes.shape({}).isRequired,
   match: PropTypes.shape({}).isRequired,
   panelState: PropTypes.shape({}).isRequired
 }

--- a/src/components/JobsPanelParameters/JobsPanelParameters.js
+++ b/src/components/JobsPanelParameters/JobsPanelParameters.js
@@ -256,15 +256,8 @@ const JobsPanelParameters = ({
     [panelState.tableData.parameters]
   )
 
-  const nameNotValid = name => {
-    return panelState.tableData.parameters.some(
-      parameter => parameter.data.name === name
-    )
-  }
-
   return (
     <JobsPanelParametersView
-      nameNotValid={nameNotValid}
       checkParameter={checkParameter}
       disabledOptions={disabledOptions}
       handleAddNewItem={handleAddNewParameter}

--- a/src/components/JobsPanelParameters/JobsPanelParametersView.js
+++ b/src/components/JobsPanelParameters/JobsPanelParametersView.js
@@ -10,11 +10,12 @@ import JobsPanelTableAddItemRow from '../../elements/JobsPanelTableAddItemRow/Jo
 import JobsPanelParametersTable from '../../elements/JobsPanelParametersTable/JobsPanelParametersTable'
 import Select from '../../common/Select/Select'
 
-import { ReactComponent as Plus } from '../../images/plus.svg'
-
 import panelData from '../JobsPanel/panelData'
 import { parametersActions } from './jobsPanelParametersReducer'
 import { selectOptions } from './jobsPanelParameters.util'
+import { isNameNotUnique } from '../JobsPanel/jobsPanel.util'
+
+import { ReactComponent as Plus } from '../../images/plus.svg'
 
 const JobsPanelParametersView = ({
   checkParameter,
@@ -23,7 +24,6 @@ const JobsPanelParametersView = ({
   handleDeleteParameter,
   handleEditParameter,
   isHyperTypeExist,
-  nameNotValid,
   parameters,
   parametersDispatch,
   parametersState,
@@ -56,7 +56,6 @@ const JobsPanelParametersView = ({
           handleDeleteParameter={handleDeleteParameter}
           handleEditParameter={handleEditParameter}
           headers={panelData.parameters['table-headers']}
-          nameValidation={nameNotValid}
           selectedItem={parametersState.selectedParameter}
           setSelectedItem={selectedParam =>
             parametersDispatch({
@@ -80,7 +79,10 @@ const JobsPanelParametersView = ({
                       payload: value
                     })
                   }
-                  required={nameNotValid(parametersState.newParameter.name)}
+                  required={isNameNotUnique(
+                    parametersState.newParameter.name,
+                    parameters
+                  )}
                   requiredText="Name already exists"
                   type="text"
                 />
@@ -125,7 +127,10 @@ const JobsPanelParametersView = ({
               </div>
               <button
                 className="add-input btn-add"
-                disabled={nameNotValid(parametersState.newParameter.name)}
+                disabled={isNameNotUnique(
+                  parametersState.newParameter.name,
+                  parameters
+                )}
                 onClick={() => handleAddNewItem(true)}
               >
                 <Tooltip template={<TextTooltipTemplate text="Add item" />}>
@@ -207,7 +212,6 @@ JobsPanelParametersView.propTypes = {
   handleDeleteParameter: PropTypes.func.isRequired,
   handleEditParameter: PropTypes.func.isRequired,
   isHyperTypeExist: PropTypes.bool.isRequired,
-  nameNotValid: PropTypes.func.isRequired,
   parameters: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   parametersDispatch: PropTypes.func.isRequired,
   parametersState: PropTypes.shape({}).isRequired,

--- a/src/elements/EditableAdvancedRow/EditableAdvancedRow.js
+++ b/src/elements/EditableAdvancedRow/EditableAdvancedRow.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types'
 import Input from '../../common/Input/Input'
 import Select from '../../common/Select/Select'
 
+import { selectOptions } from '../../components/JobsPanelAdvanced/jobsPanelAdvanced.util'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
+
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 
-import { selectOptions } from '../../components/JobsPanelAdvanced/jobsPanelAdvanced.util'
-
 const EditableAdvancedRow = ({
+  content,
   handleEdit,
   selectedItem,
   setSelectedItem,
@@ -28,8 +30,13 @@ const EditableAdvancedRow = ({
                 newName: name
               })
             }
+            required={
+              selectedItem.newName !== selectedItem.data.name &&
+              isNameNotUnique(selectedItem.newName, content)
+            }
+            requiredText="Name already exists"
             type="text"
-            value={selectedItem.newName || selectedItem.data.name}
+            value={selectedItem.newName ?? selectedItem.data.name}
           />
         ) : (
           <Select
@@ -65,6 +72,10 @@ const EditableAdvancedRow = ({
       <div className="table__cell table__cell-actions">
         <button
           className="apply-edit-btn"
+          disabled={
+            selectedItem.newName !== selectedItem.data.name &&
+            isNameNotUnique(selectedItem.newName, content)
+          }
           onClick={() => handleEdit(selectedItem.data, table === 'env')}
         >
           <Checkmark />
@@ -75,6 +86,7 @@ const EditableAdvancedRow = ({
 }
 
 EditableAdvancedRow.propTypes = {
+  content: PropTypes.array.isRequired,
   handleEdit: PropTypes.func.isRequired,
   match: PropTypes.shape({}).isRequired,
   selectedItem: PropTypes.shape({}).isRequired,

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
@@ -15,11 +15,13 @@ import {
   applyEditButtonHandler,
   handleEditInputPath
 } from './EditableDataInputsRow.utils'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
 
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 
 const EditableDataInputsRow = ({
   comboboxMatchesList,
+  content,
   handleEdit,
   inputsDispatch,
   inputsState,
@@ -139,6 +141,11 @@ const EditableDataInputsRow = ({
                 }
               })
             }}
+            required={
+              inputName !== selectedDataInput.data.name &&
+              isNameNotUnique(inputName, content)
+            }
+            requiredText="Name already exists"
             type="text"
             value={inputName}
           />
@@ -175,6 +182,10 @@ const EditableDataInputsRow = ({
       <div className="table__cell table__cell-actions">
         <button
           className="apply-edit-btn"
+          disabled={
+            inputName !== selectedDataInput.data.name &&
+            isNameNotUnique(inputName, content)
+          }
           onClick={() => {
             applyEditButtonHandler(
               handleEdit,
@@ -195,6 +206,7 @@ const EditableDataInputsRow = ({
 
 EditableDataInputsRow.propTypes = {
   comboboxMatchesList: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  content: PropTypes.array.isRequired,
   handleEdit: PropTypes.func.isRequired,
   inputsDispatch: PropTypes.func.isRequired,
   inputsState: PropTypes.shape({}).isRequired,

--- a/src/elements/EditableParametersRow/EditableParametersRow.js
+++ b/src/elements/EditableParametersRow/EditableParametersRow.js
@@ -5,13 +5,14 @@ import Input from '../../common/Input/Input'
 import Select from '../../common/Select/Select'
 
 import { selectOptions as selectOption } from '../../components/JobsPanelParameters/jobsPanelParameters.util'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
 
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 
 const EditableParametersRow = ({
+  content,
   disabledOptions,
   handleEdit,
-  nameValidation,
   selectedParameter,
   setSelectedParameter
 }) => {
@@ -41,11 +42,11 @@ const EditableParametersRow = ({
               }}
               required={
                 selectedParameter.newName !== selectedParameter.data.name &&
-                nameValidation(selectedParameter.newName)
+                isNameNotUnique(selectedParameter.newName, content)
               }
               requiredText="Name already exists"
               type="text"
-              value={selectedParameter.newName || selectedParameter.data.name}
+              value={selectedParameter.newName ?? selectedParameter.data.name}
             />
           </div>
           <div className="table__cell table__cell_edit">
@@ -101,7 +102,7 @@ const EditableParametersRow = ({
           className="apply-edit-btn"
           disabled={
             selectedParameter.newName !== selectedParameter.data.name &&
-            nameValidation(selectedParameter.newName)
+            isNameNotUnique(selectedParameter.newName, content)
           }
           onClick={() => handleEdit(selectedParameter, false)}
         >
@@ -113,9 +114,9 @@ const EditableParametersRow = ({
 }
 
 EditableParametersRow.propTypes = {
+  content: PropTypes.array.isRequired,
   disabledOptions: PropTypes.array,
   handleEdit: PropTypes.func.isRequired,
-  nameValidation: PropTypes.func.isRequired,
   selectedParameter: PropTypes.shape({}).isRequired,
   setSelectedParameter: PropTypes.func.isRequired
 }

--- a/src/elements/EditableVolumesRow/EditableVolumesRow.js
+++ b/src/elements/EditableVolumesRow/EditableVolumesRow.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types'
 
 import Input from '../../common/Input/Input'
 
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
+
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 
 import './editableVolumesRow.scss'
 
 const EditableVolumesRow = ({
+  content,
   handleEdit,
   selectedVolume,
   setSelectedVolume
@@ -28,6 +31,11 @@ const EditableVolumesRow = ({
                   newName: name
                 })
               }
+              required={
+                selectedVolume.newName !== selectedVolume.data.name &&
+                isNameNotUnique(selectedVolume.newName, content)
+              }
+              requiredText="Name already exists"
               type="text"
               value={selectedVolume.newName ?? selectedVolume.data.name}
             />
@@ -66,7 +74,14 @@ const EditableVolumesRow = ({
           />
         </div>
         <div className="table__cell table__cell-actions">
-          <button className="apply-edit-btn" onClick={handleEdit}>
+          <button
+            className="apply-edit-btn"
+            onClick={handleEdit}
+            disabled={
+              selectedVolume.newName !== selectedVolume.data.name &&
+              isNameNotUnique(selectedVolume.newName, content)
+            }
+          >
             <Checkmark />
           </button>
         </div>
@@ -109,6 +124,7 @@ const EditableVolumesRow = ({
 }
 
 EditableVolumesRow.propTypes = {
+  content: PropTypes.array.isRequired,
   handleEdit: PropTypes.func.isRequired,
   selectedVolume: PropTypes.shape({}).isRequired,
   setSelectedVolume: PropTypes.func.isRequired

--- a/src/elements/JobsPanelAdvancedTable/JobsPanelAdvancedTable.js
+++ b/src/elements/JobsPanelAdvancedTable/JobsPanelAdvancedTable.js
@@ -8,18 +8,21 @@ import JobsPanelTableAddItemRow from '../JobsPanelTableAddItemRow/JobsPanelTable
 import JobsPanelTable from '../JobsPanelTable/JobsPanelTable'
 import Select from '../../common/Select/Select'
 
-import { ReactComponent as Plus } from '../../images/plus.svg'
 import { selectOptions } from '../../components/JobsPanelAdvanced/jobsPanelAdvanced.util'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
+
+import { ReactComponent as Plus } from '../../images/plus.svg'
 
 export const JobsPanelAdvancedTable = ({
   addNewItem,
   className,
   content,
   handleAddNewItem,
-  handleEditItems,
   handleDeleteItems,
+  handleEditItems,
   headers,
   match,
+  newName,
   section,
   selectedId,
   selectedItem,
@@ -58,6 +61,8 @@ export const JobsPanelAdvancedTable = ({
                 floatingLabel
                 label="Name"
                 onChange={setNewItemName}
+                required={isNameNotUnique(newName, content)}
+                requiredText="Name already exists"
                 type="text"
               />
             )}
@@ -72,6 +77,7 @@ export const JobsPanelAdvancedTable = ({
           </div>
           <button
             className="add-input btn-add"
+            disabled={isNameNotUnique(newName, content)}
             onClick={() => handleAddNewItem(section.includes('env') && true)}
           >
             <Tooltip template={<TextTooltipTemplate text="Add item" />}>
@@ -91,6 +97,7 @@ export const JobsPanelAdvancedTable = ({
 
 JobsPanelAdvancedTable.defaultProps = {
   className: '',
+  newName: '',
   selectedId: ''
 }
 
@@ -99,10 +106,11 @@ JobsPanelAdvancedTable.propTypes = {
   className: PropTypes.string,
   content: PropTypes.arrayOf(PropTypes.shape).isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
-  handleEditItems: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
+  handleEditItems: PropTypes.func.isRequired,
   headers: PropTypes.arrayOf(PropTypes.shape).isRequired,
   match: PropTypes.shape({}).isRequired,
+  newName: PropTypes.string,
   section: PropTypes.string.isRequired,
   selectedId: PropTypes.string,
   selectedItem: PropTypes.shape({}).isRequired,

--- a/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
+++ b/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
@@ -12,6 +12,7 @@ import panelData from '../../components/JobsPanel/panelData'
 import { inputsActions } from '../../components/JobsPanelDataInputs/jobsPanelDataInputsReducer'
 import { MLRUN_STORAGE_INPUT_PATH_SCHEME } from '../../constants'
 import { COMBOBOX_MATCHES } from '../../types'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
 
 import { ReactComponent as Plus } from '../../images/plus.svg'
 
@@ -75,8 +76,8 @@ export const JobsPanelDataInputsTable = ({
       }}
     >
       {inputsState.addNewInput ? (
-        <div className="table__row-add-item">
-          <div className="input-row-wrapper" ref={addItemRowRef}>
+        <div className="table__row-add-item" ref={addItemRowRef}>
+          <div className="input-row-wrapper">
             <Input
               className="input-row__item"
               density="medium"
@@ -88,6 +89,11 @@ export const JobsPanelDataInputsTable = ({
                   payload: name
                 })
               }
+              required={isNameNotUnique(
+                inputsState.newInput.name,
+                panelState.tableData.dataInputs
+              )}
+              requiredText="Name already exists"
               type="text"
             />
             <Combobox
@@ -114,6 +120,10 @@ export const JobsPanelDataInputsTable = ({
           </div>
           <button
             className="add-input btn-add"
+            disabled={isNameNotUnique(
+              inputsState.newInput.name,
+              panelState.tableData.dataInputs
+            )}
             onClick={() => handleAddNewItem(true)}
           >
             <Tooltip template={<TextTooltipTemplate text="Add item" />}>

--- a/src/elements/JobsPanelParametersTable/JobsPanelParametersTable.js
+++ b/src/elements/JobsPanelParametersTable/JobsPanelParametersTable.js
@@ -1,10 +1,10 @@
 import React, { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 
+import JobsPanelParametersTableView from './JobsPanelParametersTableView'
+
 import { ReactComponent as Edit } from '../../images/edit.svg'
 import { ReactComponent as Delete } from '../../images/delete.svg'
-
-import JobsPanelParametersTableView from './JobsPanelParametersTableView'
 
 const JobsPanelParametersTable = ({
   addNewItem,
@@ -16,7 +16,6 @@ const JobsPanelParametersTable = ({
   handleDeleteParameter,
   handleEditParameter,
   headers,
-  nameValidation,
   selectedItem,
   setSelectedItem,
   tableContent
@@ -68,7 +67,6 @@ const JobsPanelParametersTable = ({
       handleDeleteParameter={handleDeleteParameter}
       handleEditParameter={handleEdit}
       headers={headers}
-      nameValidation={nameValidation}
       selectedItem={selectedItem}
       setSelectedItem={setSelectedItem}
       tableContent={tableContent}
@@ -95,7 +93,6 @@ JobsPanelParametersTable.propTypes = {
   handleDeleteParameter: PropTypes.func,
   handleEditParameter: PropTypes.func.isRequired,
   headers: PropTypes.arrayOf(PropTypes.shape({})),
-  nameValidation: PropTypes.func.isRequired,
   selectedItem: PropTypes.shape({}).isRequired,
   setSelectedItem: PropTypes.func.isRequired,
   tableContent: PropTypes.shape({}).isRequired

--- a/src/elements/JobsPanelParametersTable/JobsPanelParametersTableView.js
+++ b/src/elements/JobsPanelParametersTable/JobsPanelParametersTableView.js
@@ -9,16 +9,16 @@ import './jobsPanelParametersTable.scss'
 
 const JobsPanelParametersTableView = ({
   addNewItem,
-  children,
   checkParameter,
+  children,
   className,
+  content,
   disabledOptions,
   editItem,
   generateActionsMenu,
   handleDeleteParameter,
   handleEditParameter,
   headers,
-  nameValidation,
   selectedItem,
   setSelectedItem,
   tableContent
@@ -58,7 +58,7 @@ const JobsPanelParametersTableView = ({
                     disabledOptions={disabledOptions}
                     handleEdit={handleEditParameter}
                     key={`${contentItem.data.name}${index}`}
-                    nameValidation={nameValidation}
+                    content={content}
                     selectedParameter={selectedItem}
                     setSelectedParameter={setSelectedItem}
                   />
@@ -102,7 +102,6 @@ JobsPanelParametersTableView.propTypes = {
   handleDeleteParameter: PropTypes.func.isRequired,
   handleEditParameter: PropTypes.func.isRequired,
   headers: PropTypes.array.isRequired,
-  nameValidation: PropTypes.func.isRequired,
   selectedItem: PropTypes.shape({}).isRequired,
   setSelectedItem: PropTypes.func.isRequired,
   tableContent: PropTypes.shape({}).isRequired

--- a/src/elements/JobsPanelTable/JobsPanelTableView.js
+++ b/src/elements/JobsPanelTable/JobsPanelTableView.js
@@ -55,6 +55,7 @@ const JobsPanelTableView = ({
           return section === 'data-inputs' ? (
             <EditableDataInputsRow
               comboboxMatchesList={sectionData.comboboxMatchesList}
+              content={content}
               handleEdit={handleEdit}
               inputsDispatch={sectionDispatch}
               inputsState={sectionState}
@@ -65,6 +66,7 @@ const JobsPanelTableView = ({
             />
           ) : (
             <EditableAdvancedRow
+              content={content}
               handleEdit={handleEdit}
               key={index}
               match={match}

--- a/src/elements/VolumesTable/VolumesTableView.js
+++ b/src/elements/VolumesTable/VolumesTableView.js
@@ -13,6 +13,7 @@ import Select from '../../common/Select/Select'
 
 import { selectTypeOptions, tableHeaders } from './volumesTable.util'
 import { joinDataOfArrayOrObject } from '../../utils'
+import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
 
 import { ReactComponent as Plus } from '../../images/plus.svg'
 
@@ -63,6 +64,7 @@ const VolumesTableView = ({
         ) {
           return (
             <EditableVolumesRow
+              content={volumeMounts}
               handleEdit={editVolume}
               key={index}
               selectedVolume={selectedVolume}
@@ -121,6 +123,8 @@ const VolumesTableView = ({
                 label="Name"
                 className="input-row__item"
                 floatingLabel
+                required={isNameNotUnique(newVolume.name, volumeMounts)}
+                requiredText="Name already exists"
                 type="text"
               />
               <Input
@@ -179,7 +183,11 @@ const VolumesTableView = ({
               </div>
             )}
           </div>
-          <button className="add-input btn-add" onClick={addVolume}>
+          <button
+            className="add-input btn-add"
+            disabled={isNameNotUnique(newVolume.name, volumeMounts)}
+            onClick={addVolume}
+          >
             <Tooltip template={<TextTooltipTemplate text="Add item" />}>
               <Plus />
             </Tooltip>

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -120,7 +120,7 @@
       &-column {
         width: 100%;
 
-        .input {
+        .input:not(.input_required) {
           border: none;
         }
       }
@@ -233,6 +233,7 @@
 
     &__item {
       width: 100%;
+      height: 100%;
 
       &::placeholder {
         font-style: italic;


### PR DESCRIPTION
https://trello.com/c/ByS0xSna/847-jobs-functions-add-unique-validation-by-name

- **Job panel**: In “Data Inputs”, “Parameters”, “Volumes” and “Environment variables” sections, the user could unexpectedly add two items with the same name. This is now invalid and the UI clearly shows it:
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/120510306-f8855180-c3d1-11eb-8b42-d56a2c94f4ca.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/120510335-ff13c900-c3d1-11eb-8a43-29a8d2021af5.png)

Jira ticket ML-651