### PR TITLE
[Function panel] Description not properly loaded on edit

### DIFF
--- a/src/components/FunctionsPanel/FunctionsPanel.js
+++ b/src/components/FunctionsPanel/FunctionsPanel.js
@@ -7,6 +7,7 @@ import { chain } from 'lodash'
 import FunctionsPanelView from './FunctionsPanelView'
 
 import functionsActions from '../../actions/functions'
+import { FUNCTION_PANEL_MODE } from '../../types'
 
 const FunctionsPanel = ({
   functionsStore,
@@ -142,7 +143,7 @@ FunctionsPanel.propTypes = {
   handleDeployFunctionFailure: PropTypes.func.isRequired,
   handleDeployFunctionSuccess: PropTypes.func.isRequired,
   match: PropTypes.shape({}).isRequired,
-  mode: PropTypes.string.isRequired,
+  mode: FUNCTION_PANEL_MODE.isRequired,
   project: PropTypes.string.isRequired
 }
 

--- a/src/components/FunctionsPanel/FunctionsPanelView.js
+++ b/src/components/FunctionsPanel/FunctionsPanelView.js
@@ -11,6 +11,7 @@ import FunctionsPanelEnvironmentVariables from '../../elements/FunctionsPanelEnv
 import Button from '../../common/Button/Button'
 import ErrorMessage from '../../common/ErrorMessage/ErrorMessage'
 import FunctionsPanelSecrets from '../../elements/FunctionsPanelSecrets/FunctionsPanelSecrets'
+import { FUNCTION_PANEL_MODE } from '../../types'
 
 import { ReactComponent as Arrow } from '../../images/arrow.svg'
 
@@ -133,7 +134,7 @@ FunctionsPanelView.propTypes = {
   isHandlerValid: PropTypes.bool.isRequired,
   isNameValid: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
-  mode: PropTypes.string.isRequired,
+  mode: FUNCTION_PANEL_MODE.isRequired,
   removeFunctionsError: PropTypes.func.isRequired,
   setHandlerValid: PropTypes.func.isRequired,
   setNameValid: PropTypes.func.isRequired

--- a/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneral.js
+++ b/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneral.js
@@ -20,7 +20,7 @@ const FunctionsPanelGeneral = ({
 }) => {
   const [data, setData] = useState({
     name: defaultData.name ?? '',
-    description: defaultData.delete ?? '',
+    description: defaultData.description ?? '',
     type: defaultData.type ?? DEFAULT_TYPE,
     labels: parseKeyValues(defaultData.labels) ?? [],
     tag: defaultData.tag ?? ''

--- a/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
+++ b/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
@@ -11,6 +11,7 @@ import {
   getDefaultMemoryUnit,
   getDefaultVolumeMounts
 } from './functionsPanelResources.util'
+import { FUNCTION_PANEL_MODE } from '../../types'
 
 const FunctionsPanelResources = ({
   defaultData,
@@ -291,7 +292,7 @@ FunctionsPanelResources.defaultProp = {
 
 FunctionsPanelResources.propTypes = {
   defaultData: PropTypes.shape({}),
-  mode: PropTypes.string.isRequired
+  mode: FUNCTION_PANEL_MODE.isRequired
 }
 
 export default connect(functionsStore => ({ ...functionsStore }), {

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import { PANEL_CREATE_MODE, PANEL_EDIT_MODE } from './constants'
 
 export const COMBOBOX_MATCHES = PropTypes.arrayOf(
   PropTypes.shape({
@@ -50,6 +51,11 @@ export const CHIP_OPTIONS = PropTypes.shape({
 })
 
 export const CHIPS = PropTypes.arrayOf(CHIP)
+
+export const FUNCTION_PANEL_MODE = PropTypes.oneOf([
+  PANEL_EDIT_MODE,
+  PANEL_CREATE_MODE
+])
 
 export const POP_UP_CUSTOM_POSITION = PropTypes.shape({
   element: PropTypes.shape({}),


### PR DESCRIPTION
https://trello.com/c/ruNckLuo/942-function-panel-description-not-properly-loaded-on-edit

- **Function panel**: In “General” section, “Description” field was not pre-loaded properly, it was always empty.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/128625209-75ce6bcf-a8a0-43cd-959e-5e21dc13bb91.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/128625216-b08d68d4-1e8a-4f9c-bbf2-7548d4a0dda9.png)

Jira ticket ML-974