### PR TITLE
[Details Panel] The main table pokes behind the panel

### DIFF
--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -41,9 +41,9 @@
 
     .artifacts {
       &_medium {
-        max-width: 235px;
+        max-width: 240px;
 
-        @include tableColumnFlex(1, 200px);
+        @include tableColumnFlex(1, 235px);
       }
 
       &_small {


### PR DESCRIPTION
https://trello.com/c/E0zZtTWT/862-details-panel-the-main-table-pokes-behind-the-panel

- **Details Panel**: When the details panel was open, on narrow screens, part of the main table was visible behind the panel.
  Before:  
  ![image](https://user-images.githubusercontent.com/13918850/122423263-76328b00-cf96-11eb-8fbc-fd2004482593.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/122423271-7894e500-cf96-11eb-93b7-9bc549b97d2a.png)

Jira ticket ML-704