### PR TITLE
[Functions] First row Name cell is clipped on expand

### DIFF
--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -265,7 +265,7 @@
           .table-body__row {
             &:first-child {
               position: sticky;
-              top: 45px;
+              top: 35px;
               z-index: 1;
               background-color: $white;
 


### PR DESCRIPTION
https://trello.com/c/1PlEerWA/964-functions-first-row-name-cell-is-clipped-on-expand

- **Functions**: When details panel is open, expanding the first row resulted in cropped date of the function
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/131334436-a99284c5-7d7d-4bf6-8d13-2dfe9ccd00ed.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/131334430-bb547d6f-ed64-4c93-bc21-872b9b81d446.png)

Jira ML-1025