### PR TITLE
[Feature Sets] Switching to another feature set doesn't close edit mode on Details

### DIFF
--- a/src/common/LoadButton/LoadButton.js
+++ b/src/common/LoadButton/LoadButton.js
@@ -4,19 +4,21 @@ import classNames from 'classnames'
 
 import './loadButton.scss'
 
-const LoadButton = ({ className, label, variant, ...restProps }) => {
-  const buttonClassName = classNames(
-    'btn-load',
-    `btn-load-${variant}`,
-    className
-  )
+const LoadButton = React.forwardRef(
+  ({ className, label, variant, ...restProps }, ref) => {
+    const buttonClassName = classNames(
+      'btn-load',
+      `btn-load-${variant}`,
+      className
+    )
 
-  return (
-    <button {...restProps} className={buttonClassName}>
-      {label}
-    </button>
-  )
-}
+    return (
+      <button ref={ref} {...restProps} className={buttonClassName}>
+        {label}
+      </button>
+    )
+  }
+)
 
 LoadButton.defaultProps = {
   className: '',

--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -34,6 +34,7 @@ const DetailsView = React.forwardRef(
     {
       actionsMenu,
       applyChanges,
+      applyChangesRef,
       cancelChanges,
       detailsMenu,
       detailsMenuClick,
@@ -130,6 +131,7 @@ const DetailsView = React.forwardRef(
                 }
               >
                 <LoadButton
+                  ref={applyChangesRef}
                   variant="primary"
                   label="Apply Changes"
                   className="btn_apply-changes"

--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -231,6 +231,7 @@ export const generateFunctionsContent = selectedItem => ({
 })
 
 export const renderContent = (
+  applyChangesRef,
   match,
   detailsState,
   selectedItem,
@@ -251,6 +252,7 @@ export const renderContent = (
           content={detailsState.infoContent}
           match={match}
           pageData={pageData}
+          ref={applyChangesRef}
           selectedItem={selectedItem}
           setChangesData={setChangesData}
           setChangesCounter={setChangesCounter}
@@ -435,23 +437,25 @@ export const handleFinishEdit = (
 
   if (
     isEqual(
-      detailsTabState.fieldsData[field]?.previousFieldValue,
-      changes.data[field]
+      changes.data[field]?.initialFieldValue,
+      changes.data[field]?.currentFieldValue
     )
   ) {
-    const fieldsData = { ...detailsTabState.fieldsData }
     const changesData = { ...changes.data }
 
-    delete fieldsData[field]
     delete changesData[field]
 
-    setChangesCounter(fieldsData.length || 0)
-    detailsTabDispatch({
-      type: detailsTabState.SET_FIELDS_DATA,
-      payload: { ...fieldsData }
-    })
+    setChangesCounter(changes.data.length || 0)
     setChangesData({ ...changesData })
   } else {
     setChangesCounter(Object.keys(changes.data).length)
+    setChangesData({
+      ...changes.data,
+      [field]: {
+        initialFieldValue: changes.data[field].initialFieldValue,
+        currentFieldValue: changes.data[field].currentFieldValue,
+        previousFieldValue: changes.data[field].currentFieldValue
+      }
+    })
   }
 }

--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { capitalize } from 'lodash'
+import { capitalize, isNil } from 'lodash'
 import classnames from 'classnames'
 
 import ArtifactInfoSources from '../ArtifactInfoSources/ArtifactInfoSources'
@@ -94,8 +94,8 @@ const DetailsInfoView = React.forwardRef(
                 pageData.page === FEATURE_STORE_PAGE
               ) {
                 if (header.id === 'labels') {
-                  chipsData.chips = changes.data[header.id]
-                    ? changes.data[header.id]
+                  chipsData.chips = !isNil(changes.data[header.id])
+                    ? changes.data[header.id].currentFieldValue
                     : parseKeyValues(content[header.id]?.value)
                   chipsData.chipOptions = getChipOptions(header.id)
                 }
@@ -108,8 +108,8 @@ const DetailsInfoView = React.forwardRef(
                   chipsData.delimiter = <RightArrow />
                 }
 
-                info = changes.data[header.id]
-                  ? changes.data[header.id]
+                info = !isNil(changes.data[header.id])
+                  ? changes.data[header.id].currentFieldValue
                   : selectedItem && content[header.id]?.value
                 target_path =
                   content[header.id]?.value === selectedItem.target_path

--- a/src/components/DetailsInfo/detailsInfoReducer.js
+++ b/src/components/DetailsInfo/detailsInfoReducer.js
@@ -2,18 +2,21 @@ export const initialState = {
   editMode: {
     field: '',
     fieldType: ''
-  },
-  fieldsData: {}
+  }
 }
 
 export const detailsInfoActions = {
+  RESET_EDIT_MODE: 'RESET_EDIT_MODE',
   SET_EDIT_MODE: 'SET_EDIT_MODE',
-  SET_EDIT_MODE_FIELD_TYPE: 'SET_EDIT_MODE_FIELD_TYPE',
-  SET_FIELDS_DATA: 'SET_FIELDS_DATA'
+  SET_EDIT_MODE_FIELD_TYPE: 'SET_EDIT_MODE_FIELD_TYPE'
 }
 
 export const detailsInfoReducer = (state, { type, payload }) => {
   switch (type) {
+    case detailsInfoActions.RESET_EDIT_MODE:
+      return {
+        ...initialState
+      }
     case detailsInfoActions.SET_EDIT_MODE:
       return {
         ...state,
@@ -21,16 +24,10 @@ export const detailsInfoReducer = (state, { type, payload }) => {
       }
     case detailsInfoActions.SET_EDIT_MODE_FIELD_TYPE:
       return {
-        ...state,
         editMode: {
           ...state.editMode,
           fieldType: payload
         }
-      }
-    case detailsInfoActions.SET_FIELDS_DATA:
-      return {
-        ...state,
-        fieldsData: payload
       }
     default:
       return state

--- a/src/components/DetailsRequestedFeatures/detailsRequestedFeaturesReducer.js
+++ b/src/components/DetailsRequestedFeatures/detailsRequestedFeaturesReducer.js
@@ -2,23 +2,20 @@ export const initialState = {
   editMode: {
     field: '',
     fieldType: ''
-  },
-  fieldsData: {}
+  }
 }
 
 export const detailsRequestedFeaturesActions = {
   RESET_EDIT_MODE: 'RESET_EDIT_MODE',
   SET_EDIT_MODE: 'SET_EDIT_MODE',
-  SET_EDIT_MODE_FIELD_TYPE: 'SET_EDIT_MODE_FIELD_TYPE',
-  SET_FIELDS_DATA: 'SET_FIELDS_DATA'
+  SET_EDIT_MODE_FIELD_TYPE: 'SET_EDIT_MODE_FIELD_TYPE'
 }
 
 export const detailsRequestedFeaturesReducer = (state, { type, payload }) => {
   switch (type) {
     case detailsRequestedFeaturesActions.RESET_EDIT_MODE:
       return {
-        ...state,
-        editMode: initialState.editMode
+        ...initialState
       }
     case detailsRequestedFeaturesActions.SET_EDIT_MODE:
       return {
@@ -27,16 +24,10 @@ export const detailsRequestedFeaturesReducer = (state, { type, payload }) => {
       }
     case detailsRequestedFeaturesActions.SET_EDIT_MODE_FIELD_TYPE:
       return {
-        ...state,
         editMode: {
           ...state.editMode,
           fieldType: payload
         }
-      }
-    case detailsRequestedFeaturesActions.SET_FIELDS_DATA:
-      return {
-        ...state,
-        fieldsData: payload
       }
     default:
       return state

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -469,10 +469,12 @@ export const handleApplyDetailsChanges = (
   filters
 ) => {
   const data = {
-    spec: {
-      ...changes.data
-    }
+    spec: {}
   }
+
+  Object.keys(changes.data).forEach(
+    key => (data.spec[key] = changes.data[key].previousFieldValue)
+  )
 
   if (data.spec.labels) {
     const objectLabels = {}


### PR DESCRIPTION
https://trello.com/c/QwEDAfNQ/916-feature-sets-switching-to-another-feature-set-doesnt-close-edit-mode-on-details

- **Feature sets**: Edit mode of “Description” & “Labels” fields remains active after switching to another feature set.
  ![image](https://user-images.githubusercontent.com/13918850/127173445-0a53e410-7db3-4ba6-9b08-d54c23563589.png)