### PR TITLE
[Jobs] Crashes when filter by status error

### DIFF
--- a/src/common/ActionsMenu/ActionsMenu.js
+++ b/src/common/ActionsMenu/ActionsMenu.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
 
 import ActionsMenuItem from '../../elements/ActionMenuItem/ActionsMenuItem'
 
@@ -10,11 +11,13 @@ import './actionsMenu.scss'
 const ActionsMenu = ({ dataItem, menu, time }) => {
   const [isShowMenu, setIsShowMenu] = useState(false)
   const [isIconDisplayed, setIsIconDisplayed] = useState(false)
-  const [actionMenu, setActionMenu] = useState([])
+  const [actionMenu, setActionMenu] = useState(menu)
   let idTimeout = null
 
   useEffect(() => {
-    setActionMenu(typeof menu === 'function' ? menu(dataItem) : menu)
+    if (!isEmpty(dataItem) && typeof menu === 'function') {
+      setActionMenu(menu(dataItem))
+    }
   }, [dataItem, menu])
 
   useEffect(() => {

--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -228,10 +228,10 @@ export const generateActionsMenu = (
         {
           label: 'Re-run',
           icon: <Run />,
-          onClick: handleRerunJob,
           hidden: ['local', ''].includes(
             job.ui.originalContent.metadata.labels.kind
-          )
+          ),
+          onClick: handleRerunJob
         },
         {
           label: 'Monitoring',

--- a/src/components/Table/TableView.js
+++ b/src/components/Table/TableView.js
@@ -53,7 +53,10 @@ const TableView = ({
   }
   const actionsMenu =
     typeof pageData.actionsMenu === 'function'
-      ? item => [viewYamlAction, ...(pageData.actionsMenu(item) ?? [])]
+      ? item =>
+          item
+            ? [viewYamlAction, ...(pageData.actionsMenu(item) ?? [])]
+            : [viewYamlAction]
       : [viewYamlAction, ...(pageData.actionsMenu ?? [])]
 
   return (


### PR DESCRIPTION
https://trello.com/c/VQNhZooW/983-jobs-crashes-when-filter-by-status-error

- **Jobs**: In “Monitor” tab, error occurred when filtering by “Status” by “Error” when there were some jobs not in error state.

Jira ticket ML-1060