### PR TITLE
Fix [Functions] Overview: Code Origin value missing

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -208,7 +208,7 @@ export const generateFunctionsContent = selectedItem => ({
     value: selectedItem.hash
   },
   codeOrigin: {
-    value: selectedItem.build.codeOrigin ?? ''
+    value: selectedItem.build.code_origin ?? ''
   },
   updated: {
     value: formatDatetime(new Date(selectedItem.updated), 'N/A')


### PR DESCRIPTION
Backporting PR https://github.com/mlrun/ui/pull/714 from branch **development** to branch **0.6.x**:

- **Functions**: In “Overview” tab, the “Code Origin” did not display its value even though there was a valid value for it.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/127825623-dc25aae6-4400-4852-bed8-dee91fe9f0df.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/127825577-e87976d4-2f71-40b9-ab7b-65eb127b43f7.png)
