### PR TITLE
[Jobs panel] Can't edit parameter type and value type

### DIFF
--- a/src/elements/EditableParametersRow/EditableParametersRow.js
+++ b/src/elements/EditableParametersRow/EditableParametersRow.js
@@ -32,10 +32,10 @@ const EditableParametersRow = ({
 
   useEffect(() => {
     if (tableRowRef.current) {
-      document.addEventListener('click', handleDocumentClick)
+      window.addEventListener('click', handleDocumentClick)
 
       return () => {
-        document.removeEventListener('click', handleDocumentClick)
+        window.removeEventListener('click', handleDocumentClick)
       }
     }
   }, [handleDocumentClick, tableRowRef])


### PR DESCRIPTION
https://trello.com/c/0LCBG41Q/924-jobs-panel-cant-edit-parameter-type-and-value-type

- **Jobs Panel**: In “Parameters” section, sometimes the user could not edit the parameter details.