### PR TITLE
[Monitor] Date picker has the wrong cursor

### DIFF
--- a/src/common/DatePicker/DatePicker.js
+++ b/src/common/DatePicker/DatePicker.js
@@ -34,6 +34,7 @@ import './datePicker.scss'
 const DatePicker = ({
   date,
   dateTo,
+  disabled,
   label,
   onChange,
   splitCharacter,
@@ -308,20 +309,22 @@ const DatePicker = ({
   }
 
   const onInputDatePickerClick = () => {
-    if (withOptions && !isDatePickerOpened) {
-      setIsDatePickerOptionsOpened(true)
-    } else {
-      setIsDatePickerOpened(true)
-      datePickerDispatch({
-        type: datePickerActions.UPDATE_SELECTED_DATE_FROM,
-        payload: date || new Date()
-      })
-
-      if (isRange) {
+    if (!disabled) {
+      if (withOptions && !isDatePickerOpened) {
+        setIsDatePickerOptionsOpened(true)
+      } else {
+        setIsDatePickerOpened(true)
         datePickerDispatch({
-          type: datePickerActions.UPDATE_SELECTED_DATE_TO,
-          payload: dateTo || new Date()
+          type: datePickerActions.UPDATE_SELECTED_DATE_FROM,
+          payload: date || new Date()
         })
+
+        if (isRange) {
+          datePickerDispatch({
+            type: datePickerActions.UPDATE_SELECTED_DATE_TO,
+            payload: dateTo || new Date()
+          })
+        }
       }
     }
   }
@@ -388,6 +391,7 @@ const DatePicker = ({
         }
         dateMask={dateMask}
         datePickerOptions={datePickerOptions}
+        disabled={disabled}
         isCalendarInvalid={isCalendarInvalid}
         isDatePickerOpened={isDatePickerOpened}
         isDatePickerOptionsOpened={isDatePickerOptionsOpened}
@@ -416,6 +420,7 @@ const DatePicker = ({
 }
 DatePicker.defaultProps = {
   dateTo: new Date(),
+  disabled: false,
   label: 'Date',
   splitCharacter: '/',
   type: 'date',
@@ -426,6 +431,7 @@ DatePicker.propTypes = {
   date: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string])
     .isRequired,
   dateTo: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+  disabled: PropTypes.bool,
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   splitCharacter: PropTypes.oneOf(['/', '.']),

--- a/src/common/DatePicker/DatePickerView.js
+++ b/src/common/DatePicker/DatePickerView.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types'
 import MaskedInput from 'react-text-mask'
 import classnames from 'classnames'
 
-import { ReactComponent as Arrow } from '../../images/arrow.svg'
 import Button from '../Button/Button'
 import ErrorMessage from '../ErrorMessage/ErrorMessage'
 import TimePicker from '../TimePicker/TimePicker'
 import SelectOption from '../../elements/SelectOption/SelectOption'
+
+import { ReactComponent as Arrow } from '../../images/arrow.svg'
 
 const DatePickerView = React.forwardRef(
   (
@@ -16,6 +17,7 @@ const DatePickerView = React.forwardRef(
       config,
       dateMask,
       datePickerOptions,
+      disabled,
       isCalendarInvalid,
       isDatePickerOpened,
       isDatePickerOptionsOpened,
@@ -44,7 +46,9 @@ const DatePickerView = React.forwardRef(
       'input',
       'date-picker__input',
       'active-input',
-      isRange && 'long-input'
+      isRange && 'long-input',
+      isValueEmpty && 'date-picker__input_empty',
+      disabled && 'date-picker__input_disabled'
     )
     const inputLabelClassNames = classnames('input__label', 'active-label')
 
@@ -59,7 +63,7 @@ const DatePickerView = React.forwardRef(
             className={inputClassNames}
             keepCharPositions={true}
             mask={dateMask}
-            disabled={isValueEmpty}
+            disabled={isValueEmpty || disabled}
             showMask={!isValueEmpty}
             onChange={onInputChange}
             pipe={autoCorrectedDatePipe}
@@ -219,6 +223,7 @@ DatePickerView.propTypes = {
   config: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   dateMask: PropTypes.array.isRequired,
   datePickerOptions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  disabled: PropTypes.bool.isRequired,
   floatingLabel: PropTypes.bool,
   isCalendarInvalid: PropTypes.bool.isRequired,
   isDatePickerOpened: PropTypes.bool.isRequired,

--- a/src/common/DatePicker/datePicker.scss
+++ b/src/common/DatePicker/datePicker.scss
@@ -9,6 +9,15 @@
     position: relative;
 
     .date-picker__input {
+      &_empty {
+        cursor: pointer;
+      }
+
+      &_disabled {
+        border: $disabledBorder;
+        cursor: not-allowed;
+      }
+
       &.long-input {
         width: 300px;
       }


### PR DESCRIPTION
https://trello.com/c/rIBzertg/852-monitor-date-picker-has-the-wrong-cursor

- **Date picker**: Hovering on the date-picker unexpectedly had a “not-allowed” cursor, instead of the a “pointer” cursor
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/121034419-af5c4580-c7b5-11eb-9c7e-659a633d895c.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/121034425-b08d7280-c7b5-11eb-8fce-fd79a5ceb516.png)

Jira ticket ML-665