### PR TITLE
[General] Expand button has wrong tooltip

### DIFF
--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -153,25 +153,27 @@ const Content = ({
 
   const handleExpandRow = (e, item) => {
     const parentRow = e.target.closest('.parent-row')
+    let newArray = []
 
     if (parentRow.classList.contains('parent-row-expanded')) {
-      const newArray = expandedItems.filter(
-        expanded =>
-          expanded.name?.value !== item.name?.value ||
-          expanded.name !== item.name ||
-          expanded.name !== item.key.value
+      newArray = expandedItems.filter(expanded =>
+        item.key?.value
+          ? expanded.name !== item.key?.value
+          : expanded.name !== item.name?.value
       )
 
       parentRow.classList.remove('parent-row-expanded')
       pageData.handleRemoveRequestData && pageData.handleRemoveRequestData(item)
-      setExpandedItems(newArray)
       expandRow && expandRow(item, true)
     } else {
       parentRow.classList.remove('row_active')
       parentRow.classList.add('parent-row-expanded')
       pageData.handleRequestOnExpand && pageData.handleRequestOnExpand(item)
-      setExpandedItems([...expandedItems, item])
+      newArray = [...expandedItems, item]
     }
+
+    setExpandedItems(newArray)
+    setExpand(newArray.length === Object.keys(groupedByName).length)
   }
 
   const handleExpandAll = collapseRows => {


### PR DESCRIPTION
https://trello.com/c/2CoOB0JO/923-general-expand-button-has-wrong-tooltip

- **General**: Expand/collapse all action button had an inconsistent behavior. Now Collapse All is displayed only when the entire list of expanded. If at least one item is collapsed, then the Expand All is displayed.