### PR TITLE
[Jobs] Two loaders exists on entering Details Logs tab

### DIFF
--- a/src/components/DetailsLogs/DetailsLogs.js
+++ b/src/components/DetailsLogs/DetailsLogs.js
@@ -19,12 +19,12 @@ const DetailsLogs = ({
   const [detailsLogs, setDetailsLogs] = useState('')
 
   useEffect(() => {
-    setDetailsLogs(jobsStore.logs || functionsStore.logs.data)
+    setDetailsLogs(jobsStore.logs.data || functionsStore.logs.data)
 
     return () => {
       setDetailsLogs('')
     }
-  }, [functionsStore.logs.data, jobsStore.logs])
+  }, [functionsStore.logs.data, jobsStore.logs.data])
 
   useEffect(() => {
     if (withLogsRefreshBtn) {
@@ -50,7 +50,7 @@ const DetailsLogs = ({
     <div className="table__item_logs">
       {detailsLogs.length > 0 ? (
         <div className="table__item_logs__content">{detailsLogs}</div>
-      ) : functionsStore.logs.loading || jobsStore.loading ? (
+      ) : functionsStore.logs.loading || jobsStore.logs.loading ? (
         <Loader section secondary />
       ) : (
         <NoData />

--- a/src/reducers/jobReducer.js
+++ b/src/reducers/jobReducer.js
@@ -43,7 +43,11 @@ const initialState = {
   allJobsData: [],
   job: {},
   jobs: [],
-  logs: '',
+  logs: {
+    data: '',
+    loading: false,
+    error: null
+  },
   loading: false,
   error: null,
   newJob: {
@@ -99,7 +103,10 @@ export default (state = initialState, { type, payload }) => {
     case FETCH_JOB_LOGS_BEGIN:
       return {
         ...state,
-        loading: true
+        logs: {
+          ...state.logs,
+          loading: true
+        }
       }
     case FETCH_JOB_BEGIN:
       return {
@@ -139,15 +146,20 @@ export default (state = initialState, { type, payload }) => {
     case FETCH_JOB_LOGS_FAILURE:
       return {
         ...state,
-        logs: [],
-        loading: false,
-        error: payload
+        logs: {
+          data: [],
+          loading: false,
+          error: payload
+        }
       }
     case FETCH_JOB_LOGS_SUCCESS:
       return {
         ...state,
-        logs: payload,
-        loading: false
+        logs: {
+          data: payload,
+          loading: false,
+          error: null
+        }
       }
     case FETCH_JOBS_BEGIN:
       return {
@@ -170,7 +182,7 @@ export default (state = initialState, { type, payload }) => {
     case REMOVE_JOB_LOGS:
       return {
         ...state,
-        logs: ''
+        logs: initialState.logs
       }
     case REMOVE_JOB_ERROR:
       return {


### PR DESCRIPTION
https://trello.com/c/da2E52Xy/1060-jobs-two-loaders-exists-on-entering-details-logs-tab

- **Jobs**: In “Logs” tab in details panel of a job, there were two loaders instead of one.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/137303760-8db0da21-484d-4df8-bfa3-979cc7cfd7fc.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/137303786-bd92a7c6-680f-4620-8c4d-885b7819172a.png)