### PR TITLE
[Files] UI stuck on entering preview tab with numerous rows

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -49,7 +49,7 @@ const ArtifactsPreviewView = ({
               })}
             </div>
             <div className="artifact-preview__table-body">
-              {preview.data.content.map((contentItem, index) => (
+              {preview.data.content.splice(0, 100).map((contentItem, index) => (
                 <div key={index} className="artifact-preview__table-row">
                   {Array.isArray(contentItem) ? (
                     contentItem.map(value => (


### PR DESCRIPTION
https://trello.com/c/EXdqm3rK/1056-files-project-stucks-on-entering-preview-tab

- **Models, Files, Datasets**: Previewing artifacts with a preview of type `table` might make UI hang when there is a very large amount of records. It is now limited to showing only the first 100 records.

Jira ticket ML-1221