### PR TITLE
[Feature sets] Transformations: text overflows

### DIFF
--- a/src/components/DetailsTransformations/ConfigFunctionTemplate/ConfigFunctionTemplate.js
+++ b/src/components/DetailsTransformations/ConfigFunctionTemplate/ConfigFunctionTemplate.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import { ReactComponent as Arrow } from '../../../images/arrow.svg'
 import Accordion from '../../../common/Accordion/Accordion'
+import TextTooltipTemplate from '../../../elements/TooltipTemplate/TextTooltipTemplate'
+import Tooltip from '../../../common/Tooltip/Tooltip'
 
 const ConfigFunctionTemplate = ({ selectedItem }) => {
   return (
@@ -15,15 +17,39 @@ const ConfigFunctionTemplate = ({ selectedItem }) => {
       <div className="config-item__content">
         <div className="row">
           <div className="row-label">URL:</div>
-          <div className="row-value">{selectedItem.function?.url}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.function?.url} />
+              }
+            >
+              {selectedItem.function?.url}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">Kind:</div>
-          <div className="row-value">{selectedItem.function?.kind}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.function?.kind} />
+              }
+            >
+              {selectedItem.function?.kind}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">Image:</div>
-          <div className="row-value">{selectedItem.function?.image}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.function?.image} />
+              }
+            >
+              {selectedItem.function?.image}
+            </Tooltip>
+          </div>
         </div>
       </div>
     </Accordion>

--- a/src/components/DetailsTransformations/ConfigSource/ConfigSource.js
+++ b/src/components/DetailsTransformations/ConfigSource/ConfigSource.js
@@ -6,6 +6,8 @@ import cronstrue from 'cronstrue'
 import { ReactComponent as Arrow } from '../../../images/arrow.svg'
 import Accordion from '../../../common/Accordion/Accordion'
 import ChipCell from '../../../common/ChipCell/ChipCell'
+import TextTooltipTemplate from '../../../elements/TooltipTemplate/TextTooltipTemplate'
+import Tooltip from '../../../common/Tooltip/Tooltip'
 
 const ConfigSource = ({ selectedItem }) => {
   return (
@@ -18,11 +20,27 @@ const ConfigSource = ({ selectedItem }) => {
       <div className="config-item__content">
         <div className="row">
           <div className="row-label">Kind:</div>
-          <div className="row-value">{selectedItem.source?.kind}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.source?.kind} />
+              }
+            >
+              {selectedItem.source?.kind}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">URL:</div>
-          <div className="row-value">{selectedItem.source?.path}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.source?.path} />
+              }
+            >
+              {selectedItem.source?.path}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">Attributes:</div>
@@ -38,22 +56,57 @@ const ConfigSource = ({ selectedItem }) => {
         </div>
         <div className="row">
           <div className="row-label">Workers:</div>
-          <div className="row-value">{selectedItem.source?.workers}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.source?.workers} />
+              }
+            >
+              {selectedItem.source?.workers}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">Schedule:</div>
-          <div className="row-value">
-            {selectedItem.source?.schedule &&
-              cronstrue.toString(selectedItem.source?.schedule)}
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate
+                  text={
+                    selectedItem.source?.schedule &&
+                    cronstrue.toString(selectedItem.source?.schedule)
+                  }
+                />
+              }
+            >
+              {selectedItem.source?.schedule &&
+                cronstrue.toString(selectedItem.source?.schedule)}
+            </Tooltip>
           </div>
         </div>
         <div className="row">
           <div className="row-label">Key column:</div>
-          <div className="row-value">{selectedItem.source?.key_column}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.source?.key_column} />
+              }
+            >
+              {selectedItem.source?.key_column}
+            </Tooltip>
+          </div>
         </div>
         <div className="row">
           <div className="row-label">Time column:</div>
-          <div className="row-value">{selectedItem.source?.time_column}</div>
+          <div className="row-value data-ellipsis">
+            <Tooltip
+              template={
+                <TextTooltipTemplate text={selectedItem.source?.time_column} />
+              }
+            >
+              {selectedItem.source?.time_column}
+            </Tooltip>
+          </div>
         </div>
       </div>
     </Accordion>

--- a/src/components/DetailsTransformations/detailsTransformations.scss
+++ b/src/components/DetailsTransformations/detailsTransformations.scss
@@ -27,6 +27,31 @@
           box-shadow: unset;
         }
 
+        .react-flow__node-label {
+          position: relative;
+
+          &::before {
+            position: absolute;
+            bottom: 25px;
+            left: 30%;
+            z-index: 10;
+            min-width: 30px;
+            padding: 6px 8px;
+            color: $white;
+            font-weight: 400;
+            font-size: 15px;
+            background-color: $primary;
+            border-radius: 4px;
+            opacity: 0;
+            transition: all 0.2s ease-in-out;
+            content: attr(data-title);
+          }
+
+          &:hover::before {
+            opacity: 1;
+          }
+        }
+
         &.react-flow__node-input {
           color: $white;
           background-color: $hotPink;

--- a/src/components/DetailsTransformations/detailsTransformations.util.js
+++ b/src/components/DetailsTransformations/detailsTransformations.util.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import dagre from 'dagre'
 import { isNode } from 'react-flow-renderer'
 
@@ -23,6 +24,14 @@ export const getLayoutedElements = (elements, direction = 'TB') => {
       el.targetPosition = isHorizontal ? 'left' : 'top'
       el.sourcePosition = isHorizontal ? 'right' : 'bottom'
 
+      el.data.label = (
+        <div className="react-flow__node-label" data-title={el.data.label}>
+          <div className="data-ellipsis">{el.data.label}</div>
+        </div>
+      )
+      el.style = {
+        pointerEvents: 'all'
+      }
       // unfortunately we need this little hack to pass a slighltiy different position
       // in order to notify react flow about the change
       el.position = {


### PR DESCRIPTION
https://trello.com/c/2xblQZKq/903-feature-sets-transformations-text-overflows

- **Feature sets**: In “Transformations” tab, text was overflowing outside of steps. Now it is cropped with ellipsis and a tooltip with the full value is displayed on hover.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/126067065-aa1b3d23-bf90-4d26-b56b-95cbdd479abd.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/126067069-e1989e35-4e4c-489a-aed3-973216c903e8.png)

Jira ticket ML-831