### PR TITLE
[Jobs] Error when grouping by workflows

### DIFF
--- a/src/components/JobsPage/jobsData.js
+++ b/src/components/JobsPage/jobsData.js
@@ -244,7 +244,7 @@ export const generateActionsMenu = (
           label: 'Re-run',
           icon: <Run />,
           hidden: ['local', ''].includes(
-            job.ui.originalContent.metadata.labels.kind
+            job.ui?.originalContent.metadata.labels.kind
           ),
           onClick: handleRerunJob
         },

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -114,6 +114,7 @@ const Table = ({
         groupLatestItem: [],
         groupWorkflowItems: createJobsContent(
           groupWorkflowItem,
+          !isEveryObjectValueEmpty(selectedItem),
           groupedByWorkflow
         )
       })


### PR DESCRIPTION
https://trello.com/c/LfH9vfMP/1011-jobs-error-when-grouping-by-workflows

- **Jobs**: In “Monitor” tab, setting “Group By” to “Workflows” caused an error in UI when there were workflows in the project.