### PR TITLE
[Function panel] Resources overflows container

### DIFF
--- a/src/components/JobsPanel/jobsPanel.scss
+++ b/src/components/JobsPanel/jobsPanel.scss
@@ -26,6 +26,10 @@
         .panel-section__body {
           align-items: center;
         }
+
+        .select__value {
+          min-width: 120px;
+        }
       }
 
       .select {

--- a/src/elements/FunctionsPanelResources/functionsPanelResources.scss
+++ b/src/elements/FunctionsPanelResources/functionsPanelResources.scss
@@ -10,10 +10,14 @@
 
   .memory,
   .cpu {
-    margin-right: 30px;
+    margin-right: 20px;
 
     .panel-section__body {
       align-items: center;
+    }
+
+    .select__value {
+      min-width: 120px;
     }
   }
 


### PR DESCRIPTION
https://trello.com/c/39Xuk0l4/1054-function-panel-resources-overflows-container

- **Function panel**: In “Resources” section, “Memory Limit” field moved to the next line when selecting “millicpus” in the “CPU Unit” field.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/137479767-57670ea6-26da-4cb4-8e2f-e249142df4a4.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/137479757-26fa3272-bd43-4d10-89e8-2000f875a1b3.png)