### PR TITLE
[Function panel] Volumes: wrong field name

### DIFF
--- a/src/elements/EditableVolumesRow/EditableVolumesRow.js
+++ b/src/elements/EditableVolumesRow/EditableVolumesRow.js
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 
 import Input from '../../common/Input/Input'
 
 import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
+import { getVolumeTypeInput, V3IO } from '../VolumesTable/volumesTable.util'
 
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 
@@ -15,6 +16,11 @@ const EditableVolumesRow = ({
   selectedVolume,
   setSelectedVolume
 }) => {
+  const volumeTypeInput = useMemo(
+    () => getVolumeTypeInput(selectedVolume.type.value),
+    [selectedVolume.type.value]
+  )
+
   return (
     <>
       <div className="table__row edit-row">
@@ -62,7 +68,7 @@ const EditableVolumesRow = ({
         <div className="table__cell table__cell-input">
           <Input
             floatingLabel
-            label="Container"
+            label={volumeTypeInput.label}
             onChange={typeName =>
               setSelectedVolume({
                 ...selectedVolume,
@@ -86,7 +92,7 @@ const EditableVolumesRow = ({
           </button>
         </div>
       </div>
-      {selectedVolume.type.value === 'V3IO' && (
+      {selectedVolume.type.value === V3IO && (
         <div className="table__row edit-row">
           <div className="table__cell table__cell-input">
             <Input

--- a/src/elements/VolumesTable/VolumesTable.js
+++ b/src/elements/VolumesTable/VolumesTable.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import VolumesTableView from './VolumesTableView'
+import { CONFIG_MAP, PVC, SECRET, V3IO } from './volumesTable.util'
 
 import { ReactComponent as Edit } from '../../images/edit.svg'
 import { ReactComponent as Delete } from '../../images/delete.svg'
@@ -35,7 +36,7 @@ export const VolumesTable = ({
         return setSelectedVolume({
           ...selectedVolume,
           type: {
-            value: 'Config Map',
+            value: CONFIG_MAP,
             name: searchItem.configMap.name
           }
         })
@@ -43,7 +44,7 @@ export const VolumesTable = ({
         return setSelectedVolume({
           ...selectedVolume,
           type: {
-            value: 'PVC',
+            value: PVC,
             name: searchItem.persistentVolumeClaim.claimName
           }
         })
@@ -51,7 +52,7 @@ export const VolumesTable = ({
         return setSelectedVolume({
           ...selectedVolume,
           type: {
-            value: 'Secret',
+            value: SECRET,
             name: searchItem.secret.secretName
           }
         })
@@ -59,7 +60,7 @@ export const VolumesTable = ({
         return setSelectedVolume({
           ...selectedVolume,
           type: {
-            value: 'V3IO',
+            value: V3IO,
             name: searchItem.flexVolume.options.container,
             accessKey: searchItem.flexVolume.options.accessKey,
             subPath: searchItem.flexVolume.options.subPath
@@ -127,13 +128,13 @@ export const VolumesTable = ({
         volume.name = selectedVolume.newName || selectedVolume.data.name
 
         switch (selectedVolume.type.value) {
-          case 'Config Map':
+          case CONFIG_MAP:
             volume.configMap.name = selectedVolume.type.name
             break
-          case 'PVC':
+          case PVC:
             volume.persistentVolumeClaim.claimName = selectedVolume.type.name
             break
-          case 'Secret':
+          case SECRET:
             volume.secret.secretName = selectedVolume.type.name
             break
           default:

--- a/src/elements/VolumesTable/VolumesTableView.js
+++ b/src/elements/VolumesTable/VolumesTableView.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { find, has, map } from 'lodash'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
@@ -11,7 +11,12 @@ import ActionsMenu from '../../common/ActionsMenu/ActionsMenu'
 import Input from '../../common/Input/Input'
 import Select from '../../common/Select/Select'
 
-import { selectTypeOptions, tableHeaders } from './volumesTable.util'
+import {
+  getVolumeTypeInput,
+  selectTypeOptions,
+  tableHeaders,
+  V3IO
+} from './volumesTable.util'
 import { joinDataOfArrayOrObject } from '../../utils'
 import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
 
@@ -32,21 +37,9 @@ const VolumesTableView = ({
   setShowAddNewVolumeRow,
   showAddNewVolumeRow
 }) => {
-  const volumeTypeNameLabel =
-    newVolume.type === 'V3IO'
-      ? {
-          label: 'Container',
-          tip: 'The name of the data container that contains the data'
-        }
-      : newVolume.type === 'PVC'
-      ? {
-          label: 'Claim name'
-        }
-      : newVolume.type.length > 0
-      ? {
-          label: `${newVolume.type} name`
-        }
-      : ''
+  const volumeTypeInput = useMemo(() => getVolumeTypeInput(newVolume.type), [
+    newVolume.type
+  ])
   const tableClassNames = classnames(
     'new-item-side-panel__table',
     'volumes-table',
@@ -155,20 +148,20 @@ const VolumesTableView = ({
             </div>
             <div
               className={`input-row-wrapper no-border_top
-                  ${newVolume.type === 'V3IO' && 'no-border'}`}
+                  ${newVolume.type === V3IO && 'no-border'}`}
             >
               <Input
                 onChange={typeName =>
                   setNewVolume(state => ({ ...state, typeName }))
                 }
-                label={volumeTypeNameLabel.label}
+                label={volumeTypeInput.label}
                 className="input-row__item"
                 disabled={newVolume.type.length === 0}
                 floatingLabel
                 type="text"
-                tip={volumeTypeNameLabel.tip}
+                tip={volumeTypeInput.tip}
               />
-              {newVolume.type === 'V3IO' && (
+              {newVolume.type === V3IO && (
                 <Input
                   onChange={accessKey =>
                     setNewVolume(state => ({ ...state, accessKey }))
@@ -181,7 +174,7 @@ const VolumesTableView = ({
                 />
               )}
             </div>
-            {newVolume.type === 'V3IO' && (
+            {newVolume.type === V3IO && (
               <div className="input-row-wrapper no-border_top">
                 <Input
                   onChange={subPath =>

--- a/src/elements/VolumesTable/volumesTable.util.js
+++ b/src/elements/VolumesTable/volumesTable.util.js
@@ -1,3 +1,19 @@
+export const V3IO = 'V3IO'
+export const CONFIG_MAP = 'Config Map'
+export const SECRET = 'Secret'
+export const PVC = 'PVC'
+
+export const volumeTypeInputLabels = {
+  [V3IO]: 'Container',
+  [CONFIG_MAP]: 'Config map name',
+  [SECRET]: 'Secret name',
+  [PVC]: 'Claim name'
+}
+
+export const volumeTypeInputTips = {
+  [V3IO]: 'The name of the data container that contains the data'
+}
+
 export const tableHeaders = [
   { label: 'Type', id: 'type' },
   { label: 'Volume name', id: 'name' },
@@ -6,9 +22,16 @@ export const tableHeaders = [
 
 export const selectTypeOptions = {
   volumeType: [
-    { label: 'V3IO', id: 'V3IO' },
-    { label: 'Config Map', id: 'Config Map' },
-    { label: 'Secret', id: 'Secret' },
-    { label: 'PVC', id: 'PVC' }
+    { label: 'V3IO', id: V3IO },
+    { label: 'Config Map', id: CONFIG_MAP },
+    { label: 'Secret', id: SECRET },
+    { label: 'PVC', id: PVC }
   ]
+}
+
+export const getVolumeTypeInput = type => {
+  return {
+    label: volumeTypeInputLabels[type],
+    tip: volumeTypeInputTips[type]
+  }
 }

--- a/src/utils/createNewVolume.js
+++ b/src/utils/createNewVolume.js
@@ -1,6 +1,12 @@
+import {
+  CONFIG_MAP,
+  SECRET,
+  V3IO
+} from '../elements/VolumesTable/volumesTable.util'
+
 export const createNewVolume = newVolume => {
   switch (newVolume.type) {
-    case 'V3IO':
+    case V3IO:
       return {
         name: newVolume.name,
         flexVolume: {
@@ -12,14 +18,14 @@ export const createNewVolume = newVolume => {
           }
         }
       }
-    case 'Config Map':
+    case CONFIG_MAP:
       return {
         name: newVolume.name,
         configMap: {
           name: newVolume.typeName
         }
       }
-    case 'Secret':
+    case SECRET:
       return {
         name: newVolume.name,
         secret: {

--- a/src/utils/panelResources.util.js
+++ b/src/utils/panelResources.util.js
@@ -1,3 +1,10 @@
+import {
+  CONFIG_MAP,
+  PVC,
+  SECRET,
+  V3IO
+} from '../elements/VolumesTable/volumesTable.util'
+
 export const selectMemoryOptions = {
   unitCpu: [
     { label: 'cpu', id: 'cpu' },
@@ -32,12 +39,12 @@ export const generateMemoryValue = (memory = '') =>
 
 export const getVolumeType = volume => {
   if (volume.configMap) {
-    return 'Config Map'
+    return CONFIG_MAP
   } else if (volume.persistentVolumeClaim) {
-    return 'PVC'
+    return PVC
   } else if (volume.secret) {
-    return 'Secret'
+    return SECRET
   } else {
-    return 'V3IO'
+    return V3IO
   }
 }


### PR DESCRIPTION
https://trello.com/c/8SCTxxzd/933-function-panel-volumes-wrong-field-name

- **Job/Function panel**: In ”Volumes” section, when editing an existing volume the extra custom field was always labeled ”Container” regardless of the volume type. Now it is properly labeled “Config Map Name”, “Secret name” or ”Claim name” according to the volume type.
  Before & after:
  ![image](https://user-images.githubusercontent.com/13918850/128342458-f2a324c8-a2c8-4f3a-b01c-4f53885a83dd.png)![image](https://user-images.githubusercontent.com/13918850/128342470-e27f6a84-0afd-4147-b2ad-63b10522afc3.png)
  ![image](https://user-images.githubusercontent.com/13918850/128342568-f65840e9-b6e1-4a93-83f8-bdcf2a665d93.png)![image](https://user-images.githubusercontent.com/13918850/128342571-1609fbec-0b1a-4435-8c2e-238a74931c3c.png)
  ![image](https://user-images.githubusercontent.com/13918850/128342584-37612dfd-8347-42dc-a078-f50239b6005d.png)![image](https://user-images.githubusercontent.com/13918850/128342590-82b191bd-3412-4d23-8622-136c13a7d293.png)

Jira ticket ML-921