### PR TITLE
[Feature sets] Show first two entities instead of one

### DIFF
--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -154,7 +154,7 @@ export const featureSetsTableHeaders = [
     class: 'artifacts_big'
   },
   {
-    header: 'Entity',
+    header: 'Entities',
     class: 'artifacts_small'
   },
   {

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -75,10 +75,11 @@ const createFeatureSetsRowData = (featureSet, project) => {
       type: 'hidden'
     },
     entity: {
-      value: featureSet.entities[0]?.name
-        ? `${featureSet.entities[0]?.name} ${featureSet.entities[1]?.name ??
-            ''}`
-        : '',
+      value:
+        featureSet.entities
+          ?.slice(0, 2)
+          .map(entity => entity.name)
+          .join(', ') ?? '',
       class: 'artifacts_small'
     },
     targets: getFeatureSetTargetCellValue(featureSet.targets),

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -75,7 +75,10 @@ const createFeatureSetsRowData = (featureSet, project) => {
       type: 'hidden'
     },
     entity: {
-      value: featureSet.entities ? featureSet.entities[0]?.name : '',
+      value: featureSet.entities[0]?.name
+        ? `${featureSet.entities[0]?.name} ${featureSet.entities[1]?.name ??
+            ''}`
+        : '',
       class: 'artifacts_small'
     },
     targets: getFeatureSetTargetCellValue(featureSet.targets),


### PR DESCRIPTION
https://trello.com/c/kkyrO6WC/910-feature-sets-show-first-two-entities-instead-of-one

- **Feature sets**: Rename “Entity” to “Entities” and display the two first entities instead of just one.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/126159063-a8238d01-3658-4d73-b3e2-c49791dfb1b1.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/126158986-12679c4c-6120-478c-b0eb-4d40500f9360.png)

Jira ticket ML-718