### PR TITLE
[Project Overview] Filter users selected as owner

### DIFF
--- a/src/api/projects-iguazio-api.js
+++ b/src/api/projects-iguazio-api.js
@@ -39,6 +39,9 @@ export default {
   updateProjectMembers: data => {
     return iguazioHttpClient.post('/async_transactions', data)
   },
-  getScrubbedUsers: () => iguazioHttpClient.get('/scrubbed_users'),
+  getScrubbedUsers: config =>
+    iguazioHttpClient.get('/scrubbed_users', {
+      ...config
+    }),
   getScrubbedUserGroups: () => iguazioHttpClient.get('/scrubbed_user_groups')
 }

--- a/src/api/projects-iguazio-api.js
+++ b/src/api/projects-iguazio-api.js
@@ -39,9 +39,6 @@ export default {
   updateProjectMembers: data => {
     return iguazioHttpClient.post('/async_transactions', data)
   },
-  getScrubbedUsers: config =>
-    iguazioHttpClient.get('/scrubbed_users', {
-      ...config
-    }),
+  getScrubbedUsers: config => iguazioHttpClient.get('/scrubbed_users', config),
   getScrubbedUserGroups: () => iguazioHttpClient.get('/scrubbed_user_groups')
 }

--- a/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
+++ b/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
@@ -72,7 +72,12 @@ const ChangeOwnerPopUp = ({ changeOwnerCallback, closePopUp, projectId }) => {
 
   const generateSuggestionList = useCallback(
     debounce(async resolve => {
-      const response = await projectsIguazioApi.getScrubbedUsers()
+      const response = await projectsIguazioApi.getScrubbedUsers({
+        params: {
+          'filter[assigned_policies]':
+            '[$contains_any]Developer,Project Admin,Project Read Only'
+        }
+      })
       const {
         data: { data: users }
       } = response


### PR DESCRIPTION
https://trello.com/c/FEJd5zlm/1072-project-overview-filter-users-selected-as-owner

- **Project Overview**: In “Change owner” pop-up, in the user auto-complete, filter to only the users who have management policy of Developer, Project Admin, or Project Read Only — as they are the only ones who should be valid as project owners.

Jira ticket ML-1204