### PR TITLE
Fix [Function panel] Cannot add env vars on edit function

### DIFF
--- a/src/components/FunctionsPanel/FunctionsPanelView.js
+++ b/src/components/FunctionsPanel/FunctionsPanelView.js
@@ -72,7 +72,7 @@ const FunctionsPanelView = ({
             iconClassName="new-item-side-panel__expand-icon"
             openByDefault
           >
-            <FunctionsPanelEnvironmentVariables defaultData={defaultData} />
+            <FunctionsPanelEnvironmentVariables />
           </Accordion>
           <Accordion
             accordionClassName="new-item-side-panel__accordion hidden"

--- a/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
+++ b/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
 
 import FunctionsPanelEnvironmentVariablesView from './FunctionsPanelEnvironmentVariablesView'
 
 import functionsActions from '../../actions/functions'
 
 const FunctionsPanelEnvironmentVariables = ({
-  defaultData,
   functionsStore,
   setNewFunctionEnv
 }) => {
@@ -41,25 +39,15 @@ const FunctionsPanelEnvironmentVariables = ({
 
   return (
     <FunctionsPanelEnvironmentVariablesView
-      env={(defaultData.env || functionsStore.newFunction.spec.env).map(
-        env => ({
-          key: env.name,
-          value: env.value
-        })
-      )}
+      env={functionsStore.newFunction.spec.env.map(env => ({
+        key: env.name,
+        value: env.value
+      }))}
       handleAddNewEnv={handleAddNewEnv}
       handleDeleteEnv={handleDeleteEnv}
       handleEditEnv={handleEditEnv}
     />
   )
-}
-
-FunctionsPanelEnvironmentVariables.defaultProps = {
-  defaultData: {}
-}
-
-FunctionsPanelEnvironmentVariables.propTypes = {
-  defaultData: PropTypes.shape({})
 }
 
 export default connect(


### PR DESCRIPTION
Backports PR https://github.com/mlrun/ui/pull/707 from branch **development** to branch **0.6.x**:

- **Function panel**: A new created environment variable was hidden in the list but was actually there behind the scenes and was sent when saving/deploying the function. Now it is properly visible right after adding it.

Jira ticket ML-905