### PR TITLE
Impl [Projects] Move to new project summaries endpoint

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -448,11 +448,11 @@ const projectsAction = {
     dispatch(projectsAction.fetchProjectsSummaryBegin())
 
     return projectsApi
-      .getProjectsSummary(cancelToken)
-      .then(({ data: { projects } }) => {
-        dispatch(projectsAction.fetchProjectsSummarySuccess(projects))
+      .getProjectSummaries(cancelToken)
+      .then(({ data: { project_summaries } }) => {
+        dispatch(projectsAction.fetchProjectsSummarySuccess(project_summaries))
 
-        return projects
+        return project_summaries
       })
       .catch(err => {
         dispatch(projectsAction.fetchProjectsSummaryFailure(err))

--- a/src/api/projects-api.js
+++ b/src/api/projects-api.js
@@ -58,12 +58,9 @@ export default {
         format: 'name_only'
       }
     }),
-  getProjectsSummary: cancelToken =>
-    mainHttpClient.get('/projects', {
-      cancelToken,
-      params: {
-        format: 'summary'
-      }
+  getProjectSummaries: cancelToken =>
+    mainHttpClient.get('/project-summaries', {
+      cancelToken
     }),
   getProjectWorkflows: project => {
     return mainHttpClient.get(`/projects/${project}/pipelines`)


### PR DESCRIPTION
- **Projects**: Fetch project summaries from newer endpoint `GET /api/project-summaries` instead of the older (and soon to be deprecated): `GET /api/projects?format=summary`.

Relates to PRs https://github.com/mlrun/mlrun/pull/1342 & https://github.com/mlrun/mlrun/pull/1347

Jira ticket ML-498