### PR TITLE
[Volumes] Hide horizontal dividers, show field borders

### DIFF
--- a/src/elements/EditableVolumesRow/EditableVolumesRow.js
+++ b/src/elements/EditableVolumesRow/EditableVolumesRow.js
@@ -109,7 +109,7 @@ const EditableVolumesRow = ({
         </div>
         <div className="table__cell-actions" />
       </div>
-      <div className="table__row edit-row flex-row">
+      <div className="table__row edit-row flex-row no-border_top">
         <div className="table__cell table__cell-input">
           <Input
             floatingLabel
@@ -153,7 +153,7 @@ const EditableVolumesRow = ({
         </div>
       </div>
       {selectedVolume.type.value === V3IO && (
-        <div className="table__row edit-row">
+        <div className="table__row edit-row no-border_top">
           <div className="table__cell table__cell-input">
             <Input
               floatingLabel

--- a/src/elements/VolumesTable/VolumesTableView.js
+++ b/src/elements/VolumesTable/VolumesTableView.js
@@ -49,6 +49,10 @@ const VolumesTableView = ({
     showAddNewVolumeRow && 'no-border',
     className
   )
+  const volumeTypeInputRowWrapperClassNames = classnames(
+    'input-row-wrapper',
+    newVolume.type === V3IO && 'no-border'
+  )
 
   return (
     <div className={tableClassNames}>
@@ -182,10 +186,7 @@ const VolumesTableView = ({
                 type="text"
               />
             </div>
-            <div
-              className={`input-row-wrapper no-border_top
-                  ${newVolume.type === V3IO && 'no-border'}`}
-            >
+            <div className={volumeTypeInputRowWrapperClassNames}>
               <Input
                 className="input-row__item"
                 disabled={newVolume.type.length === 0}
@@ -226,7 +227,7 @@ const VolumesTableView = ({
               )}
             </div>
             {newVolume.type === V3IO && (
-              <div className="input-row-wrapper no-border_top">
+              <div className="input-row-wrapper">
                 <Input
                   className="input-row__item"
                   floatingLabel


### PR DESCRIPTION
https://trello.com/c/NZepqBbJ/960-volumes-hide-horizontal-dividers-show-field-borders

- **Volumes**: Hid redundant horizontal lines on edit, added field borders on creation.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/131002913-0c221a83-fa79-4abc-8b95-a6d8b4b5b310.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/131003033-bab7273a-ebdf-4e66-9219-7814cec8bbbc.png)

Jira ticket ML-918