### PR TITLE
[Jobs] Status filter: unaligned option labels

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -93,6 +93,10 @@ button {
   @include statusState($brightTurquoise);
 }
 
+[class^=state-all] {
+  @include statusState(transparent);
+}
+
 [class^=state-warn] {
   @include statusState($grandis);
 }


### PR DESCRIPTION
https://trello.com/c/evTwjIDu/1005-jobs-status-filter-unaligned-option-labels

- **Jobs**: In “Monitor” tab, the “All” option label in the “Status” filter was unaligned with the rest of the option labels.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/134005082-58b60598-9fa7-4ea9-8bde-ae0c866bd57c.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/134005103-d4c0440d-5e27-41eb-9b12-97d7f189041b.png)
