### PR TITLE
Fix [Feature sets] Preview: boolean values are not displayed

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -60,7 +60,7 @@ const ArtifactsPreviewView = ({
                       >
                         {typeof value === 'object' && value !== null
                           ? JSON.stringify(value)
-                          : value}
+                          : String(value)}
                       </Tooltip>
                     ))
                   ) : (

--- a/src/components/ArtifactsPreview/artifactsPreview.scss
+++ b/src/components/ArtifactsPreview/artifactsPreview.scss
@@ -43,6 +43,7 @@
       top: -21px;
       z-index: 2;
       background-color: $white;
+      font-weight: 500;
     }
 
     &-body {


### PR DESCRIPTION
- **Feature sets**: In “Preview” tab, the values for features of type boolean were missing.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/124949920-a5c73700-e01a-11eb-9b09-b4638cae4bc5.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/124949932-a8299100-e01a-11eb-8386-29d7ddaf7fd4.png)

Jira ticket ML-825