### PR TITLE
Fix [Model Endpoints] Error when an item has model_uri of null

### DIFF
--- a/src/utils/parseUri.js
+++ b/src/utils/parseUri.js
@@ -48,8 +48,8 @@
  *         tag:       undefined,
  *         uid:       '24fce79e709f9b3fe5e8251a39e67c678d94c20c' }
  */
-const parseUri = (uri = '') =>
-  uri.match(
+const parseUri = uri =>
+  (uri ?? '').match(
     /^store:\/\/(?<kind>.+?)\/(?<project>.+?)\/(?<key>.+?)(#(?<iteration>.+?))?(:(?<tag>.+?))?(@(?<uid>.+))?$/
   )?.groups ?? {}
 


### PR DESCRIPTION
- **Model Endpoints**: An error occurred when loading the list of model endpoints and an endpoint had a `spec.model_url` value of `null`.