### PR TITLE
Fix [Feature set panel] Missing validation for name

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitle.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitle.js
@@ -24,8 +24,12 @@ const FeatureSetsPanelTitle = ({
   })
 
   const handleNameChange = name => {
-    if (!isNameValid && name.length > 0) {
+    const pattern = /^(?=[\S\s]{1,63}$)([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/
+
+    if (!isNameValid && name.length > 0 && pattern.test(name)) {
       setNameValid(true)
+    } else if (!pattern.test(name)) {
+      setNameValid(false)
     }
 
     setData(state => ({


### PR DESCRIPTION
Backporting PR https://github.com/mlrun/ui/pull/706 from branch **development** into branch **0.6.x**:

- **Feature sets**: Validation rules on feature set name were not enforced.
  ![image](https://user-images.githubusercontent.com/13918850/127776173-0af3ebc0-dd71-4e27-8bf6-1a0fcec2b4f0.png)

Jira ticket ML-884