### PR TITLE
[Function panel] Pre-populate Resulting Image

### DIFF
--- a/src/components/FunctionsPanel/FunctionsPanel.js
+++ b/src/components/FunctionsPanel/FunctionsPanel.js
@@ -39,7 +39,6 @@ const FunctionsPanel = ({
 }) => {
   const [confirmData, setConfirmData] = useState(null)
   const [validation, setValidation] = useState({
-    isNameValid: true,
     isHandlerValid: true,
     isCodeImageValid: true,
     isBaseImageValid: true,
@@ -154,10 +153,6 @@ const FunctionsPanel = ({
 
   const handleSave = deploy => {
     if (checkValidation()) {
-      if (functionsStore.newFunction.metadata.name.length === 0) {
-        return setValidation(state => ({ ...state, isNameValid: false }))
-      }
-
       if (
         functionsStore.newFunction.kind !== FUNCTION_TYPE_SERVING &&
         functionsStore.newFunction.spec.default_handler.length === 0

--- a/src/components/FunctionsPanel/FunctionsPanelView.js
+++ b/src/components/FunctionsPanel/FunctionsPanelView.js
@@ -76,12 +76,7 @@ const FunctionsPanelView = ({
               iconClassName="new-item-side-panel__expand-icon"
               openByDefault
             >
-              <FunctionsPanelGeneral
-                defaultData={defaultData}
-                isNameValid={validation.isNameValid}
-                mode={mode}
-                setNameValid={setValidation}
-              />
+              <FunctionsPanelGeneral defaultData={defaultData} />
             </Accordion>
             <Accordion
               accordionClassName="new-item-side-panel__accordion"

--- a/src/elements/FunctionsPanelCode/FunctionsPanelCode.js
+++ b/src/elements/FunctionsPanelCode/FunctionsPanelCode.js
@@ -83,6 +83,11 @@ const FunctionsPanelCode = ({
             ]
         }))
       } else {
+        const buildImage = appStore.frontendSpec?.function_deployment_target_image_template
+          .replace('{project}', match.params.projectName)
+          .replace('{name}', functionsStore.newFunction.metadata.name)
+          .replace('{tag}', functionsStore.newFunction.metadata.tag || 'latest')
+
         setNewFunctionCommands(
           trimSplit(
             appStore.frontendSpec?.function_deployment_mlrun_command,
@@ -95,13 +100,15 @@ const FunctionsPanelCode = ({
             functionsStore.newFunction.kind
           ]
         )
+        setNewFunctionBuildImage(buildImage)
         setData(state => ({
           ...state,
           commands: appStore.frontendSpec?.function_deployment_mlrun_command,
           base_image:
             appStore.frontendSpec?.default_function_image_by_kind?.[
               functionsStore.newFunction.kind
-            ]
+            ],
+          build_image: buildImage
         }))
       }
     } else if (
@@ -126,6 +133,7 @@ const FunctionsPanelCode = ({
     defaultData.build,
     defaultData.image,
     functionsStore.newFunction.kind,
+    functionsStore.newFunction.metadata.name,
     functionsStore.newFunction.metadata.tag,
     imageType.length,
     match.params.projectName,
@@ -181,6 +189,11 @@ const FunctionsPanelCode = ({
           ]
       )
     } else {
+      const buildImage = appStore.frontendSpec?.function_deployment_target_image_template
+        .replace('{project}', match.params.projectName)
+        .replace('{name}', functionsStore.newFunction.metadata.name)
+        .replace('{tag}', functionsStore.newFunction.metadata.tag || 'latest')
+
       if (mode === PANEL_CREATE_MODE) {
         setNewFunctionImage('')
         setData(state => ({
@@ -190,7 +203,8 @@ const FunctionsPanelCode = ({
           base_image:
             appStore.frontendSpec?.default_function_image_by_kind?.[
               functionsStore.newFunction.kind
-            ]
+            ],
+          build_image: buildImage
         }))
       } else {
         setData(state => ({
@@ -202,7 +216,8 @@ const FunctionsPanelCode = ({
             state.base_image ||
             appStore.frontendSpec?.default_function_image_by_kind?.[
               functionsStore.newFunction.kind
-            ]
+            ],
+          build_image: state.build_image || buildImage
         }))
       }
 
@@ -220,7 +235,7 @@ const FunctionsPanelCode = ({
             functionsStore.newFunction.kind
           ]
       )
-      setNewFunctionBuildImage(data.build_image || '')
+      setNewFunctionBuildImage(data.build_image || buildImage)
     }
 
     setImageType(imageType)

--- a/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneral.js
+++ b/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneral.js
@@ -10,32 +10,16 @@ import { parseKeyValues } from '../../utils'
 const FunctionsPanelGeneral = ({
   defaultData,
   functionsStore,
-  isNameValid,
-  mode,
-  setNameValid,
   setNewFunctionDescription,
-  setNewFunctionLabels,
-  setNewFunctionName,
-  setNewFunctionTag
+  setNewFunctionLabels
 }) => {
   const [data, setData] = useState({
-    name: defaultData.name ?? '',
     description: defaultData.description ?? '',
+    kind: defaultData.type ?? functionsStore.newFunction.kind,
     labels: parseKeyValues(defaultData.labels) ?? [],
-    tag: defaultData.tag ?? ''
+    name: defaultData.name ?? functionsStore.newFunction.metadata.name,
+    tag: defaultData.tag ?? functionsStore.newFunction.metadata.tag
   })
-
-  const handleNameOnBlur = event => {
-    if (data.name !== functionsStore.newFunction.metadata.name) {
-      setNewFunctionName(event.target.value)
-    }
-  }
-
-  const handleTagOnBlur = event => {
-    if (data.tag !== functionsStore.newFunction.metadata.tag) {
-      setNewFunctionTag(event.target.value)
-    }
-  }
 
   const handleAddLabel = (label, labels) => {
     const newLabels = {}
@@ -66,18 +50,19 @@ const FunctionsPanelGeneral = ({
     }))
   }
 
+  const handleDescriptionOnBlur = () => {
+    if (functionsStore.newFunction.spec.description !== data.description) {
+      setNewFunctionDescription(data.description)
+    }
+  }
+
   return (
     <FunctionsPanelGeneralView
       data={data}
-      functionsStore={functionsStore}
       handleAddLabel={handleAddLabel}
       handleChangeLabels={handleChangeLabels}
-      handleNameOnBlur={handleNameOnBlur}
-      handleTagOnBlur={handleTagOnBlur}
-      isNameValid={isNameValid}
-      mode={mode}
+      handleDescriptionOnBlur={handleDescriptionOnBlur}
       setData={setData}
-      setNameValid={setNameValid}
       setNewFunctionDescription={setNewFunctionDescription}
     />
   )
@@ -88,10 +73,7 @@ FunctionsPanelGeneral.defaultProps = {
 }
 
 FunctionsPanelGeneral.propTypes = {
-  defaultData: PropTypes.shape({}),
-  isNameValid: PropTypes.bool.isRequired,
-  mode: PropTypes.string.isRequired,
-  setNameValid: PropTypes.func.isRequired
+  defaultData: PropTypes.shape({})
 }
 
 export default connect(functionsStore => ({ ...functionsStore }), {

--- a/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneralView.js
+++ b/src/elements/FunctionsPanelGeneral/FunctionsPanelGeneralView.js
@@ -2,72 +2,31 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import FunctionsPanelSection from '../FunctionsPanelSection/FunctionsPanelSection'
-import Input from '../../common/Input/Input'
 import TextArea from '../../common/TextArea/TextArea'
 import ChipCell from '../../common/ChipCell/ChipCell'
-
-import { PANEL_EDIT_MODE } from '../../constants'
 
 import './functionsPanelGeneral.scss'
 
 const FunctionsPanelGeneralView = ({
   data,
-  functionsStore,
   handleAddLabel,
   handleChangeLabels,
-  handleNameOnBlur,
-  handleTagOnBlur,
-  isNameValid,
-  mode,
-  setData,
-  setNameValid,
-  setNewFunctionDescription
+  handleDescriptionOnBlur,
+  setData
 }) => {
-  const nameValidationTip = (
-    <>
-      <span>&bull; Valid characters: a-z, 0-9, -</span>
-      <br />
-      <span>&bull; Must begin and end with: a-z, 0-9</span>
-      <br />
-      <span>&bull; Length - max: 63</span>
-    </>
-  )
-
   return (
     <div className="functions-panel__item new-item-side-panel__item general">
       <FunctionsPanelSection title="General">
         <div className="general__required-info">
-          <Input
-            disabled={mode === PANEL_EDIT_MODE}
-            floatingLabel
-            invalid={!isNameValid}
-            invalidText="This field is invalid"
-            label="Function Name"
-            maxLength={63}
-            onChange={name => setData(state => ({ ...state, name }))}
-            onBlur={handleNameOnBlur}
-            pattern="^(?=[\S\s]{1,63}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-            required
-            requiredText="This field is required"
-            setInvalid={value =>
-              setNameValid(state => ({ ...state, isNameValid: value }))
-            }
-            tip={nameValidationTip}
-            type="text"
-            value={data.name}
-            wrapperClassName="name"
-          />
-          <Input
-            disabled={mode === PANEL_EDIT_MODE}
-            floatingLabel
-            label="Tag"
-            onChange={tag => setData(state => ({ ...state, tag }))}
-            onBlur={handleTagOnBlur}
-            placeholder="latest"
-            type="text"
-            value={data.tag}
-            wrapperClassName="tag"
-          />
+          <div className="name">
+            Name: <span>{data.name}</span>
+          </div>
+          <div className="tag">
+            Tag: <span>{data.tag || 'latest'}</span>
+          </div>
+          <div className="runtime">
+            Runtime: <span>{data.kind}</span>
+          </div>
         </div>
         <TextArea
           floatingLabel
@@ -78,13 +37,7 @@ const FunctionsPanelGeneralView = ({
               description
             }))
           }
-          onBlur={event => {
-            if (
-              functionsStore.newFunction.spec.description !== event.target.value
-            ) {
-              setNewFunctionDescription(event.target.value)
-            }
-          }}
+          onBlur={handleDescriptionOnBlur}
           type="text"
           value={data.description}
           wrapperClassName="description"
@@ -109,15 +62,10 @@ const FunctionsPanelGeneralView = ({
 
 FunctionsPanelGeneralView.propTypes = {
   data: PropTypes.shape({}).isRequired,
-  functionsStore: PropTypes.shape({}).isRequired,
   handleAddLabel: PropTypes.func.isRequired,
   handleChangeLabels: PropTypes.func.isRequired,
-  handleNameOnBlur: PropTypes.func.isRequired,
-  handleTagOnBlur: PropTypes.func.isRequired,
-  isNameValid: PropTypes.bool.isRequired,
-  mode: PropTypes.string.isRequired,
+  handleDescriptionOnBlur: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
-  setNameValid: PropTypes.func.isRequired,
   setNewFunctionDescription: PropTypes.func.isRequired
 }
 

--- a/src/elements/FunctionsPanelGeneral/functionsPanelGeneral.scss
+++ b/src/elements/FunctionsPanelGeneral/functionsPanelGeneral.scss
@@ -6,21 +6,10 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
+    padding: 5px;
 
-    .name {
-      .input {
-        width: 100%;
-      }
-    }
-
-    .tag {
-      flex: 0.3;
-      max-width: 150px;
-      margin-left: 10px;
-
-      .input {
-        width: 100%;
-      }
+    span {
+      font-weight: bold;
     }
   }
 

--- a/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
+++ b/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
@@ -44,7 +44,7 @@ const NewFunctionPopUp = ({
   }
 
   const checkValidation = () => {
-    return Object.values(validation).find(value => value === false) ?? true
+    return !Object.values(validation).includes(false)
   }
 
   const handleNameOnBlur = () => {

--- a/src/elements/NewFunctionPopUp/newFunctionPopUp.scss
+++ b/src/elements/NewFunctionPopUp/newFunctionPopUp.scss
@@ -1,5 +1,22 @@
 .new-function {
   &__pop-up {
     width: 200px;
+
+    &-inputs {
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      margin-bottom: 10px;
+
+      .name {
+        flex: 0.7;
+        width: 100%;
+      }
+
+      .tag {
+        flex: 0.3;
+        margin-left: 10px;
+      }
+    }
   }
 }


### PR DESCRIPTION
https://trello.com/c/kmAQyQyy/1000-function-panel-pre-populate-resulting-image

- **Functions, Function panel**: Moved “Function Name” and “Tag” fields from “General” section of the function panel to the pop-over in the “Functions” screen (after clicking on the “New” button). Added the function name, tag and runtime as read-only text in the “General” section. Added default value pre-population for the “Resulting Image” field, where it gets its default value from `frontend-spec` and supplant `{project}`, `{name}` and `{tag}` with the project name, function name, and function tag, respectively.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/133639521-6bfd466b-2403-489f-bc6b-92410eff443d.png)
  ![image](https://user-images.githubusercontent.com/13918850/133639490-88ff1010-d8af-4af2-a4c1-2888f285727f.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/133639536-19e46688-a11a-4653-98a8-681221276fb1.png)
  ![image](https://user-images.githubusercontent.com/13918850/133639179-403f019a-28b9-4048-86d1-841815e96f96.png)

In-release (GA) for the most part.

Jira ticket ML-906, ML-1111