### PR TITLE
[Jobs Panel] Invalid input icon has wrong position

### DIFF
--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
@@ -54,7 +54,6 @@ const JobsPanelDataInputsView = ({
         />
         <Input
           label="Default artifact path"
-          className="default-input"
           floatingLabel
           invalid={panelState.outputPath.length === 0}
           onChange={inputValue => {


### PR DESCRIPTION
https://trello.com/c/Pk9fQT3F/914-jobs-panel-invalid-input-icon-has-wrong-position

- **Create job**: The invalid indication icon was mispositioned in “Default Artifact Path” field.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/126315697-12bae41e-6ef6-4114-894f-9adf68138ea0.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/126315804-a32bd5bc-9056-49b7-bbe6-90c550e9a9ed.png)