### PR TITLE
Impl [Jobs] Redirect /jobs/monitor/* to /jobs/monitor-jobs/*

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,6 +63,11 @@ const App = () => {
               from="/projects/:projectName/settings"
               to={`/projects/:projectName/settings/${PROJECTS_SETTINGS_GENERAL_TAB}`}
             />
+            {/* Adding the next redirect for backwards compatability */}
+            <Redirect
+              from="/projects/:projectName/jobs/monitor/*"
+              to={'/projects/:projectName/jobs/monitor-jobs/*'}
+            />
             <Route
               path="/projects/:projectName/jobs/:pageTab/create-new-job"
               render={routeProps => <CreateJobPage {...routeProps} />}


### PR DESCRIPTION
- **Jobs**: Added a router redirect from `/projects/:project/jobs/monitor/*` to `/projects/:project/jobs/monitor-jobs/*`.

Relates to PR https://github.com/mlrun/ui/pull/804 [v0.8.0-rc3](https://github.com/mlrun/ui/releases/tag/v0.8.0-rc3) where `/monitor/` was changed to `/monitor-jobs`