### PR TITLE
[Feature vectors] Overview: populate Label Column correctly

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -410,7 +410,7 @@ export const generateFeatureVectorsOverviewContent = selectedItem => ({
     value: selectedItem.usage_example ?? ''
   },
   label_column: {
-    value: selectedItem.label_column ?? ''
+    value: selectedItem.label_feature ?? ''
   }
 })
 export const handleFinishEdit = (


### PR DESCRIPTION
https://trello.com/c/aRmMjhKE/911-feature-vectors-overview-populate-label-column-correctly

- **Feature vectors**: In “Overview” tab, the “Label column” was always empty.

Jira ticket ML-760