### PR TITLE
Fix [Pkg] Set Build CI workflow to use git hash of 8 charaters for images tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Extract git hashes and latest version
       id: git_info
       run: |
-        echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short=8 $GITHUB_SHA)"
         echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set computed versions params
       id: computed_params


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/1326