### PR TITLE
[General] Tooltip text with dashes may be wrapped incorrectly

### DIFF
--- a/src/elements/TooltipTemplate/TextTooltipTemplate.js
+++ b/src/elements/TooltipTemplate/TextTooltipTemplate.js
@@ -24,7 +24,8 @@ const TextTooltipTemplate = ({ text, warning }) => {
           width > window.innerWidth
             ? window.innerWidth - offset
             : width + horizontalPadding * 2,
-        wordBreak: width > window.innerWidth ? 'break-word' : 'unset'
+        wordBreak: width > window.innerWidth ? 'break-word' : 'unset',
+        whiteSpace: width > window.innerWidth ? 'pre-wrap' : 'nowrap'
       })
     }
   }, [])

--- a/src/elements/TooltipTemplate/textTooltipTemplate.scss
+++ b/src/elements/TooltipTemplate/textTooltipTemplate.scss
@@ -4,7 +4,6 @@
 .tooltip {
   &__text {
     color: $white;
-    white-space: pre-wrap;
     background-color: $primary;
     border-radius: 4px;
   }


### PR DESCRIPTION
https://trello.com/c/xy7G4x2v/1023-general-tooltip-text-with-dashes-may-be-wrapped-incorrectly

- **General**: Tooltip close to the viewport‘s edge sometimes got broken down improperly.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/134472853-0276a739-159a-4b47-92e3-d4ec90fcdab3.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/134472849-15c69ee8-24dc-4884-aca7-fb344ffe01f4.png)
