### PR TITLE
[Feature sets][Feature vectors] Histograms: added min/max

### DIFF
--- a/src/components/DetailsStatistics/DetailsStatistics.js
+++ b/src/components/DetailsStatistics/DetailsStatistics.js
@@ -57,6 +57,40 @@ const DetailsStatistics = ({ selectedItem }) => {
                     `statistics-cell__type_${headers[index].type}`,
                     headers[index].hidden && 'statistics-cell_hidden'
                   )
+                  const config =
+                    statisticsValue.type === 'chart'
+                      ? {
+                          ...chartConfig,
+                          data: {
+                            labels: statisticsValue.value[1],
+                            datasets: [
+                              {
+                                data: statisticsValue.value[0],
+                                showLine: false,
+                                backgroundColor: [colors.amethyst]
+                              }
+                            ]
+                          },
+                          options: {
+                            ...chartConfig.options,
+                            scales: {
+                              ...chartConfig.options.scales,
+                              y: {
+                                ...chartConfig.options.scales.y,
+                                display: true,
+                                min: Math.min(...statisticsValue.value[0]),
+                                max: Math.max(...statisticsValue.value[0]),
+                                ticks: {
+                                  ...chartConfig.options.scales.y.ticks,
+                                  stepSize: Math.max(
+                                    ...statisticsValue.value[0]
+                                  )
+                                }
+                              }
+                            }
+                          }
+                        }
+                      : {}
 
                   return (
                     <div
@@ -68,21 +102,7 @@ const DetailsStatistics = ({ selectedItem }) => {
                         statisticsValue.value}
                       {statisticsValue.type === 'chart' &&
                         statisticsValue.value[1]?.length > 0 && (
-                          <MlChart
-                            config={{
-                              ...chartConfig,
-                              data: {
-                                labels: statisticsValue.value[1],
-                                datasets: [
-                                  {
-                                    data: statisticsValue.value[0],
-                                    showLine: false,
-                                    backgroundColor: [colors.amethyst]
-                                  }
-                                ]
-                              }
-                            }}
-                          />
+                          <MlChart config={config} />
                         )}
                       {!statisticsValue.type.match(/icon|chart/) && (
                         <Tooltip

--- a/src/scss/mixins.scss
+++ b/src/scss/mixins.scss
@@ -61,7 +61,7 @@
       display: flex;
       flex-direction: row;
       min-width: 100%;
-      height: 32px;
+      height: 45px;
       border-bottom: $secondaryBorder;
     }
   }


### PR DESCRIPTION
https://trello.com/c/fS72LV7U/952-feature-setsfeature-vectors-histograms-add-min-max

- **Feature sets, Feature vectors**: In “Statistics” tab, added the maximum and minimum values of the y-axis in the histograms.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/131373919-dbc728ae-69fc-4ed4-bc09-ac7ddc6a1a78.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/131373926-72bfa883-0a62-42a8-a370-a6fa58ef2861.png)

Jira ticket ML-1026