### PR TITLE
Impl [Job Panel] Node Selectors: renames and move below Resources

### DIFF
--- a/src/components/JobsPanelResources/JobsPanelResourcesView.js
+++ b/src/components/JobsPanelResources/JobsPanelResourcesView.js
@@ -25,20 +25,6 @@ const JobsPanelResourcesView = ({
 }) => (
   <div className="job-panel__item resources new-item-side-panel__item">
     <JobsPanelSection title="Resources" />
-    <JobsPanelSection title="Node selectors">
-      <KeyValueTable
-        addNewItem={handleAddNewNodeSelector}
-        addNewItemLabel="Add node selector"
-        className="node-selector"
-        content={panelState.tableData.node_selector}
-        deleteItem={handleDeleteNodeSelector}
-        editItem={handleEditNodeSelector}
-        keyHeader="Key"
-        keyType="input"
-        valueHeader="Value"
-        withEditMode
-      />
-    </JobsPanelSection>
     <JobsPanelSection title="Volumes">
       <VolumesTable
         handleAddNewVolume={handleAddNewVolume}
@@ -152,6 +138,20 @@ const JobsPanelResourcesView = ({
         />
       </JobsPanelSection>
     </div>
+    <JobsPanelSection title="Node selector">
+      <KeyValueTable
+        addNewItem={handleAddNewNodeSelector}
+        addNewItemLabel="Add entry"
+        className="node-selector"
+        content={panelState.tableData.node_selector}
+        deleteItem={handleDeleteNodeSelector}
+        editItem={handleEditNodeSelector}
+        keyHeader="Key"
+        keyType="input"
+        valueHeader="Value"
+        withEditMode
+      />
+    </JobsPanelSection>
   </div>
 )
 


### PR DESCRIPTION
- **Job Panel**: Moved “Node Selectors” below the Memory/CPU/GPU part, rename the heading to “Node Selector” (singular), and “Add new node selector” to “Add new entry”
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/121882034-b08ef480-cd18-11eb-87d1-9d066c0f366b.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/121882047-b389e500-cd18-11eb-8f8c-7093e24f2042.png)

Continues https://github.com/mlrun/ui/pull/621 [v0.6.5-RC3](https://github.com/mlrun/ui/releases/tag/v0.6.5-rc3) ML-595