### PR TITLE
[Feature sets] Overview: remove Partition Keys field

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -378,9 +378,6 @@ export const generateFeatureSetsOverviewContent = (
   target_uri: {
     value: selectedItem.URI
   },
-  partition_keys: {
-    value: selectedItem.partition_keys?.toString() ?? ''
-  },
   timestamp_key: {
     value: selectedItem.timestamp_key ?? ''
   },

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -59,7 +59,6 @@ export const featureSetsInfoHeaders = [
   { label: 'Last updated', id: 'updated' },
   { label: 'Entities', id: 'entities' },
   { label: 'URI', id: 'target_uri' },
-  { label: 'Partition keys', id: 'partition_keys' },
   { label: 'Timestamp key', id: 'timestamp_key' },
   { label: 'Relations', id: 'relations' },
   { label: 'Label column', id: 'label_column' },


### PR DESCRIPTION
https://trello.com/c/bGRUxS9d/898-feature-sets-overview-remove-partition-keys-field

- **Feature sets**: In “Overview” tab, removed the “Partition Keys” field.
  ![image](https://user-images.githubusercontent.com/13918850/124951150-c2b03a00-e01b-11eb-8651-7eeaa731d513.png)