### PR TITLE
[Functions] Build Log: Loader area in tab only

### DIFF
--- a/src/components/DetailsLogs/DetailsLogs.js
+++ b/src/components/DetailsLogs/DetailsLogs.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
 import NoData from '../../common/NoData/NoData'
+import Loader from '../../common/Loader/Loader'
 
 import { ReactComponent as Refresh } from '../../images/refresh.svg'
 
@@ -18,12 +19,12 @@ const DetailsLogs = ({
   const [detailsLogs, setDetailsLogs] = useState('')
 
   useEffect(() => {
-    setDetailsLogs(jobsStore.logs || functionsStore.logs)
+    setDetailsLogs(jobsStore.logs || functionsStore.logs.data)
 
     return () => {
       setDetailsLogs('')
     }
-  }, [functionsStore.logs, jobsStore.logs])
+  }, [functionsStore.logs.data, jobsStore.logs])
 
   useEffect(() => {
     if (withLogsRefreshBtn) {
@@ -49,7 +50,9 @@ const DetailsLogs = ({
     <div className="table__item_logs">
       {detailsLogs.length > 0 ? (
         <div className="table__item_logs__content">{detailsLogs}</div>
-      ) : functionsStore.loading || jobsStore.loading ? null : (
+      ) : functionsStore.logs.loading || jobsStore.loading ? (
+        <Loader section secondary />
+      ) : (
         <NoData />
       )}
       {withLogsRefreshBtn && (

--- a/src/reducers/functionReducer.js
+++ b/src/reducers/functionReducer.js
@@ -43,7 +43,11 @@ import {
 
 const initialState = {
   functions: [],
-  logs: '',
+  logs: {
+    data: '',
+    loading: false,
+    error: null
+  },
   loading: false,
   error: null,
   newFunction: {
@@ -134,20 +138,28 @@ export default (state = initialState, { type, payload }) => {
     case FETCH_FUNCTION_LOGS_BEGIN:
       return {
         ...state,
-        loading: true
+        logs: {
+          ...state.logs,
+          loading: true
+        }
       }
     case FETCH_FUNCTION_LOGS_FAILURE:
       return {
         ...state,
-        logs: initialState.logs,
-        loading: false,
-        error: payload
+        logs: {
+          data: initialState.logs.data,
+          loading: false,
+          error: payload
+        }
       }
     case FETCH_FUNCTION_LOGS_SUCCESS:
       return {
         ...state,
-        logs: `${state.logs}${payload}`,
-        loading: false
+        logs: {
+          data: `${state.logs.data}${payload}`,
+          loading: false,
+          error: null
+        }
       }
     case SET_FUNCTIONS_TEMPLATES:
       return {


### PR DESCRIPTION
https://trello.com/c/IzZMSWNP/988-functions-build-log-loader-area-in-tab-only

- **Functions**: In “Build Log” tab, when the function is being deployed — display the spinning loader in the console area only instead of the entire screen. Also show the loader only until there is some contents to the log, then proceed adding new lines without showing the loader.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/132359326-22ae9184-96ad-4241-bd95-0c297012c2ab.png)
  After:

https://user-images.githubusercontent.com/13918850/132359353-56d36dc2-4530-4983-b915-4d51cb676bbd.mp4




