### PR TITLE
[General] Wrong redirection on "MLRun" logo click

### DIFF
--- a/src/layout/Page/Page.js
+++ b/src/layout/Page/Page.js
@@ -28,11 +28,10 @@ const Page = ({ children, fetchFrontendSpec, history, location }) => {
   useLayoutEffect(() => {
     if (savedDemoMode && !isDemoMode(location.search)) {
       history.replace({
-        pathname: location.pathname,
         search: '?demo=true'
       })
     }
-  }, [savedDemoMode, history, location.pathname, location.search])
+  }, [history, location.search, savedDemoMode])
 
   return <PageView>{children}</PageView>
 }


### PR DESCRIPTION
https://trello.com/c/5L4eSIAQ/1057-general-wrong-redirection-on-mlrun-logo-click

- **General**: Clicking on the MLRun logo when address bar has `?demo=true` in the URL resulted in an error.

In-release (GA)
Continuing https://github.com/mlrun/ui/pull/804 [v0.8.0-rc3](https://github.com/mlrun/ui/releases/tag/v0.8.0-rc3) ML-688