### PR TITLE
[General] NumberInput: looks weird on Firefox

### DIFF
--- a/src/common/RangeInput/rangeInput.scss
+++ b/src/common/RangeInput/rangeInput.scss
@@ -39,6 +39,7 @@
 
   &__input {
     border: none;
+    -moz-appearance: textfield;
 
     &::-webkit-outer-spin-button,
     &::-webkit-inner-spin-button {


### PR DESCRIPTION
https://trello.com/c/ZhZ52700/1065-general-numberinput-looks-weird-on-firefox

- **General**: The number input fields had an extra pair of arrows in Firefox.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/137882390-681c3318-462e-44c0-a27e-7433f43ca960.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/137882343-289b39a7-12eb-406c-8ff4-cdc14d130a8e.png)
