### PR TITLE
[Functions] Default `kind` to 'job' in Save request

### DIFF
--- a/src/reducers/functionReducer.js
+++ b/src/reducers/functionReducer.js
@@ -39,7 +39,7 @@ const initialState = {
   loading: false,
   error: null,
   newFunction: {
-    kind: 'local',
+    kind: 'job',
     metadata: {
       labels: {},
       name: '',


### PR DESCRIPTION
- **Functions**: Although the “Runtime” field has the only option “Job”, the value that was actually sent in the request to create the function was `'local'` instead of `'job'`.

Relates to https://github.com/mlrun/ui/pull/601 [v0.6.4-RC10](https://github.com/mlrun/ui/releases/tag/v0.6.4-rc10)