### PR TITLE
[Project Settings] Add General and Secrets tabs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import {
   FEATURE_SETS_TAB,
   MODELS_TAB,
   MONITOR_JOBS_TAB,
+  PROJECTS_SETTINGS_GENERAL_TAB,
   WORKFLOW_SUB_PAGE
 } from './constants'
 
@@ -54,8 +55,13 @@ const App = () => {
             />
             <Route
               exact
-              path="/projects/:projectName/settings"
+              path="/projects/:projectName/settings/:pageTab"
               render={routeProps => <ProjectSettings {...routeProps} />}
+            />
+            <Redirect
+              exact
+              from="/projects/:projectName/settings"
+              to={`/projects/:projectName/settings/${PROJECTS_SETTINGS_GENERAL_TAB}`}
             />
             <Route
               path="/projects/:projectName/jobs/:pageTab/create-new-job"

--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -1,55 +1,41 @@
-import React, { useCallback, useEffect } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
-import { isEmpty } from 'lodash'
 import PropTypes from 'prop-types'
+import { useLocation } from 'react-router-dom'
 
 import ProjectSettingsGeneral from '../../elements/ProjectSettingsGeneral/ProjectSettingsGeneral'
 import ProjectSettingsSecrets from '../../elements/ProjectSettingsSecrets/ProjectSettingsSecrets'
 import Breadcrumbs from '../../common/Breadcrumbs/Breadcrumbs'
-import NoData from '../../common/NoData/NoData'
-import Loader from '../../common/Loader/Loader'
+import ContentMenu from '../../elements/ContentMenu/ContentMenu'
 
 import projectsAction from '../../actions/projects'
+import { PROJECTS_SETTINGS_GENERAL_TAB } from '../../constants'
+import { page, tabs } from './projectSettings.util'
 
 import './projectSettings.scss'
 
-const ProjectSettings = ({
-  fetchProject,
-  match,
-  projectStore,
-  removeProjectData
-}) => {
-  const fetchProjectData = useCallback(() => {
-    fetchProject(match.params.projectName)
-  }, [fetchProject, match.params.projectName])
-
-  useEffect(() => {
-    fetchProjectData()
-
-    return () => {
-      removeProjectData()
-    }
-  }, [fetchProjectData, removeProjectData])
+const ProjectSettings = ({ match }) => {
+  const location = useLocation()
 
   return (
     <div className="settings">
       <div className="settings__header">
         <Breadcrumbs match={match} />
       </div>
-      {projectStore.project.loading ? (
-        <Loader />
-      ) : projectStore.project.error ? (
-        <div className=" project__error-container">
-          <h1>{projectStore.project.error}</h1>
-        </div>
-      ) : isEmpty(projectStore.project.data) ? (
-        <NoData />
-      ) : (
-        <div className="settings__content">
+      <div className="settings__content">
+        <ContentMenu
+          activeTab={match.params.pageTab}
+          location={location}
+          match={match}
+          screen={page}
+          tabs={tabs}
+        />
+        {match.params.pageTab === PROJECTS_SETTINGS_GENERAL_TAB ? (
           <ProjectSettingsGeneral match={match} />
+        ) : (
           <ProjectSettingsSecrets match={match} />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/ProjectSettings/projectSettings.scss
+++ b/src/components/ProjectSettings/projectSettings.scss
@@ -6,14 +6,14 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  min-width: 900px;
+  min-width: 600px;
 
   &__content {
+    position: relative;
     display: flex;
     flex: 1 1;
     flex-direction: row;
-    justify-content: space-between;
-    padding: 45px;
+    margin: 45px 25px 25px;
   }
 
   &__header {
@@ -23,14 +23,31 @@
   }
 
   &__card {
-    width: 50%;
+    width: 100%;
     padding: 40px;
     background-color: rgba($white, 0.84);
     border-radius: 4px;
-  }
 
-  &__card:first-child {
-    margin-right: 45px;
+    &-header {
+      margin-bottom: 25px;
+      color: $primary;
+      font-weight: 500;
+      font-size: 20px;
+      line-height: 23px;
+    }
+
+    &-divider {
+      margin: 16px 0;
+      border-top: $primaryBorder;
+    }
+
+    &-subtitle {
+      margin: 0 0 5px;
+      color: rgba($mulledWine, 0.88);
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 16px;
+    }
   }
 
   &__description {
@@ -40,29 +57,6 @@
     font-size: 14px;
     line-height: 16px;
     cursor: pointer;
-  }
-}
-
-.card {
-  &__header {
-    margin-bottom: 25px;
-    color: $primary;
-    font-weight: 500;
-    font-size: 20px;
-    line-height: 23px;
-  }
-
-  &__divider {
-    margin: 16px 0;
-    border-top: $primaryBorder;
-  }
-
-  &__subtitle {
-    margin-bottom: 5px;
-    color: rgba($mulledWine, 0.88);
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 16px;
   }
 }
 

--- a/src/components/ProjectSettings/projectSettings.scss
+++ b/src/components/ProjectSettings/projectSettings.scss
@@ -23,6 +23,10 @@
   }
 
   &__card {
+    &-content {
+      max-width: 800px;
+    }
+
     width: 100%;
     padding: 40px;
     background-color: rgba($white, 0.84);

--- a/src/components/ProjectSettings/projectSettings.util.js
+++ b/src/components/ProjectSettings/projectSettings.util.js
@@ -1,2 +1,15 @@
+import {
+  PROJECTS_SETTINGS_GENERAL_TAB,
+  PROJECTS_SETTINGS_PAGE,
+  PROJECTS_SETTINGS_SECRETS_TAB
+} from '../../constants'
+
 export const ARTIFACT_PATH = 'artifact_path'
 export const SOURCE_URL = 'source'
+
+export const tabs = [
+  { id: PROJECTS_SETTINGS_GENERAL_TAB, label: 'General' },
+  { id: PROJECTS_SETTINGS_SECRETS_TAB, label: 'Secrets' }
+]
+
+export const page = PROJECTS_SETTINGS_PAGE

--- a/src/constants.js
+++ b/src/constants.js
@@ -27,6 +27,9 @@ export const PANEL_CREATE_MODE = 'CREATE'
 /*=========== PAGES & TABS =============*/
 
 export const PROJECTS_PAGE = 'PROJECTS'
+export const PROJECTS_SETTINGS_PAGE = 'SETTINGS'
+export const PROJECTS_SETTINGS_GENERAL_TAB = 'general'
+export const PROJECTS_SETTINGS_SECRETS_TAB = 'secrets'
 
 export const JOBS_PAGE = 'JOBS'
 export const SCHEDULE_TAB = 'schedule'

--- a/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneral.js
+++ b/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneral.js
@@ -15,8 +15,10 @@ import projectsAction from '../../actions/projects'
 import './projectSettingsGeneral.scss'
 
 const ProjectSettingsGeneral = ({
+  fetchProject,
   match,
   projectStore,
+  removeProjectData,
   setProjectParams,
   setProjectSettings
 }) => {
@@ -32,6 +34,19 @@ const ProjectSettingsGeneral = ({
   })
 
   const inputRef = React.createRef()
+
+  useEffect(() => {
+    fetchProject(match.params.projectName)
+
+    return () => {
+      removeProjectData()
+    }
+  }, [
+    removeProjectData,
+    match.params.pageTab,
+    match.params.projectName,
+    fetchProject
+  ])
 
   const generalParams = useMemo(
     () =>
@@ -243,6 +258,7 @@ const ProjectSettingsGeneral = ({
     <ProjectSettingsGeneralView
       artifactPath={projectStore.project.data?.spec.artifact_path ?? ''}
       editProject={editProject}
+      error={projectStore.project?.error}
       generalParams={generalParams}
       handleAddNewParameter={handleAddNewParameter}
       handleDeleteParameter={handleDeleteParameter}
@@ -250,6 +266,7 @@ const ProjectSettingsGeneral = ({
       handleEditProject={handleEditProject}
       handleOnChangeSettings={handleOnChangeSettings}
       handleOnKeyDown={handleOnKeyDown}
+      loading={projectStore.project?.loading}
       ref={inputRef}
       source={projectStore.project.data?.spec.source ?? ''}
     />

--- a/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneralView.js
+++ b/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneralView.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Input from '../../common/Input/Input'
 import ProjectSettingsSource from '../ProjectSettingsSource/ProjectSettingsSource'
 import KeyValueTable from '../../common/KeyValueTable/KeyValueTable'
+import Loader from '../../common/Loader/Loader'
 
 import { ARTIFACT_PATH } from '../../components/ProjectSettings/projectSettings.util'
 
@@ -12,6 +13,7 @@ const ProjectSettingsGeneralView = React.forwardRef(
     {
       artifactPath,
       editProject,
+      error,
       generalParams,
       handleAddNewParameter,
       handleDeleteParameter,
@@ -19,61 +21,78 @@ const ProjectSettingsGeneralView = React.forwardRef(
       handleEditProject,
       handleOnChangeSettings,
       handleOnKeyDown,
+      loading,
       source
     },
     ref
   ) => {
     return (
       <div className="settings__card">
-        <div className="card__header">General</div>
-        <div className="card__content">
-          <ProjectSettingsSource
-            editSourceData={editProject.source}
-            handleEditProject={handleEditProject}
-            handleOnChangeSettings={handleOnChangeSettings}
-            handleOnKeyDown={handleOnKeyDown}
-            ref={ref}
-            settingsSource={source}
-          />
-          <div className="card__divider" />
-          <div
-            className="settings__artifact-path"
-            onClick={() => handleEditProject(ARTIFACT_PATH)}
-          >
-            <Input
-              floatingLabel
-              label="Artifact path"
-              onChange={handleOnChangeSettings}
-              onKeyDown={handleOnKeyDown}
-              ref={ref}
-              value={editProject.artifact_path.value ?? artifactPath}
-            />
+        {loading ? (
+          <Loader />
+        ) : error ? (
+          <div>
+            <h1>{error}</h1>
           </div>
-          <p className="card__subtitle">Parameters</p>
-          <KeyValueTable
-            addNewItem={handleAddNewParameter}
-            addNewItemLabel="Add parameter"
-            className="settings__params"
-            content={generalParams}
-            deleteItem={handleDeleteParameter}
-            editItem={handleEditParameter}
-            isKeyRequired={true}
-            isValueRequired={true}
-            keyHeader="Key"
-            keyLabel="Key"
-            valueHeader="Value"
-            valueLabel="Value"
-            withEditMode
-          />
-        </div>
+        ) : (
+          <>
+            <div className="settings__card-header">General</div>
+            <div className="settings__card-content">
+              <ProjectSettingsSource
+                editSourceData={editProject.source}
+                handleEditProject={handleEditProject}
+                handleOnChangeSettings={handleOnChangeSettings}
+                handleOnKeyDown={handleOnKeyDown}
+                ref={ref}
+                settingsSource={source}
+              />
+              <div className="settings__card-divider" />
+              <div
+                className="settings__artifact-path"
+                onClick={() => handleEditProject(ARTIFACT_PATH)}
+              >
+                <Input
+                  floatingLabel
+                  label="Artifact path"
+                  onChange={handleOnChangeSettings}
+                  onKeyDown={handleOnKeyDown}
+                  ref={ref}
+                  value={editProject.artifact_path.value ?? artifactPath}
+                />
+              </div>
+              <p className="settings__card-subtitle">Parameters</p>
+              <KeyValueTable
+                addNewItem={handleAddNewParameter}
+                addNewItemLabel="Add parameter"
+                className="settings__params"
+                content={generalParams}
+                deleteItem={handleDeleteParameter}
+                editItem={handleEditParameter}
+                isKeyRequired={true}
+                isValueRequired={true}
+                keyHeader="Key"
+                keyLabel="Key"
+                valueHeader="Value"
+                valueLabel="Value"
+                withEditMode
+              />
+            </div>
+          </>
+        )}
       </div>
     )
   }
 )
 
+ProjectSettingsGeneralView.defaultProps = {
+  error: null,
+  loading: null
+}
+
 ProjectSettingsGeneralView.propTypes = {
   artifactPath: PropTypes.string.isRequired,
   editProject: PropTypes.object.isRequired,
+  error: PropTypes.string,
   generalParams: PropTypes.array.isRequired,
   handleAddNewParameter: PropTypes.func.isRequired,
   handleDeleteParameter: PropTypes.func.isRequired,
@@ -81,6 +100,7 @@ ProjectSettingsGeneralView.propTypes = {
   handleEditProject: PropTypes.func.isRequired,
   handleOnChangeSettings: PropTypes.func.isRequired,
   handleOnKeyDown: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
   source: PropTypes.string.isRequired
 }
 

--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecrets.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecrets.js
@@ -36,7 +36,7 @@ const ProjectSettingsSecrets = ({
     return () => {
       removeProjectData()
     }
-  }, [fetchSecrets, removeProjectData])
+  }, [fetchSecrets, removeProjectData, match.params.projectName])
 
   const handleSecretDelete = (secret, index) => {
     const filteredArray = projectStore.project.secrets?.data[

--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
@@ -32,12 +32,12 @@ const ProjectSettingsSecretsView = ({
           </div>
         ) : (
           <>
-            <div className="card__header">Secrets</div>
-            <div className="card__subtitle">
+            <div className="settings__card-header">Secrets</div>
+            <div className="settings__card-subtitle">
               These secrets will automatically be available to all jobs
               belonging to this project.
             </div>
-            <div className="card__content">
+            <div className="settings__card-content">
               {secrets?.['secret_keys'] &&
                 secrets['secret_keys'].map((secret, index) => (
                   <ProjectSecretRow

--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
@@ -24,11 +24,6 @@ const ProjectSettingsSecretsView = ({
   return (
     <>
       <div className="settings__card">
-        <div className="card__header">Secrets</div>
-        <div className="card__subtitle">
-          These secrets will automatically be available to all jobs belonging to
-          this project.
-        </div>
         {loading ? (
           <Loader />
         ) : error ? (
@@ -36,30 +31,37 @@ const ProjectSettingsSecretsView = ({
             <h1>{error}</h1>
           </div>
         ) : (
-          <div className="card__content">
-            {secrets?.['secret_keys'] &&
-              secrets['secret_keys'].map((secret, index) => (
-                <ProjectSecretRow
-                  handleEditClick={handleEditClick}
-                  handleSecretDelete={secret =>
-                    handleSecretDelete(secret, index)
-                  }
-                  key={index}
-                  secret={secret}
-                />
-              ))}
-            <div className="secret__row">
-              <button
-                className="new-secret__button"
-                onClick={() => {
-                  setCreateNewSecretDialogOpen(true)
-                }}
-              >
-                <Plus />
-                Add secret
-              </button>
+          <>
+            <div className="card__header">Secrets</div>
+            <div className="card__subtitle">
+              These secrets will automatically be available to all jobs
+              belonging to this project.
             </div>
-          </div>
+            <div className="card__content">
+              {secrets?.['secret_keys'] &&
+                secrets['secret_keys'].map((secret, index) => (
+                  <ProjectSecretRow
+                    handleEditClick={handleEditClick}
+                    handleSecretDelete={secret =>
+                      handleSecretDelete(secret, index)
+                    }
+                    key={index}
+                    secret={secret}
+                  />
+                ))}
+              <div className="secret__row">
+                <button
+                  className="new-secret__button"
+                  onClick={() => {
+                    setCreateNewSecretDialogOpen(true)
+                  }}
+                >
+                  <Plus />
+                  Add secret
+                </button>
+              </div>
+            </div>
+          </>
         )}
       </div>
       {isCreateNewSecretDialogOpen && (
@@ -91,7 +93,7 @@ ProjectSettingsSecretsView.defaultProps = {
 
 ProjectSettingsSecretsView.propTypes = {
   editableSecret: PropTypes.string.isRequired,
-  error: PropTypes.bool,
+  error: PropTypes.string,
   handleEditClick: PropTypes.func.isRequired,
   handleSecretDelete: PropTypes.func.isRequired,
   isCreateNewSecretDialogOpen: PropTypes.bool.isRequired,

--- a/src/elements/ProjectSettingsSource/ProjectSettingsSource.js
+++ b/src/elements/ProjectSettingsSource/ProjectSettingsSource.js
@@ -41,7 +41,7 @@ const ProjectSettingsSource = React.forwardRef(
             <>
               {editSourceData.value || settingsSource ? (
                 <div>
-                  <p className="card__subtitle">Source URL</p>
+                  <p className="settings__card-subtitle">Source URL</p>
                   <a
                     href={editSourceData.value || settingsSource}
                     onClick={event => event.stopPropagation()}

--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -778,59 +778,7 @@ export default (state = initialState, { type, payload }) => {
       return {
         ...state,
         project: {
-          data: null,
-          error: null,
-          loading: false,
-          dataSets: {
-            data: null,
-            error: null,
-            loading: false
-          },
-          failedJobs: {
-            data: [],
-            error: null,
-            loading: false
-          },
-          featureSets: {
-            data: [],
-            error: null,
-            loading: false
-          },
-          files: {
-            data: null,
-            error: null,
-            loading: false
-          },
-          jobs: {
-            data: null,
-            error: null,
-            loading: false
-          },
-          functions: {
-            data: null,
-            error: null,
-            loading: false
-          },
-          models: {
-            data: [],
-            error: null,
-            loading: false
-          },
-          runningJobs: {
-            data: [],
-            error: null,
-            loading: false
-          },
-          scheduledJobs: {
-            data: [],
-            error: null,
-            loading: false
-          },
-          workflows: {
-            data: [],
-            error: null,
-            loading: false
-          }
+          ...initialState.project
         }
       }
     case REMOVE_PROJECTS:


### PR DESCRIPTION
https://trello.com/c/hxwHL5GQ/1045-project-settings-add-general-and-secrets-tabs

- **Project Settings**: Split into two tabs: “General” and “Secrets”
Before:
  ![screencapture-localhost-3000-projects-default-settings-2021-10-06-12_25_16](https://user-images.githubusercontent.com/13918850/136176555-275f4b51-91d5-4eec-8091-0d672c955162.png)
After:
  ![image](https://user-images.githubusercontent.com/13918850/136168328-859467ca-0121-409c-a7b5-d23680780dc1.png)
  ![image](https://user-images.githubusercontent.com/13918850/136168337-5cfbf403-b574-44c1-a04e-551bf806a005.png)

In-release (GA)
Continuing https://github.com/mlrun/ui/pull/831 [v0.8.0-rc4](https://github.com/mlrun/ui/releases/tag/v0.8.0-rc4)

Jira ticket ML-1038