### PR TITLE
Fix [Feature set panel] Data Source: redundant description

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSourceView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSourceView.js
@@ -110,9 +110,6 @@ const FeatureSetsPanelDataSourceView = ({
             )}
           </div>
         )}
-        <p className="data-source__description">
-          Users can add the following parameters to filter the data.
-        </p>
         {data.kind === CSV && (
           <Input
             className="data-source__inputs-item"


### PR DESCRIPTION
- **Feature set panel**: In “Data Source” section, removed a redundant description paragraph.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/130970957-fcf9a8f2-c879-456b-98bb-53b5fce7ea8e.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/130970967-7e072124-c3d1-4300-9e99-ae94f9162abf.png)
