### PR TITLE
[Jobs] Hide "Re-run" for kind local

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -227,7 +227,10 @@ export const generateActionsMenu = (
         {
           label: 'Re-run',
           icon: <Run />,
-          onClick: handleRerunJob
+          onClick: handleRerunJob,
+          hidden:
+            job.ui.originalContent.kind.length === 0 ||
+            job.ui.originalContent.kind === 'local'
         },
         {
           label: 'Monitoring',

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -228,9 +228,7 @@ export const generateActionsMenu = (
           label: 'Re-run',
           icon: <Run />,
           onClick: handleRerunJob,
-          hidden:
-            job.ui.originalContent.kind.length === 0 ||
-            job.ui.originalContent.kind === 'local'
+          hidden: job.ui.originalContent.metadata.labels.kind === 'local'
         },
         {
           label: 'Monitoring',


### PR DESCRIPTION
https://trello.com/c/EUXlsQrO/970-jobs-hide-re-run-for-kind-local

- **Jobs**: Hid the “Re-run” action from jobs of kind Local.
  ![image](https://user-images.githubusercontent.com/13918850/131680837-54fd2c62-b9ce-4bf7-8896-2af4240bbf87.png)

Jira ticket ML-1041, ML-1044