### PR TITLE
[Project Overview] Change owner: filter out project read only

### DIFF
--- a/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
+++ b/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
@@ -78,8 +78,7 @@ const ChangeOwnerPopUp = ({ changeOwnerCallback, closePopUp, projectId }) => {
     debounce(async resolve => {
       const response = await projectsIguazioApi.getScrubbedUsers({
         params: {
-          'filter[assigned_policies]':
-            '[$contains_any]Developer,Project Admin,Project Read Only'
+          'filter[assigned_policies]': '[$contains_any]Developer,Project Admin'
         }
       })
       const {


### PR DESCRIPTION
https://trello.com/c/ItOAosRn/1097-project-overview-change-owner-filter-out-project-read-only

- **Project Overview**: In “Change owner” pop-up, the autocomplete will no longer suggest usernames with management policy `Project Read Only`.

Jira ticket ML-1294