### PR TITLE
Impl [Functions] Show "Edit" action on demo mode only

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -105,6 +105,7 @@ const Functions = ({
           setEditableItem(func)
         },
         hidden:
+          new URLSearchParams(location.search).get('demo') !== 'true' ||
           !['job', ''].includes(item?.type) ||
           !FUNCTIONS_EDITABLE_STATES.includes(item?.state?.value)
       },


### PR DESCRIPTION
- **Functions**: Hide “Edit” action from action menu when `demo=true` is not provided.

Jira ticket ML-1002