### PR TITLE
[General] Tooltip text might get unexpectedly wrapped

### DIFF
--- a/src/common/Tooltip/Tooltip.js
+++ b/src/common/Tooltip/Tooltip.js
@@ -2,6 +2,9 @@ import React, { useRef, useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { CSSTransition } from 'react-transition-group'
 import classnames from 'classnames'
+import { debounce } from 'lodash'
+
+import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 
 import './tooltip.scss'
 
@@ -81,6 +84,12 @@ const Tooltip = ({ children, className, hidden, template, textShow }) => {
     [hidden, textShow]
   )
 
+  const clearStyles = debounce(() => {
+    if (!isEveryObjectValueEmpty(style)) {
+      setStyle({})
+    }
+  }, 100)
+
   useEffect(() => {
     const node = parentRef.current
     if (node) {
@@ -97,9 +106,18 @@ const Tooltip = ({ children, className, hidden, template, textShow }) => {
   useEffect(() => {
     if (show) {
       window.addEventListener('scroll', handleScroll, true)
-      return () => window.removeEventListener('scroll', handleScroll, true)
     }
+
+    return () => window.removeEventListener('scroll', handleScroll, true)
   }, [show])
+
+  useEffect(() => {
+    window.addEventListener('resize', clearStyles)
+
+    return () => {
+      window.removeEventListener('resize', clearStyles)
+    }
+  }, [clearStyles, style])
 
   return (
     <>

--- a/src/elements/TooltipTemplate/TextTooltipTemplate.js
+++ b/src/elements/TooltipTemplate/TextTooltipTemplate.js
@@ -7,6 +7,7 @@ import './textTooltipTemplate.scss'
 const TextTooltipTemplate = ({ text, warning }) => {
   const [style, setStyle] = useState({})
   const textRef = useRef()
+  const offset = 60
   const horizontalPadding = 8
   const tooltipClassNames = classnames(
     'tooltip__text',
@@ -19,7 +20,11 @@ const TextTooltipTemplate = ({ text, warning }) => {
 
       setStyle({
         padding: `6px ${horizontalPadding}px`,
-        width: width + horizontalPadding * 2
+        width:
+          width > window.innerWidth
+            ? window.innerWidth - offset
+            : width + horizontalPadding * 2,
+        wordBreak: width > window.innerWidth ? 'break-word' : 'unset'
       })
     }
   }, [])

--- a/src/elements/TooltipTemplate/textTooltipTemplate.scss
+++ b/src/elements/TooltipTemplate/textTooltipTemplate.scss
@@ -5,7 +5,6 @@
   &__text {
     color: $white;
     white-space: pre-wrap;
-    word-break: break-word;
     background-color: $primary;
     border-radius: 4px;
   }


### PR DESCRIPTION
https://trello.com/c/lGz0ECgf/992-general-tooltip-text-might-get-unexpectedly-wrapped

- **General**: Tooltips had the words in them broken into multiple lines.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/133880202-c59f5c5e-988a-45b8-91ee-6cf278f57266.png)
  ![image](https://user-images.githubusercontent.com/13918850/133880209-637a6ccb-b665-495e-9da6-3d37975c9acf.png)
  ![image](https://user-images.githubusercontent.com/13918850/133880221-1484d054-7560-4de1-ba4e-b12497029f68.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/133880230-3a31adf3-689e-419b-879a-de446623aafd.png)
  ![image](https://user-images.githubusercontent.com/13918850/133880234-b46c4c2d-7b41-4d2a-80bc-25b8de8b5490.png)

Jira ticket ML-889