### PR TITLE
[General] Chips pop-over is cropped

### DIFF
--- a/src/utils/getFirstScrollableParent.js
+++ b/src/utils/getFirstScrollableParent.js
@@ -1,4 +1,4 @@
-const regex = /(auto|scroll)/
+const regex = /(auto|scroll|hidden)/
 
 const style = (node, prop) =>
   getComputedStyle(node, null).getPropertyValue(prop)


### PR DESCRIPTION
https://trello.com/c/MWRYg3V2/966-general-chips-pop-over-is-cropped

- **Jobs**: Labels pop-over was obstructed.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/131539320-007d7269-1fcb-4e22-baad-f4f1f6f65bea.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/131539326-5b065923-57f4-4ec2-8c7e-ef20107f87f4.png)

Jira ticket ML-1031