### PR TITLE
Fix [Model Endpoints] Version: Router not displayed for routers

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -329,7 +329,7 @@ const createModelEndpointsRowData = (artifact, project) => {
       type: 'hidden'
     },
     version: {
-      value: artifact.children ? 'Router' : tag,
+      value: artifact?.status?.children ? 'Router' : tag,
       class: 'artifacts_extra-small'
     },
     modelClass: {


### PR DESCRIPTION
- **Model Endpoints**: Show “Router” in “Version” column of router rows.
  ![image](https://user-images.githubusercontent.com/13918850/129852295-130bb911-bf83-4bd0-bd28-82921d97a902.png)

Jira ticket ML-911

Continuing PR https://github.com/mlrun/ui/pull/741
In-release (RC)