### PR TITLE
[Volumes] Made Container Name and Resource Path optional

### DIFF
--- a/src/elements/EditableVolumesRow/EditableVolumesRow.js
+++ b/src/elements/EditableVolumesRow/EditableVolumesRow.js
@@ -113,7 +113,7 @@ const EditableVolumesRow = ({
         <div className="table__cell table__cell-input">
           <Input
             floatingLabel
-            invalid={!validation.isTypeValid}
+            invalid={!validation.isTypeNameValid}
             invalidText="This field is invalid"
             label={volumeTypeInput.label}
             onChange={typeName =>
@@ -122,10 +122,10 @@ const EditableVolumesRow = ({
                 type: { ...selectedVolume.type, name: typeName }
               })
             }
-            required
+            required={selectedVolume.type.value !== V3IO}
             requiredText="This field is invalid"
             setInvalid={value =>
-              setValidation(state => ({ ...state, isTypeValid: value }))
+              setValidation(state => ({ ...state, isTypeNameValid: value }))
             }
             type="text"
             value={selectedVolume.type.name}
@@ -144,8 +144,8 @@ const EditableVolumesRow = ({
               !validation.isNameValid ||
               !validation.isPathValid ||
               !validation.isTypeValid ||
-              !validation.isAccessKeyValid ||
-              !validation.isSubPathValid
+              !validation.isTypeNameValid ||
+              !validation.isAccessKeyValid
             }
           >
             <Checkmark />
@@ -178,19 +178,12 @@ const EditableVolumesRow = ({
           <div className="table__cell table__cell-input">
             <Input
               floatingLabel
-              invalid={!validation.isSubPathValid}
-              invalidText="This field is invalid"
               label="Resource Path"
               onChange={subPath =>
                 setSelectedVolume({
                   ...selectedVolume,
                   type: { ...selectedVolume.type, subPath: subPath }
                 })
-              }
-              required
-              requiredText="This field is required"
-              setInvalid={value =>
-                setValidation(state => ({ ...state, isSubPathValid: value }))
               }
               type="text"
               value={selectedVolume.type.subPath}

--- a/src/elements/VolumesTable/VolumesTable.js
+++ b/src/elements/VolumesTable/VolumesTable.js
@@ -28,8 +28,7 @@ export const VolumesTable = ({
     isTypeValid: true,
     isTypeNameValid: true,
     isPathValid: true,
-    isAccessKeyValid: true,
-    isSubPathValid: true
+    isAccessKeyValid: true
   })
   const [showAddNewVolumeRow, setShowAddNewVolumeRow] = useState(false)
   const [selectedVolume, setSelectedVolume] = useState(null)
@@ -123,11 +122,14 @@ export const VolumesTable = ({
 
     if (newVolume.type === V3IO) {
       volumeIsValid =
-        volumeIsValid &&
+        newVolume.name.length > 0 &&
+        validation.isNameValid &&
+        newVolume.path.length > 0 &&
+        validation.isPathValid &&
+        newVolume.type.length > 0 &&
+        validation.isTypeValid &&
         newVolume.accessKey.length > 0 &&
-        validation.isAccessKeyValid &&
-        newVolume.subPath.length > 0 &&
-        validation.isSubPathValid
+        validation.isAccessKeyValid
     }
 
     if (volumeIsValid) {
@@ -148,8 +150,7 @@ export const VolumesTable = ({
       isTypeValid: true,
       isTypeNameValid: true,
       isPathValid: true,
-      isAccessKeyValid: true,
-      isSubPathValid: true
+      isAccessKeyValid: true
     })
   }
 

--- a/src/elements/VolumesTable/VolumesTableView.js
+++ b/src/elements/VolumesTable/VolumesTableView.js
@@ -134,8 +134,7 @@ const VolumesTableView = ({
                   setValidation(state => ({
                     ...state,
                     isTypeValid: true,
-                    isAccessKeyValid: true,
-                    isSubPathValid: true
+                    isAccessKeyValid: true
                   }))
                 }}
               />
@@ -196,7 +195,7 @@ const VolumesTableView = ({
                 onChange={typeName =>
                   setNewVolume(state => ({ ...state, typeName }))
                 }
-                required
+                required={newVolume.type !== V3IO}
                 requiredText="This field is required"
                 setInvalid={value =>
                   setValidation(state => ({ ...state, isTypeNameValid: value }))
@@ -231,18 +230,9 @@ const VolumesTableView = ({
                 <Input
                   className="input-row__item"
                   floatingLabel
-                  invalid={!validation.isSubPathValid}
                   label="Resource path"
                   onChange={subPath =>
                     setNewVolume(state => ({ ...state, subPath }))
-                  }
-                  required
-                  requiredText="This field is required"
-                  setInvalid={value =>
-                    setValidation(state => ({
-                      ...state,
-                      isSubPathValid: value
-                    }))
                   }
                   tip="A relative directory path within the data container"
                   type="text"


### PR DESCRIPTION
https://trello.com/c/pzX1ApGE/958-volumes-make-container-name-and-resource-path-optional

- **Volumes**: For V3IO type, “Container name” and “Resource Path” fields turned optional.
  ![image](https://user-images.githubusercontent.com/13918850/130504749-4734d609-5903-4509-9bd6-e9d2932adf04.png)

Jira ticket ML-949

In-release (GA)
Continues https://github.com/mlrun/ui/pull/735 [v0.7.0-rc5](https://github.com/mlrun/ui/releases/tag/v0.7.0-rc5)