### PR TITLE
[Function panel] Can't empty Build Commands

### DIFF
--- a/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
+++ b/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
@@ -9,6 +9,7 @@ import EditorModal from '../../common/EditorModal/EditorModal'
 import Input from '../../common/Input/Input'
 import TextArea from '../../common/TextArea/TextArea'
 import RadioButtons from '../../common/RadioButtons/RadioButtons'
+import { trimSplit } from '../../utils'
 
 import {
   DEFAULT_ENTRY,
@@ -171,16 +172,13 @@ const FunctionsPanelCodeView = ({
             }))
           }
           onBlur={event => {
-            const currentValue = event.target.value.trim()
             if (
               !isEqual(
-                currentValue ? currentValue.split('\n') : [],
+                trimSplit(event.target.value, '\n'),
                 functionsStore.newFunction.spec.build.commands
               )
             ) {
-              setNewFunctionCommands(
-                data.commands.trim() ? data.commands.trim().split('\n') : []
-              )
+              setNewFunctionCommands(trimSplit(data.commands, '\n'))
             }
           }}
           type="text"

--- a/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
+++ b/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
@@ -171,13 +171,16 @@ const FunctionsPanelCodeView = ({
             }))
           }
           onBlur={event => {
+            const currentValue = event.target.value.trim()
             if (
               !isEqual(
-                event.target.value.split('\n'),
+                currentValue ? currentValue.split('\n') : [],
                 functionsStore.newFunction.spec.build.commands
               )
             ) {
-              setNewFunctionCommands(data.commands.split('\n'))
+              setNewFunctionCommands(
+                data.commands.trim() ? data.commands.trim().split('\n') : []
+              )
             }
           }}
           type="text"

--- a/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
+++ b/src/elements/FunctionsPanelCode/FunctionsPanelCodeView.js
@@ -172,7 +172,6 @@ const FunctionsPanelCodeView = ({
           }
           onBlur={event => {
             if (
-              event.target.value.length > 0 &&
               !isEqual(
                 event.target.value.split('\n'),
                 functionsStore.newFunction.spec.build.commands

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -18,3 +18,8 @@ export const joinDataOfArrayOrObject = (data, splitCharacter = ',') => {
 export const deleteUnsafeHtml = unsafeStr => {
   return unsafeStr.replace(/[&<>"']/g, '')
 }
+
+export const trimSplit = (value = '', delimiter) => {
+  const trimmed = (value ?? '').trim()
+  return trimmed ? trimmed.split(delimiter) : []
+}

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -19,7 +19,7 @@ export const deleteUnsafeHtml = unsafeStr => {
   return unsafeStr.replace(/[&<>"']/g, '')
 }
 
-export const trimSplit = (value = '', delimiter) => {
+export const trimSplit = (value, delimiter) => {
   const trimmed = (value ?? '').trim()
   return trimmed ? trimmed.split(delimiter) : []
 }


### PR DESCRIPTION
https://trello.com/c/y9YNN58P/972-function-panel-cant-empty-build-commands

- **Function panel**: In “Code” section, the “Build Commands” field was not updated properly on saving it when it is empty.
  ![image](https://user-images.githubusercontent.com/13918850/131545426-f618f67b-b295-4726-ab9d-bf1c77df09ba.png)

Relates to PR https://github.com/mlrun/ui/pull/760

Jira ticket ML-967