### PR TITLE
Fix [Functions] Overview: Status shows the word "empty"

### DIFF
--- a/src/utils/getState.js
+++ b/src/utils/getState.js
@@ -3,7 +3,7 @@ import { FUNCTIONS_PAGE } from '../constants'
 const getState = (state, page) => {
   if (page === FUNCTIONS_PAGE) {
     return {
-      value: state || 'empty',
+      value: state || '-',
       label: state ? functionStateLabels[state] : 'Created'
     }
   } else {


### PR DESCRIPTION
- **Functions**: In “Overview” tab, the “Status” field shows the literal word “Empty” when there is no status in the backend model.

Jira ticket ML-920