### PR TITLE
[Projects] Enter key on creation closes the pop-up

### DIFF
--- a/src/components/ProjectsPage/CreateProjectDialog/CreateProjectDialog.js
+++ b/src/components/ProjectsPage/CreateProjectDialog/CreateProjectDialog.js
@@ -69,6 +69,7 @@ const CreateProjectDialog = ({
             />
           )}
           <Button
+            type="button"
             disabled={projectStore.loading}
             variant={TERTIARY_BUTTON}
             label="Cancel"


### PR DESCRIPTION
https://trello.com/c/d3pverGV/1095-projects-enter-key-on-creation-closes-the-pop-up

- **Projects**: In “Create new project” pop-up, pressing the Enter key clicks the “Cancel” button instead of the “Create” button.

Jira ML-1282