### PR TITLE
Fix [Feature sets] Overview: no delimiter in entity list

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -373,7 +373,7 @@ export const generateFeatureSetsOverviewContent = (
     value: selectedItem.usage_example ?? ''
   },
   entities: {
-    value: selectedItem.entities?.map(entity => entity.name)
+    value: selectedItem.entities?.map(entity => entity.name).join(', ')
   },
   target_uri: {
     value: selectedItem.URI


### PR DESCRIPTION
- **Feature sets**: In “Overview” tab, the value of “Entities” field was missing a delimiter so entity names looked like one big word.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/124949327-22a5e100-e01a-11eb-826f-2a040549330d.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/124949344-25a0d180-e01a-11eb-9503-efff1c476a45.png)


Jira tikcet ML-778