### PR TITLE
[Jobs] Monitor: pending has no color indicator

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -79,11 +79,6 @@ button {
   @include statusState($brightTurquoise);
 }
 
-.state-created-job,
-.state-created-function {
-  @include statusState($topaz);
-}
-
 [class^=state-warn] {
   @include statusState($grandis);
 }
@@ -101,6 +96,12 @@ button {
 [class^=state-broken],
 [class^=state-aborted] {
   @include statusState($burntSienna);
+}
+
+.state-created-job,
+.state-created-function,
+.state-pending-job {
+  @include statusState($topaz);
 }
 
 iframe {

--- a/src/utils/getState.js
+++ b/src/utils/getState.js
@@ -26,6 +26,7 @@ const commonStateLabels = {
   fail: 'Fail',
   failed: 'Error',
   info: 'Info',
+  pending: 'Pending',
   ready: 'Ready',
   running: 'Deploying',
   succeeded: 'Succeeded',


### PR DESCRIPTION
https://trello.com/c/EnkrBNxT/991-jobs-monitor-pending-has-no-color-indicator

- **Jobs**: In “Monitor” tab, the pending status indicator (a gray circle with “Pending” tooltip”) was missing in “Name” cells, in the header of the details panel, and it had the wrong color (blue) in the “Status” filter dropdown menu.
Before:
![image](https://user-images.githubusercontent.com/13918850/132700499-f5572869-ab68-4ddb-bab9-fffda00f4fb3.png)
![image](https://user-images.githubusercontent.com/13918850/132700521-15071413-fdca-42ab-a821-11d38a5562e7.png)
After:
![image](https://user-images.githubusercontent.com/13918850/132700591-618ca714-b64a-4152-96f9-bd60f36c7382.png)
![image](https://user-images.githubusercontent.com/13918850/132700597-c2e22c96-8994-48d4-b941-a010b6830be5.png)

Jira ticket ML-1072