### PR TITLE
[General] Tooltip with long text content has redundant space

### DIFF
--- a/src/common/Tooltip/Tooltip.js
+++ b/src/common/Tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { Transition } from 'react-transition-group'
+import { CSSTransition } from 'react-transition-group'
 import classnames from 'classnames'
 
 import './tooltip.scss'
@@ -19,13 +19,7 @@ const Tooltip = ({ children, className, hidden, template, textShow }) => {
   const offset = 10
 
   const defaultStyle = {
-    transition: `opacity ${duration}ms ease-in-out`
-  }
-
-  const transitionStyles = {
-    entering: { opacity: 0 },
-    entered: { opacity: 1 },
-    exiting: { opacity: 0 }
+    transition: `opacity ${duration}ms ease-in-out ${duration}ms`
   }
 
   const handleScroll = () => {
@@ -116,22 +110,24 @@ const Tooltip = ({ children, className, hidden, template, textShow }) => {
       >
         {children}
       </div>
-      <Transition in={show} timeout={duration} unmountOnExit>
-        {state => (
-          <div
-            data-testid="tooltip"
-            ref={tooltipRef}
-            style={{
-              ...defaultStyle,
-              ...transitionStyles[state],
-              ...style
-            }}
-            className="tooltip"
-          >
-            {template}
-          </div>
-        )}
-      </Transition>
+      <CSSTransition
+        in={show}
+        timeout={duration}
+        classNames="fade"
+        unmountOnExit
+      >
+        <div
+          data-testid="tooltip"
+          ref={tooltipRef}
+          style={{
+            ...defaultStyle,
+            ...style
+          }}
+          className="tooltip"
+        >
+          {template}
+        </div>
+      </CSSTransition>
     </>
   )
 }

--- a/src/common/Tooltip/tooltip.scss
+++ b/src/common/Tooltip/tooltip.scss
@@ -5,5 +5,4 @@
   font-size: 15px;
   line-height: 18px;
   white-space: nowrap;
-  word-break: break-word;
 }

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -188,11 +188,6 @@
 
         span {
           display: block;
-          color: $topaz;
-        }
-
-        .link {
-          color: $cornflowerBlue;
         }
       }
 
@@ -306,47 +301,6 @@
         left: 8px;
         margin: 0;
       }
-    }
-  }
-
-  .name-wrapper {
-    display: flex;
-    flex: 1;
-    flex-wrap: wrap;
-    align-items: center;
-
-    .item {
-      &-name {
-        min-width: 100%;
-        max-width: 125px;
-
-        &.function-name {
-          max-width: 120px;
-        }
-      }
-
-      &-tag {
-        max-width: 150px;
-        margin-left: 10px;
-
-        span {
-          display: inline;
-        }
-      }
-    }
-  }
-
-  .date__uid_row {
-    display: flex;
-    align-items: center;
-    font-weight: normal;
-    font-size: 12px;
-    font-family: Roboto, sans-serif;
-    font-style: normal;
-    line-height: 14px;
-
-    span:last-child {
-      margin-left: 10px;
     }
   }
 

--- a/src/elements/TableLinkCell/TableLinkCell.js
+++ b/src/elements/TableLinkCell/TableLinkCell.js
@@ -9,6 +9,8 @@ import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
 
 import { formatDatetime, truncateUid } from '../../utils'
 
+import './tableLinkCell.scss'
+
 import { ReactComponent as Arrow } from '../../images/arrow.svg'
 
 const TableLinkCell = ({
@@ -59,16 +61,16 @@ const TableLinkCell = ({
                 className="item-tag"
                 template={<TextTooltipTemplate text={item.tag} />}
               >
-                <span>{item.tag}</span>
+                <span className="link-subtext">{item.tag}</span>
               </Tooltip>
             )}
         </div>
         {(link.match(/jobs/) ||
           (link.match(/functions/) &&
             Object.values(selectedItem).length !== 0)) && (
-          <div className="date__uid_row">
+          <div className="date-uid-row">
             {(item.startTime || item.updated) && (
-              <span>
+              <span className="link-subtext">
                 {data.type !== 'date' &&
                   (link.match(/functions/)
                     ? formatDatetime(item.updated, 'N/A')
@@ -78,7 +80,9 @@ const TableLinkCell = ({
                       ))}
               </span>
             )}
-            <span>{truncateUid(item.uid || item.hash)}</span>
+            <span className="link-subtext">
+              {truncateUid(item.uid || item.hash)}
+            </span>
           </div>
         )}
       </Link>

--- a/src/elements/TableLinkCell/tableLinkCell.scss
+++ b/src/elements/TableLinkCell/tableLinkCell.scss
@@ -1,0 +1,48 @@
+@import '../../scss/colors';
+
+.table-body__cell {
+  .name-wrapper {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+    align-items: center;
+
+    .item {
+      &-name {
+        min-width: 100%;
+        max-width: 125px;
+
+        &.function-name {
+          max-width: 120px;
+        }
+      }
+
+      &-tag {
+        max-width: 150px;
+        margin-left: 10px;
+
+        span {
+          display: inline;
+        }
+      }
+    }
+  }
+
+  .link-subtext {
+    color: $topaz;
+  }
+
+  .date-uid-row {
+    display: flex;
+    align-items: center;
+    font-weight: normal;
+    font-size: 12px;
+    font-family: Roboto, sans-serif;
+    font-style: normal;
+    line-height: 14px;
+
+    span:last-child {
+      margin-left: 10px;
+    }
+  }
+}

--- a/src/elements/TooltipTemplate/TextTooltipTemplate.js
+++ b/src/elements/TooltipTemplate/TextTooltipTemplate.js
@@ -1,15 +1,34 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
 import './textTooltipTemplate.scss'
 
 const TextTooltipTemplate = ({ text, warning }) => {
+  const [style, setStyle] = useState({})
+  const textRef = useRef()
+  const horizontalPadding = 8
   const tooltipClassNames = classnames(
     'tooltip__text',
     warning && 'tooltip__warning'
   )
-  return <div className={tooltipClassNames}>{text}</div>
+
+  useEffect(() => {
+    if (textRef?.current) {
+      const { width } = textRef.current?.getBoundingClientRect()
+
+      setStyle({
+        padding: `6px ${horizontalPadding}px`,
+        width: width + horizontalPadding * 2
+      })
+    }
+  }, [])
+
+  return (
+    <div className={tooltipClassNames} style={style}>
+      <span ref={textRef}>{text}</span>
+    </div>
+  )
 }
 
 TextTooltipTemplate.propTypes = {

--- a/src/elements/TooltipTemplate/textTooltipTemplate.scss
+++ b/src/elements/TooltipTemplate/textTooltipTemplate.scss
@@ -3,7 +3,6 @@
 
 .tooltip {
   &__text {
-    padding: 6px 8px;
     color: $white;
     white-space: pre-wrap;
     word-break: break-word;


### PR DESCRIPTION
https://trello.com/c/cauyBUc8/895-general-tooltip-with-long-text-content-has-redundant-space

- **Tooltips**: Sometimes there was a lot of redundant empty space in tooltips.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/124940711-e0c56c80-e012-11eb-9a6b-27c9be48234a.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/124940652-d6a36e00-e012-11eb-9e68-f794354de0ac.png)
