### PR TITLE
[Feature sets] Show truncated UID when no tag

### DIFF
--- a/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
+++ b/src/elements/ArtifactsTableRow/ArtifactsTableRow.js
@@ -135,7 +135,8 @@ const ArtifactsTableRow = ({
 
             const subRowClassNames = classnames(
               'table-body__row',
-              (selectedItemReference === subRowCurrentItemReference ||
+              ((selectedItemReference &&
+                selectedItemReference === subRowCurrentItemReference) ||
                 (selectedItem.uid &&
                   selectedItem?.uid === subRowCurrentItem?.uid &&
                   selectedItem?.tag === subRowCurrentItem?.tag)) &&

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -467,7 +467,8 @@ const createFeatureSetsRowData = (artifact, project) => {
           FEATURE_SETS_TAB,
           artifact.name,
           artifact.tag,
-          tab
+          tab,
+          artifact.uid
         ),
       expandedCellContent: {
         class: 'artifacts_medium',

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -471,7 +471,8 @@ const createFeatureSetsRowData = (artifact, project) => {
         ),
       expandedCellContent: {
         class: 'artifacts_medium',
-        value: artifact.tag
+        value: artifact.tag || truncateUid(artifact.uid),
+        tooltip: artifact.tag || artifact.uid
       }
     },
     description: {


### PR DESCRIPTION
https://trello.com/c/nabGEGmf/851-feature-sets-show-truncated-uid-when-no-tag

- **Feature sets**: Show truncated UID for feature set versions that have no tag assigned to them.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/120791540-04415700-c53d-11eb-913e-e820fd3d5155.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/120791494-f5f33b00-c53c-11eb-9854-0175bf714c87.png)

Jira ticket ML-661