### PR TITLE
[Feature sets] UI crashes on row expand

### DIFF
--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -40,6 +40,7 @@ export const pageDataInitialState = {
   filters: [],
   infoHeaders: [],
   page: '',
+  selectedRowData: {},
   registerArtifactDialogTitle: '',
   tabs: []
 }


### PR DESCRIPTION
https://trello.com/c/EXcTkbhk/1044-feature-sets-ui-crashes-on-row-expand

- **Feature sets**: Error occurred on expanding a feature-set row after visiting “Datasets” tab.

In-release (GA)
Bug originated on https://github.com/mlrun/ui/pull/816 [v0.8.0-rc3](https://github.com/mlrun/ui/releases/tag/v0.8.0-rc3) ML-1118