### PR TITLE
[Jobs panel] Wrong combobox suggestions flow for Data inputs

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSource.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/FeatureSetsPanelDataSource.js
@@ -11,8 +11,7 @@ import artifactsAction from '../../../actions/artifacts'
 import { getParsedResource } from '../../../utils/resources'
 import {
   generateComboboxMatchesList,
-  isUrlInputValid,
-  projectItemsPathTypes
+  isUrlInputValid
 } from './featureSetsPanelDataSource.util'
 import projectsAction from '../../../actions/projects'
 import {
@@ -205,10 +204,7 @@ const FeatureSetsPanelDataSource = ({
           artifactReference: artifactReference ?? ''
         }
       }))
-      setUrlProjectItemTypeEntered(
-        projectItemsPathTypes.some(type => type.id === pathItems[0]) &&
-          typeof pathItems[1] === 'string'
-      )
+      setUrlProjectItemTypeEntered(typeof pathItems[1] === 'string')
       setUrlProjectPathEntered(typeof pathItems[2] === 'string')
       setUrlArtifactPathEntered(
         artifacts.some(artifactItem => artifactItem.id === artifact)

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/featureSetsPanelDataSource.util.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/featureSetsPanelDataSource.util.js
@@ -45,7 +45,10 @@ export const generateComboboxMatchesList = (
     )
       ? projectItemsPathTypes
       : []
-  } else if (!urlProjectPathEntered) {
+  } else if (
+    !urlProjectPathEntered &&
+    projectItemsPathTypes.some(type => type.id === url.projectItemType)
+  ) {
     return projects.filter(project => {
       return project.id.startsWith(url.project)
     })

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
@@ -18,7 +18,6 @@ import {
   handleEdit,
   handleInputPathChange,
   handleInputPathTypeChange,
-  isPathInputValid,
   resetDataInputsData
 } from './jobsPanelDataInputs.util'
 import artifactsAction from '../../actions/artifacts'
@@ -317,12 +316,6 @@ const JobsPanelDataInputs = ({
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
       handlePathChange={handlePathChange}
-      handlePathOnBlur={(selectValue, inputValue) => {
-        setValidation(prevState => ({
-          ...prevState,
-          isPathValid: isPathInputValid(selectValue, inputValue)
-        }))
-      }}
       handlePathTypeChange={handlePathTypeChange}
       inputsState={inputsState}
       inputsDispatch={inputsDispatch}

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
@@ -18,8 +18,8 @@ import {
   handleEdit,
   handleInputPathChange,
   handleInputPathTypeChange,
-  handleResetDataInputs,
-  isPathInputValid
+  isPathInputValid,
+  resetDataInputsData
 } from './jobsPanelDataInputs.util'
 import artifactsAction from '../../actions/artifacts'
 import featureStoreActions from '../../actions/featureStore'
@@ -50,7 +50,7 @@ const JobsPanelDataInputs = ({
     jobsPanelDataInputsReducer,
     initialState
   )
-  const [dataInputsValidations, setDataInputsValidations] = useState({
+  const [validation, setValidation] = useState({
     isNameValid: true,
     isPathValid: true
   })
@@ -257,7 +257,7 @@ const JobsPanelDataInputs = ({
       panelActions.SET_PREVIOUS_PANEL_DATA_INPUTS,
       setNewJobInputs,
       inputsState.newInputUrlPath,
-      setDataInputsValidations
+      setValidation
     )
   }
 
@@ -304,23 +304,10 @@ const JobsPanelDataInputs = ({
   }
 
   const handlePathOnBlur = (selectValue, inputValue) => {
-    if (!isPathInputValid(selectValue, inputValue)) {
-      setDataInputsValidations(prevState => ({
-        ...prevState,
-        isPathValid: false
-      }))
-    } else {
-      if (!dataInputsValidations.isPathValid) {
-        setDataInputsValidations(prevState => ({
-          ...prevState,
-          isPathValid: true
-        }))
-      }
-    }
-  }
-
-  const resetDataInputsData = () => {
-    handleResetDataInputs(inputsDispatch, setDataInputsValidations)
+    setValidation(prevState => ({
+      ...prevState,
+      isPathValid: isPathInputValid(selectValue, inputValue)
+    }))
   }
 
   return (
@@ -333,7 +320,6 @@ const JobsPanelDataInputs = ({
           ? inputsState.comboboxMatches
           : []
       }
-      dataInputsValidations={dataInputsValidations}
       handleAddNewItem={handleAddNewItem}
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
@@ -346,9 +332,12 @@ const JobsPanelDataInputs = ({
       match={match}
       panelDispatch={panelDispatch}
       panelState={panelState}
-      resetDataInputsData={resetDataInputsData}
+      resetDataInputsData={() =>
+        resetDataInputsData(inputsDispatch, setValidation)
+      }
       setArtifactPathValid={setArtifactPathValid}
-      setDataInputsValidations={setDataInputsValidations}
+      setValidation={setValidation}
+      validation={validation}
     />
   )
 }

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
@@ -303,13 +303,6 @@ const JobsPanelDataInputs = ({
     handleInputPathChange(inputsDispatch, inputsState, path)
   }
 
-  const handlePathOnBlur = (selectValue, inputValue) => {
-    setValidation(prevState => ({
-      ...prevState,
-      isPathValid: isPathInputValid(selectValue, inputValue)
-    }))
-  }
-
   return (
     <JobsPanelDataInputsView
       comboboxMatchesList={
@@ -324,7 +317,12 @@ const JobsPanelDataInputs = ({
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
       handlePathChange={handlePathChange}
-      handlePathOnBlur={handlePathOnBlur}
+      handlePathOnBlur={(selectValue, inputValue) => {
+        setValidation(prevState => ({
+          ...prevState,
+          isPathValid: isPathInputValid(selectValue, inputValue)
+        }))
+      }}
       handlePathTypeChange={handlePathTypeChange}
       inputsState={inputsState}
       inputsDispatch={inputsDispatch}
@@ -332,9 +330,7 @@ const JobsPanelDataInputs = ({
       match={match}
       panelDispatch={panelDispatch}
       panelState={panelState}
-      resetDataInputsData={() =>
-        resetDataInputsData(inputsDispatch, setValidation)
-      }
+      resetDataInputsData={resetDataInputsData}
       setArtifactPathValid={setArtifactPathValid}
       setValidation={setValidation}
       validation={validation}

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputs.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect, useCallback } from 'react'
+import React, { useReducer, useEffect, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { uniqBy } from 'lodash'
@@ -17,7 +17,9 @@ import {
   handleDelete,
   handleEdit,
   handleInputPathChange,
-  handleInputPathTypeChange
+  handleInputPathTypeChange,
+  handleResetDataInputs,
+  isPathInputValid
 } from './jobsPanelDataInputs.util'
 import artifactsAction from '../../actions/artifacts'
 import featureStoreActions from '../../actions/featureStore'
@@ -48,6 +50,10 @@ const JobsPanelDataInputs = ({
     jobsPanelDataInputsReducer,
     initialState
   )
+  const [dataInputsValidations, setDataInputsValidations] = useState({
+    isNameValid: true,
+    isPathValid: true
+  })
 
   const getInputValue = useCallback(
     inputItem => {
@@ -246,14 +252,12 @@ const JobsPanelDataInputs = ({
       inputs,
       panelDispatch,
       panelState.previousPanelData.tableData.dataInputs,
-      inputsActions.REMOVE_NEW_INPUT_DATA,
-      inputsActions.SET_ADD_NEW_INPUT,
+      panelState.tableData.dataInputs,
       panelActions.SET_TABLE_DATA_INPUTS,
       panelActions.SET_PREVIOUS_PANEL_DATA_INPUTS,
       setNewJobInputs,
-      inputsActions.SET_PATH_PLACEHOLDER,
       inputsState.newInputUrlPath,
-      inputsActions.SET_NEW_INPUT_URL_PATH
+      setDataInputsValidations
     )
   }
 
@@ -299,6 +303,26 @@ const JobsPanelDataInputs = ({
     handleInputPathChange(inputsDispatch, inputsState, path)
   }
 
+  const handlePathOnBlur = (selectValue, inputValue) => {
+    if (!isPathInputValid(selectValue, inputValue)) {
+      setDataInputsValidations(prevState => ({
+        ...prevState,
+        isPathValid: false
+      }))
+    } else {
+      if (!dataInputsValidations.isPathValid) {
+        setDataInputsValidations(prevState => ({
+          ...prevState,
+          isPathValid: true
+        }))
+      }
+    }
+  }
+
+  const resetDataInputsData = () => {
+    handleResetDataInputs(inputsDispatch, setDataInputsValidations)
+  }
+
   return (
     <JobsPanelDataInputsView
       comboboxMatchesList={
@@ -309,10 +333,12 @@ const JobsPanelDataInputs = ({
           ? inputsState.comboboxMatches
           : []
       }
+      dataInputsValidations={dataInputsValidations}
       handleAddNewItem={handleAddNewItem}
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
       handlePathChange={handlePathChange}
+      handlePathOnBlur={handlePathOnBlur}
       handlePathTypeChange={handlePathTypeChange}
       inputsState={inputsState}
       inputsDispatch={inputsDispatch}
@@ -320,7 +346,9 @@ const JobsPanelDataInputs = ({
       match={match}
       panelDispatch={panelDispatch}
       panelState={panelState}
+      resetDataInputsData={resetDataInputsData}
       setArtifactPathValid={setArtifactPathValid}
+      setDataInputsValidations={setDataInputsValidations}
     />
   )
 }

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
@@ -11,7 +11,6 @@ import { COMBOBOX_MATCHES } from '../../types'
 
 const JobsPanelDataInputsView = ({
   comboboxMatchesList,
-  dataInputsValidations,
   handleAddNewItem,
   handleDeleteItems,
   handleEditItems,
@@ -26,7 +25,8 @@ const JobsPanelDataInputsView = ({
   panelState,
   resetDataInputsData,
   setArtifactPathValid,
-  setDataInputsValidations
+  setValidation,
+  validation
 }) => {
   return (
     <div className="job-panel__item new-item-side-panel__item">
@@ -34,7 +34,6 @@ const JobsPanelDataInputsView = ({
         <JobsPanelDataInputsTable
           comboboxMatchesList={comboboxMatchesList}
           comboboxSelectList={comboboxSelectList}
-          dataInputsValidations={dataInputsValidations}
           handleAddNewItem={handleAddNewItem}
           handleEditItems={handleEditItems}
           handleDeleteItems={handleDeleteItems}
@@ -46,7 +45,8 @@ const JobsPanelDataInputsView = ({
           match={match}
           panelState={panelState}
           resetDataInputsData={resetDataInputsData}
-          setDataInputsValidations={setDataInputsValidations}
+          setValidation={setValidation}
+          validation={validation}
         />
       </JobsPanelSection>
       <JobsPanelSection title="General">
@@ -90,7 +90,6 @@ const JobsPanelDataInputsView = ({
 
 JobsPanelDataInputsView.propTypes = {
   comboboxMatchesList: COMBOBOX_MATCHES.isRequired,
-  dataInputsValidations: PropTypes.object.isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
@@ -105,7 +104,8 @@ JobsPanelDataInputsView.propTypes = {
   panelState: PropTypes.shape({}).isRequired,
   resetDataInputsData: PropTypes.func.isRequired,
   setArtifactPathValid: PropTypes.func.isRequired,
-  setDataInputsValidations: PropTypes.func.isRequired
+  setValidation: PropTypes.func.isRequired,
+  validation: PropTypes.object.isRequired
 }
 
 export default JobsPanelDataInputsView

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
@@ -11,10 +11,12 @@ import { COMBOBOX_MATCHES } from '../../types'
 
 const JobsPanelDataInputsView = ({
   comboboxMatchesList,
+  dataInputsValidations,
   handleAddNewItem,
   handleDeleteItems,
   handleEditItems,
   handlePathChange,
+  handlePathOnBlur,
   handlePathTypeChange,
   inputsDispatch,
   inputsState,
@@ -22,7 +24,9 @@ const JobsPanelDataInputsView = ({
   match,
   panelDispatch,
   panelState,
-  setArtifactPathValid
+  resetDataInputsData,
+  setArtifactPathValid,
+  setDataInputsValidations
 }) => {
   return (
     <div className="job-panel__item new-item-side-panel__item">
@@ -30,15 +34,19 @@ const JobsPanelDataInputsView = ({
         <JobsPanelDataInputsTable
           comboboxMatchesList={comboboxMatchesList}
           comboboxSelectList={comboboxSelectList}
+          dataInputsValidations={dataInputsValidations}
           handleAddNewItem={handleAddNewItem}
           handleEditItems={handleEditItems}
           handleDeleteItems={handleDeleteItems}
           handlePathChange={handlePathChange}
+          handlePathOnBlur={handlePathOnBlur}
           handlePathTypeChange={handlePathTypeChange}
           inputsDispatch={inputsDispatch}
           inputsState={inputsState}
           match={match}
           panelState={panelState}
+          resetDataInputsData={resetDataInputsData}
+          setDataInputsValidations={setDataInputsValidations}
         />
       </JobsPanelSection>
       <JobsPanelSection title="General">
@@ -82,10 +90,12 @@ const JobsPanelDataInputsView = ({
 
 JobsPanelDataInputsView.propTypes = {
   comboboxMatchesList: COMBOBOX_MATCHES.isRequired,
+  dataInputsValidations: PropTypes.object.isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
   handlePathChange: PropTypes.func.isRequired,
+  handlePathOnBlur: PropTypes.func.isRequired,
   handlePathTypeChange: PropTypes.func.isRequired,
   inputsDispatch: PropTypes.func.isRequired,
   inputsState: PropTypes.shape({}).isRequired,
@@ -93,7 +103,9 @@ JobsPanelDataInputsView.propTypes = {
   match: PropTypes.shape({}).isRequired,
   panelDispatch: PropTypes.func.isRequired,
   panelState: PropTypes.shape({}).isRequired,
-  setArtifactPathValid: PropTypes.func.isRequired
+  resetDataInputsData: PropTypes.func.isRequired,
+  setArtifactPathValid: PropTypes.func.isRequired,
+  setDataInputsValidations: PropTypes.func.isRequired
 }
 
 export default JobsPanelDataInputsView

--- a/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
+++ b/src/components/JobsPanelDataInputs/JobsPanelDataInputsView.js
@@ -15,7 +15,6 @@ const JobsPanelDataInputsView = ({
   handleDeleteItems,
   handleEditItems,
   handlePathChange,
-  handlePathOnBlur,
   handlePathTypeChange,
   inputsDispatch,
   inputsState,
@@ -38,7 +37,6 @@ const JobsPanelDataInputsView = ({
           handleEditItems={handleEditItems}
           handleDeleteItems={handleDeleteItems}
           handlePathChange={handlePathChange}
-          handlePathOnBlur={handlePathOnBlur}
           handlePathTypeChange={handlePathTypeChange}
           inputsDispatch={inputsDispatch}
           inputsState={inputsState}
@@ -94,7 +92,6 @@ JobsPanelDataInputsView.propTypes = {
   handleDeleteItems: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
   handlePathChange: PropTypes.func.isRequired,
-  handlePathOnBlur: PropTypes.func.isRequired,
   handlePathTypeChange: PropTypes.func.isRequired,
   inputsDispatch: PropTypes.func.isRequired,
   inputsState: PropTypes.shape({}).isRequired,

--- a/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
+++ b/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
@@ -170,7 +170,7 @@ export const handleAddItem = (
         ? `${newItemObj.path.pathType}${mlRunStorePath}`
         : `${newItemObj.path.pathType}${newInputUrlPath}`
     })
-    handleResetDataInputs(inputsDispatch, setDataInputsValidations)
+    resetDataInputsData(inputsDispatch, setDataInputsValidations)
   }
 }
 
@@ -223,7 +223,7 @@ export const handleEdit = (
   })
 }
 
-export const handleResetDataInputs = (
+export const resetDataInputsData = (
   inputsDispatch,
   setDataInputsValidations
 ) => {

--- a/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
+++ b/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
@@ -248,6 +248,10 @@ export const resetDataInputsData = (
     isNameValid: true,
     isPathValid: true
   })
+  inputsDispatch({
+    type: inputsActions.SET_NEW_INPUT_URL_PATH,
+    payload: ''
+  })
 }
 
 export const handleDelete = (

--- a/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
+++ b/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
@@ -3,13 +3,18 @@ import { isNil } from 'lodash'
 
 import { joinDataOfArrayOrObject } from '../../utils'
 import {
+  AZURE_STORAGE_INPUT_PATH_SCHEME,
+  GOOGLE_STORAGE_INPUT_PATH_SCHEME,
   HTTP_STORAGE_INPUT_PATH_SCHEME,
   HTTPS_STORAGE_INPUT_PATH_SCHEME,
-  MLRUN_STORAGE_INPUT_PATH_SCHEME
+  MLRUN_STORAGE_INPUT_PATH_SCHEME,
+  S3_INPUT_PATH_SCHEME,
+  V3IO_INPUT_PATH_SCHEME
 } from '../../constants'
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { getParsedResource } from '../../utils/resources'
 import { pathPlaceholders } from '../../utils/panelPathScheme'
+import { isNameNotUnique } from '../JobsPanel/jobsPanel.util'
 
 export const generateComboboxMatchesList = (
   artifacts,
@@ -26,8 +31,19 @@ export const generateComboboxMatchesList = (
   selectedDataInputPath
 ) => {
   if (!inputStorePathTypeEntered) {
-    return storePathTypes
-  } else if (!inputProjectPathEntered) {
+    return storePathTypes.some(type =>
+      type.id.startsWith(newInput.path.storePathType)
+    )
+      ? storePathTypes
+      : []
+  } else if (
+    !inputProjectPathEntered &&
+    storePathTypes.some(
+      type =>
+        type.id === newInput.path.storePathType ||
+        type.id === selectedDataInputPath.value.split('/')[0]
+    )
+  ) {
     return projects.filter(project => {
       return isEveryObjectValueEmpty(selectedDataInputPath)
         ? project.id.startsWith(newInput.path.project)
@@ -83,14 +99,12 @@ export const handleAddItem = (
   newJobData,
   panelDispatch,
   previousData,
-  removeNewItemObj,
-  setAddNewItem,
+  dataInputs,
   setCurrentTableData,
   setPreviousData,
   setNewJobData,
-  setPathPlaceholder,
   newInputUrlPath,
-  setNewInputUrl
+  setDataInputsValidations
 ) => {
   const isMlRunStorePath =
     newItemObj.path.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME
@@ -100,7 +114,7 @@ export const handleAddItem = (
     mlRunStorePath = `${newItemObj.path.storePathType}/${newItemObj.path.project}/${newItemObj.path.projectItem}${newItemObj.path.projectItemReference}`
 
     inputsDispatch({
-      type: setNewInputUrl,
+      type: inputsActions.SET_NEW_INPUT_URL_PATH,
       payload: ''
     })
   }
@@ -110,66 +124,54 @@ export const handleAddItem = (
     isMlRunStorePath ? mlRunStorePath : newInputUrlPath
   )
 
-  inputsDispatch({
-    type: removeNewItemObj
-  })
-
-  inputsDispatch({
-    type: setPathPlaceholder,
-    payload: ''
-  })
-
-  inputsDispatch({
-    type: setAddNewItem,
-    payload: false
-  })
-
   if (newItemObj.name.length === 0 || !pathInputIsValid) {
-    return
+    setDataInputsValidations({
+      isNameValid:
+        !isNameNotUnique(newItemObj.name, dataInputs) &&
+        newItemObj.name.length > 0,
+      isPathValid: pathInputIsValid
+    })
+  } else {
+    panelDispatch({
+      type: setPreviousData,
+      payload: [
+        ...previousData,
+        {
+          isDefault: false,
+          data: {
+            name: newItemObj.name,
+            path: {
+              pathType: newItemObj.path.pathType,
+              value: isMlRunStorePath ? mlRunStorePath : newInputUrlPath
+            }
+          }
+        }
+      ]
+    })
+    panelDispatch({
+      type: setCurrentTableData,
+      payload: [
+        ...currentTableData,
+        {
+          isDefault: false,
+          data: {
+            name: newItemObj.name,
+            path: {
+              pathType: newItemObj.path.pathType,
+              value: isMlRunStorePath ? mlRunStorePath : newInputUrlPath
+            }
+          }
+        }
+      ]
+    })
+    setNewJobData({
+      ...newJobData,
+      [newItemObj.name]: isMlRunStorePath
+        ? `${newItemObj.path.pathType}${mlRunStorePath}`
+        : `${newItemObj.path.pathType}${newInputUrlPath}`
+    })
+    handleResetDataInputs(inputsDispatch, setDataInputsValidations)
   }
-
-  panelDispatch({
-    type: setPreviousData,
-    payload: [
-      ...previousData,
-      {
-        isDefault: false,
-        data: {
-          name: newItemObj.name,
-          path: {
-            pathType: newItemObj.path.pathType,
-            value: isMlRunStorePath ? mlRunStorePath : newInputUrlPath
-          }
-        }
-      }
-    ]
-  })
-  panelDispatch({
-    type: setCurrentTableData,
-    payload: [
-      ...currentTableData,
-      {
-        isDefault: false,
-        data: {
-          name: newItemObj.name,
-          path: {
-            pathType: newItemObj.path.pathType,
-            value: isMlRunStorePath ? mlRunStorePath : newInputUrlPath
-          }
-        }
-      }
-    ]
-  })
-  setNewJobData({
-    ...newJobData,
-    [newItemObj.name]: isMlRunStorePath
-      ? `${newItemObj.path.pathType}${mlRunStorePath}`
-      : `${newItemObj.path.pathType}${newInputUrlPath}`
-  })
-  inputsDispatch({
-    type: inputsActions.SET_COMBOBOX_MATCHES,
-    payload: []
-  })
 }
 
 export const handleEdit = (
@@ -218,6 +220,33 @@ export const handleEdit = (
   })
   inputsDispatch({
     type: removeSelectedItem
+  })
+}
+
+export const handleResetDataInputs = (
+  inputsDispatch,
+  setDataInputsValidations
+) => {
+  inputsDispatch({
+    type: inputsActions.REMOVE_NEW_INPUT_DATA
+  })
+
+  inputsDispatch({
+    type: inputsActions.SET_PATH_PLACEHOLDER,
+    payload: ''
+  })
+
+  inputsDispatch({
+    type: inputsActions.SET_ADD_NEW_INPUT,
+    payload: false
+  })
+  inputsDispatch({
+    type: inputsActions.SET_COMBOBOX_MATCHES,
+    payload: []
+  })
+  setDataInputsValidations({
+    isNameValid: true,
+    isPathValid: true
   })
 }
 
@@ -427,10 +456,13 @@ export const handleStoreInputPathChange = (
   const projectItemReferenceIsEntered = projectItemsReferences.find(
     projectItemRef => projectItemRef.id === projectItemReference
   )
+  const isInputStorePathTypeValid = storePathTypes.some(type =>
+    type.id.startsWith(pathItems[0])
+  )
 
   inputsDispatch({
     type: inputsActions.SET_INPUT_STORE_PATH_TYPE_ENTERED,
-    payload: typeof pathItems[1] === 'string'
+    payload: isInputStorePathTypeValid && typeof pathItems[1] === 'string'
   })
   inputsDispatch({
     type: inputsActions.SET_INPUT_PROJECT_PATH_ENTERED,
@@ -458,4 +490,13 @@ export const isPathInputValid = (pathInputType, pathInputValue) => {
     default:
       return pathInputValue.length > 0
   }
+}
+
+export const pathTips = {
+  [MLRUN_STORAGE_INPUT_PATH_SCHEME]:
+    'artifacts/my-project/my-artifact:my-tag" or "artifacts/my-project/my-artifact@my-uid',
+  [S3_INPUT_PATH_SCHEME]: 'bucket/path',
+  [GOOGLE_STORAGE_INPUT_PATH_SCHEME]: 'bucket/path',
+  [AZURE_STORAGE_INPUT_PATH_SCHEME]: 'container/path',
+  [V3IO_INPUT_PATH_SCHEME]: '/container-name/file'
 }

--- a/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
+++ b/src/components/JobsPanelDataInputs/jobsPanelDataInputs.util.js
@@ -230,12 +230,10 @@ export const resetDataInputsData = (
   inputsDispatch({
     type: inputsActions.REMOVE_NEW_INPUT_DATA
   })
-
   inputsDispatch({
     type: inputsActions.SET_PATH_PLACEHOLDER,
     payload: ''
   })
-
   inputsDispatch({
     type: inputsActions.SET_ADD_NEW_INPUT,
     payload: false

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
@@ -37,7 +37,7 @@ const EditableDataInputsRow = ({
     label: ''
   })
   const [inputName, setInputName] = useState(selectedDataInput.data.name)
-  const [isComboboxValid, setIsComboboxValid] = useState(true)
+  const [isPathValid, setIsPathValid] = useState(true)
   const [requiredField, setRequiredField] = useState({
     path: false,
     name: false
@@ -160,7 +160,7 @@ const EditableDataInputsRow = ({
         <Combobox
           comboboxClassName={comboboxClassNames}
           inputPlaceholder={inputsState.pathPlaceholder}
-          invalid={!isComboboxValid}
+          invalid={!isPathValid}
           invalidText={`Field must be in "${
             pathTips[selectedDataInput.data.path.pathType]
           }" format`}
@@ -179,7 +179,7 @@ const EditableDataInputsRow = ({
               path,
               selectedDataInput,
               setSelectedDataInput,
-              setIsComboboxValid
+              setIsPathValid
             )
           }}
           hideSearchInput={!inputsState.inputStorePathTypeEntered}

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
@@ -149,10 +149,10 @@ const EditableDataInputsRow = ({
                 }
               })
             }}
-            type="text"
-            value={inputName}
             required
             requiredText="This field is required"
+            type="text"
+            value={inputName}
           />
         </div>
       )}
@@ -183,12 +183,11 @@ const EditableDataInputsRow = ({
             )
           }}
           hideSearchInput={!inputsState.inputStorePathTypeEntered}
+          required
+          requiredText="This field is required"
           selectDefaultValue={selectDefaultValue}
           selectDropdownList={comboboxSelectList}
           selectOnChange={path => selectOnChangeComboboxHandler(path)}
-          selectPlaceholder="Path Scheme"
-          required
-          requiredText="This field is required"
         />
       </div>
       <div className="table__cell table__cell-actions">

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.js
@@ -5,7 +5,10 @@ import classNames from 'classnames'
 import Input from '../../common/Input/Input'
 import Combobox from '../../common/Combobox/Combobox'
 
-import { comboboxSelectList } from '../../components/JobsPanelDataInputs/jobsPanelDataInputs.util'
+import {
+  comboboxSelectList,
+  pathTips
+} from '../../components/JobsPanelDataInputs/jobsPanelDataInputs.util'
 import { inputsActions } from '../../components/JobsPanelDataInputs/jobsPanelDataInputsReducer'
 import { MLRUN_STORAGE_INPUT_PATH_SCHEME } from '../../constants'
 import {
@@ -34,6 +37,7 @@ const EditableDataInputsRow = ({
     label: ''
   })
   const [inputName, setInputName] = useState(selectedDataInput.data.name)
+  const [isComboboxValid, setIsComboboxValid] = useState(true)
   const [requiredField, setRequiredField] = useState({
     path: false,
     name: false
@@ -147,6 +151,8 @@ const EditableDataInputsRow = ({
             }}
             type="text"
             value={inputName}
+            required
+            requiredText="This field is required"
           />
         </div>
       )}
@@ -154,6 +160,10 @@ const EditableDataInputsRow = ({
         <Combobox
           comboboxClassName={comboboxClassNames}
           inputPlaceholder={inputsState.pathPlaceholder}
+          invalid={!isComboboxValid}
+          invalidText={`Field must be in "${
+            pathTips[selectedDataInput.data.path.pathType]
+          }" format`}
           matches={comboboxMatchesList}
           maxSuggestedMatches={
             inputsState.selectedDataInput.data.path.pathType ===
@@ -168,7 +178,8 @@ const EditableDataInputsRow = ({
               inputsState,
               path,
               selectedDataInput,
-              setSelectedDataInput
+              setSelectedDataInput,
+              setIsComboboxValid
             )
           }}
           hideSearchInput={!inputsState.inputStorePathTypeEntered}
@@ -176,6 +187,8 @@ const EditableDataInputsRow = ({
           selectDropdownList={comboboxSelectList}
           selectOnChange={path => selectOnChangeComboboxHandler(path)}
           selectPlaceholder="Path Scheme"
+          required
+          requiredText="This field is required"
         />
       </div>
       <div className="table__cell table__cell-actions">

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
@@ -40,7 +40,7 @@ export const handleEditInputPath = (
   path,
   selectedDataInput,
   setSelectedDataInput,
-  setValidation
+  setIsPathValid
 ) => {
   if (path !== selectedDataInput.data.path.value) {
     setSelectedDataInput({
@@ -56,11 +56,11 @@ export const handleEditInputPath = (
     })
   }
 
-  setValidation(isPathInputValid(selectedDataInput.data.path.pathType, path))
-
   if (
     selectedDataInput.data.path.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME
   ) {
     handleStoreInputPathChange(false, inputsDispatch, inputsState, path)
   }
+
+  setIsPathValid(isPathInputValid(selectedDataInput.data.path.pathType, path))
 }

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
@@ -56,10 +56,7 @@ export const handleEditInputPath = (
     })
   }
 
-  setValidation(state => ({
-    ...state,
-    isPathValid: isPathInputValid(selectedDataInput.data.path.pathType, path)
-  }))
+  setValidation(isPathInputValid(selectedDataInput.data.path.pathType, path))
 
   if (
     selectedDataInput.data.path.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME

--- a/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
+++ b/src/elements/EditableDataInputsRow/EditableDataInputsRow.utils.js
@@ -39,7 +39,8 @@ export const handleEditInputPath = (
   inputsState,
   path,
   selectedDataInput,
-  setSelectedDataInput
+  setSelectedDataInput,
+  setValidation
 ) => {
   if (path !== selectedDataInput.data.path.value) {
     setSelectedDataInput({
@@ -54,6 +55,11 @@ export const handleEditInputPath = (
       }
     })
   }
+
+  setValidation(state => ({
+    ...state,
+    isPathValid: isPathInputValid(selectedDataInput.data.path.pathType, path)
+  }))
 
   if (
     selectedDataInput.data.path.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME

--- a/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
+++ b/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
@@ -21,7 +21,6 @@ import { ReactComponent as Delete } from '../../images/delete.svg'
 export const JobsPanelDataInputsTable = ({
   comboboxMatchesList,
   comboboxSelectList,
-  dataInputsValidations,
   handleAddNewItem,
   handleEditItems,
   handleDeleteItems,
@@ -33,7 +32,8 @@ export const JobsPanelDataInputsTable = ({
   match,
   panelState,
   resetDataInputsData,
-  setDataInputsValidations
+  setValidation,
+  validation
 }) => {
   return (
     <JobsPanelTable
@@ -64,7 +64,7 @@ export const JobsPanelDataInputsTable = ({
               density="medium"
               floatingLabel
               invalid={
-                !dataInputsValidations.isNameValid ||
+                !validation.isNameValid ||
                 isNameNotUnique(
                   inputsState.newInput.name,
                   panelState.tableData.dataInputs
@@ -82,7 +82,7 @@ export const JobsPanelDataInputsTable = ({
               required
               requiredText="This field is required"
               setInvalid={value =>
-                setDataInputsValidations(state => ({
+                setValidation(state => ({
                   ...state,
                   isNameValid: value
                 }))
@@ -96,7 +96,7 @@ export const JobsPanelDataInputsTable = ({
                 handlePathChange(path)
               }}
               inputPlaceholder={inputsState.pathPlaceholder}
-              invalid={!dataInputsValidations.isPathValid}
+              invalid={!validation.isPathValid}
               invalidText={`Field must be in "${
                 pathTips[inputsState.newInput.path.pathType]
               }" format`}
@@ -107,14 +107,14 @@ export const JobsPanelDataInputsTable = ({
                   ? 3
                   : 2
               }
+              onBlur={handlePathOnBlur}
+              required
+              requiredText="This field is required"
               selectDropdownList={comboboxSelectList}
               selectOnChange={path => {
                 handlePathTypeChange(path)
               }}
               selectPlaceholder="Path Scheme"
-              onBlur={handlePathOnBlur}
-              required
-              requiredText="This field is required"
             />
           </div>
           <button
@@ -153,7 +153,6 @@ export const JobsPanelDataInputsTable = ({
 JobsPanelDataInputsTable.propTypes = {
   comboboxMatchesList: COMBOBOX_MATCHES.isRequired,
   comboboxSelectList: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  dataInputsValidations: PropTypes.object.isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
@@ -164,5 +163,7 @@ JobsPanelDataInputsTable.propTypes = {
   inputsState: PropTypes.shape({}).isRequired,
   match: PropTypes.shape({}).isRequired,
   panelState: PropTypes.shape({}).isRequired,
-  resetDataInputsData: PropTypes.func.isRequired
+  resetDataInputsData: PropTypes.func.isRequired,
+  setValidation: PropTypes.func.isRequired,
+  validation: PropTypes.object.isRequired
 }

--- a/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
+++ b/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
@@ -78,7 +78,6 @@ export const JobsPanelDataInputsTable = ({
                   payload: name
                 })
               }
-              type="text"
               required
               requiredText="This field is required"
               setInvalid={value =>
@@ -87,6 +86,7 @@ export const JobsPanelDataInputsTable = ({
                   isNameValid: value
                 }))
               }
+              type="text"
             />
             <Combobox
               comboboxClassName="input-row__item"
@@ -129,7 +129,9 @@ export const JobsPanelDataInputsTable = ({
               <Plus />
             </Tooltip>
           </button>
-          <button onClick={resetDataInputsData}>
+          <button
+            onClick={() => resetDataInputsData(inputsDispatch, setValidation)}
+          >
             <Tooltip template={<TextTooltipTemplate text="Discard changes" />}>
               <Delete />
             </Tooltip>

--- a/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
+++ b/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
@@ -13,7 +13,10 @@ import { inputsActions } from '../../components/JobsPanelDataInputs/jobsPanelDat
 import { MLRUN_STORAGE_INPUT_PATH_SCHEME } from '../../constants'
 import { COMBOBOX_MATCHES } from '../../types'
 import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
-import { pathTips } from '../../components/JobsPanelDataInputs/jobsPanelDataInputs.util'
+import {
+  isPathInputValid,
+  pathTips
+} from '../../components/JobsPanelDataInputs/jobsPanelDataInputs.util'
 
 import { ReactComponent as Plus } from '../../images/plus.svg'
 import { ReactComponent as Delete } from '../../images/delete.svg'
@@ -25,7 +28,6 @@ export const JobsPanelDataInputsTable = ({
   handleEditItems,
   handleDeleteItems,
   handlePathChange,
-  handlePathOnBlur,
   handlePathTypeChange,
   inputsDispatch,
   inputsState,
@@ -79,7 +81,6 @@ export const JobsPanelDataInputsTable = ({
                 })
               }
               required
-              requiredText="This field is required"
               setInvalid={value =>
                 setValidation(state => ({
                   ...state,
@@ -107,7 +108,12 @@ export const JobsPanelDataInputsTable = ({
                   ? 3
                   : 2
               }
-              onBlur={handlePathOnBlur}
+              onBlur={(selectValue, inputValue) => {
+                setValidation(prevState => ({
+                  ...prevState,
+                  isPathValid: isPathInputValid(selectValue, inputValue)
+                }))
+              }}
               required
               requiredText="This field is required"
               selectDropdownList={comboboxSelectList}
@@ -159,7 +165,6 @@ JobsPanelDataInputsTable.propTypes = {
   handleEditItems: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
   handlePathChange: PropTypes.func.isRequired,
-  handlePathOnBlur: PropTypes.func.isRequired,
   handlePathTypeChange: PropTypes.func.isRequired,
   inputsDispatch: PropTypes.func.isRequired,
   inputsState: PropTypes.shape({}).isRequired,

--- a/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
+++ b/src/elements/JobsPanelDataInputsTable/JobsPanelDataInputsTable.js
@@ -13,21 +13,27 @@ import { inputsActions } from '../../components/JobsPanelDataInputs/jobsPanelDat
 import { MLRUN_STORAGE_INPUT_PATH_SCHEME } from '../../constants'
 import { COMBOBOX_MATCHES } from '../../types'
 import { isNameNotUnique } from '../../components/JobsPanel/jobsPanel.util'
+import { pathTips } from '../../components/JobsPanelDataInputs/jobsPanelDataInputs.util'
 
 import { ReactComponent as Plus } from '../../images/plus.svg'
+import { ReactComponent as Delete } from '../../images/delete.svg'
 
 export const JobsPanelDataInputsTable = ({
   comboboxMatchesList,
   comboboxSelectList,
+  dataInputsValidations,
   handleAddNewItem,
   handleEditItems,
   handleDeleteItems,
   handlePathChange,
+  handlePathOnBlur,
   handlePathTypeChange,
   inputsDispatch,
   inputsState,
   match,
-  panelState
+  panelState,
+  resetDataInputsData,
+  setDataInputsValidations
 }) => {
   return (
     <JobsPanelTable
@@ -57,10 +63,13 @@ export const JobsPanelDataInputsTable = ({
               className="input-row__item"
               density="medium"
               floatingLabel
-              invalid={isNameNotUnique(
-                inputsState.newInput.name,
-                panelState.tableData.dataInputs
-              )}
+              invalid={
+                !dataInputsValidations.isNameValid ||
+                isNameNotUnique(
+                  inputsState.newInput.name,
+                  panelState.tableData.dataInputs
+                )
+              }
               invalidText="Name already exists"
               label="Input name"
               onChange={name =>
@@ -70,6 +79,14 @@ export const JobsPanelDataInputsTable = ({
                 })
               }
               type="text"
+              required
+              requiredText="This field is required"
+              setInvalid={value =>
+                setDataInputsValidations(state => ({
+                  ...state,
+                  isNameValid: value
+                }))
+              }
             />
             <Combobox
               comboboxClassName="input-row__item"
@@ -79,6 +96,10 @@ export const JobsPanelDataInputsTable = ({
                 handlePathChange(path)
               }}
               inputPlaceholder={inputsState.pathPlaceholder}
+              invalid={!dataInputsValidations.isPathValid}
+              invalidText={`Field must be in "${
+                pathTips[inputsState.newInput.path.pathType]
+              }" format`}
               matches={comboboxMatchesList}
               maxSuggestedMatches={
                 inputsState.newInput.path.pathType ===
@@ -91,10 +112,13 @@ export const JobsPanelDataInputsTable = ({
                 handlePathTypeChange(path)
               }}
               selectPlaceholder="Path Scheme"
+              onBlur={handlePathOnBlur}
+              required
+              requiredText="This field is required"
             />
           </div>
           <button
-            className="add-input btn-add"
+            className="btn-add"
             disabled={isNameNotUnique(
               inputsState.newInput.name,
               panelState.tableData.dataInputs
@@ -103,6 +127,11 @@ export const JobsPanelDataInputsTable = ({
           >
             <Tooltip template={<TextTooltipTemplate text="Add item" />}>
               <Plus />
+            </Tooltip>
+          </button>
+          <button onClick={resetDataInputsData}>
+            <Tooltip template={<TextTooltipTemplate text="Discard changes" />}>
+              <Delete />
             </Tooltip>
           </button>
         </div>
@@ -124,13 +153,16 @@ export const JobsPanelDataInputsTable = ({
 JobsPanelDataInputsTable.propTypes = {
   comboboxMatchesList: COMBOBOX_MATCHES.isRequired,
   comboboxSelectList: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  dataInputsValidations: PropTypes.object.isRequired,
   handleAddNewItem: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
   handleDeleteItems: PropTypes.func.isRequired,
   handlePathChange: PropTypes.func.isRequired,
+  handlePathOnBlur: PropTypes.func.isRequired,
   handlePathTypeChange: PropTypes.func.isRequired,
   inputsDispatch: PropTypes.func.isRequired,
   inputsState: PropTypes.shape({}).isRequired,
   match: PropTypes.shape({}).isRequired,
-  panelState: PropTypes.shape({}).isRequired
+  panelState: PropTypes.shape({}).isRequired,
+  resetDataInputsData: PropTypes.func.isRequired
 }

--- a/src/elements/JobsPanelTable/jobsPanelTable.scss
+++ b/src/elements/JobsPanelTable/jobsPanelTable.scss
@@ -38,6 +38,10 @@
             border: none;
           }
         }
+
+        .combobox_invalid {
+          border: $errorBorder;
+        }
       }
     }
   }
@@ -56,6 +60,11 @@
         &:first-child {
           max-width: 220px;
         }
+      }
+
+      .combobox_invalid {
+        border: $errorBorder;
+        border-radius: 0;
       }
 
       .input-row__item_edit {


### PR DESCRIPTION
https://trello.com/c/yDhzjqGd/985-jobs-panel-wrong-combobox-suggestions-flow-for-data-inputs

- **Data Inputs**: when using the wrong value for first step, which should be either `artifacts` or `feature-vectors` only, the UI still suggests project names as the next step instead of fail.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/132362373-021fb073-2c4a-4a5c-ae74-97dfa8560865.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/132362358-9de7fba5-c5c0-4dec-9107-e9df6b436259.png)
