### PR TITLE
Fix [Jobs] "Re-run" not always hidden for kind local

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -229,7 +229,9 @@ export const generateActionsMenu = (
           label: 'Re-run',
           icon: <Run />,
           onClick: handleRerunJob,
-          hidden: job.ui.originalContent.metadata.labels.kind === 'local'
+          hidden: ['local', ''].includes(
+            job.ui.originalContent.metadata.labels.kind
+          )
         },
         {
           label: 'Monitoring',


### PR DESCRIPTION
- **Jobs**: “Re-run” was still showing for jobs of kind Local (when the `kind` label did not exist for the job).

In-release (GA)
Continues https://github.com/mlrun/ui/pull/768 [v0.7.0-rc15](https://github.com/mlrun/ui/releases/tag/v0.7.0-rc15)

Jira ticket ML-1044