### PR TITLE
[Feature sets] Refresh doesn't show notification with changes on Details

### DIFF
--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -219,7 +219,11 @@ const DetailsView = React.forwardRef(
             <div className="pop-up-dialog__footer-container">
               <Button
                 variant="tertiary"
-                label="Don't Leave"
+                label={
+                  detailsStore.refreshWasHandled
+                    ? "Don't refresh"
+                    : "Don't Leave"
+                }
                 onClick={() => {
                   handleShowWarning(false)
                   setRefreshWasHandled(false)
@@ -227,7 +231,7 @@ const DetailsView = React.forwardRef(
               />
               <Button
                 variant="primary"
-                label="Leave"
+                label={detailsStore.refreshWasHandled ? 'Refresh' : 'Leave'}
                 className="pop-up-dialog__btn_cancel"
                 onClick={leavePage}
               />

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -352,6 +352,9 @@ export const handleFetchData = async (
     if (result) {
       data.content = parseFeatureSets(result)
       data.originalContent = result
+    } else {
+      data.content = null
+      data.originalContent = null
     }
   } else if (pageTab === FEATURES_TAB) {
     const allSettledResult = await Promise.allSettled([


### PR DESCRIPTION
https://trello.com/c/OiKVt66a/932-feature-sets-refresh-doesnt-show-notification-with-changes-on-details

- **Feature sets**: When there are pending changes, there was no warning on clicking the “Refresh” icon button regarding discarding the changes.
  ![image](https://user-images.githubusercontent.com/13918850/128005568-daefba2c-6689-4b14-a2b7-5d7d7449ad6a.png)