### PR TITLE
[Notification] Moved to bottom-right corner

### DIFF
--- a/src/common/Notification/Notification.js
+++ b/src/common/Notification/Notification.js
@@ -9,6 +9,7 @@ import notificationAction from '../../actions/notification'
 const Notification = ({ notificationStore, removeNotification }) => {
   const defaultStyle = {
     position: 'fixed',
+    right: '24px',
     bottom: '-100px',
     opacity: 0,
     zIndex: '1000'


### PR DESCRIPTION
https://trello.com/c/AzdIaWWp/930-notification-move-to-bottom-right-corner

- **Notifications**: Moved notifications to the bottom-right corner of the screen, instead of the bottom center.
  ![image](https://user-images.githubusercontent.com/13918850/127857929-b2052dd1-c800-4aed-b3d4-0623b1a04bc5.png)