### PR TITLE
[Functions] Hide Edit action when not in Ready state

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -103,7 +103,9 @@ const Functions = ({
           setFunctionsPanelIsOpen(true)
           setEditableItem(func)
         },
-        hidden: !['job', ''].includes(item?.type)
+        hidden:
+          !['job', ''].includes(item?.type) ||
+          !FUNCTIONS_READY_STATES.includes(item?.state?.value)
       },
       {
         label: 'Delete',


### PR DESCRIPTION
https://trello.com/c/RDJazjBs/938-functions-hide-edit-action-when-not-in-ready-state

- **Functions**: Hide the “Edit” action when the function is not in “Ready” state.

Jira ticket ML-966