### PR TITLE
[Projects] Archived Projects label is cropped

### DIFF
--- a/src/components/ProjectsPage/projects.scss
+++ b/src/components/ProjectsPage/projects.scss
@@ -39,9 +39,10 @@
       }
 
       .project-types-select {
-        width: 180px;
+        width: 210px;
 
         .select__header {
+          width: auto;
           font-size: 20px;
 
           .select__value {


### PR DESCRIPTION
https://trello.com/c/5IevRJHg/1027-projects-archived-projects-label-is-cropped

- **Projects**: “Archived Projects” was always cropped
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/135610927-c5ebdc80-f42b-4cff-9973-c9a901e18c14.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/135610938-4611af61-d339-40b5-9ab8-2ff6ba877f65.png)
