### PR TITLE
[Jobs] On opening Job Monitor details panel filter resets

### DIFF
--- a/src/components/JobsPage/Jobs.js
+++ b/src/components/JobsPage/Jobs.js
@@ -82,6 +82,7 @@ const Jobs = ({
   const [editableItem, setEditableItem] = useState(null)
   const [selectedFunction, setSelectedFunction] = useState({})
   const [workflowsViewMode, setWorkflowsViewMode] = useState('graph')
+  const [dataIsLoaded, setDataIsLoaded] = useState(false)
   const isDemoMode = useDemoMode()
 
   const dispatch = useDispatch()
@@ -343,17 +344,11 @@ const Jobs = ({
             status: error?.response?.status || 400,
             id: Math.random(),
             message: 'Failed to fetch jobs',
-            retry: () => refreshJobs(filtersStore.filters)
+            retry: () => refreshJobs(filters)
           })
         })
     },
-    [
-      fetchJobs,
-      filtersStore.filters,
-      match.params.pageTab,
-      match.params.projectName,
-      setNotification
-    ]
+    [fetchJobs, match.params.pageTab, match.params.projectName, setNotification]
   )
 
   useEffect(() => {
@@ -456,10 +451,7 @@ const Jobs = ({
   ])
 
   useEffect(() => {
-    if (
-      (isEmpty(selectedJob) && !match.params.jobId) ||
-      workflowsViewMode === 'list'
-    ) {
+    if (isEmpty(selectedJob) && !match.params.jobId && !dataIsLoaded) {
       let filters = {}
 
       if (match.params.pageTab === MONITOR_JOBS_TAB) {
@@ -478,19 +470,23 @@ const Jobs = ({
       }
 
       refreshJobs(filters)
-
-      return () => {
-        setJobs([])
-      }
+      setDataIsLoaded(true)
     }
   }, [
+    dataIsLoaded,
     match.params.jobId,
     match.params.pageTab,
     refreshJobs,
     selectedJob,
-    setFilters,
-    workflowsViewMode
+    setFilters
   ])
+
+  useEffect(() => {
+    return () => {
+      setJobs([])
+      setDataIsLoaded(false)
+    }
+  }, [match.params.projectName, match.params.pageTab])
 
   const getWorkflows = useCallback(() => {
     fetchWorkflows(match.params.projectName)

--- a/src/layout/Content/Content.js
+++ b/src/layout/Content/Content.js
@@ -67,6 +67,10 @@ const Content = ({
     [JOBS_PAGE, FEATURE_STORE_PAGE, MODELS_PAGE].includes(pageData.page) &&
       'content_with-menu'
   )
+  const filterMenuClassNames = classnames(
+    'content__action-bar',
+    pageData.hideFilterMenu && 'content__action-bar_hidden'
+  )
 
   const actionsMenu = useMemo(() => {
     return generateContentActionsMenu(pageData.actionsMenu, [
@@ -154,6 +158,13 @@ const Content = ({
     toggleConvertedYaml
   ])
 
+  useEffect(() => {
+    return () => {
+      setExpand(false)
+      setExpandedItems([])
+    }
+  }, [match.params.jobId])
+
   const handleExpandRow = (e, item) => {
     const parentRow = e.target.closest('.parent-row')
     let newArray = []
@@ -215,24 +226,21 @@ const Content = ({
             tabs={pageData.tabs}
           />
         )}
-        {!pageData.hideFilterMenu && (
-          <div className="content__action-bar">
-            <FilterMenu
-              actionButton={pageData.filterMenuActionButton}
-              expand={expand}
-              filters={pageData.filters}
-              handleExpandAll={handleExpandAll}
-              match={match}
-              onChange={filtersChangeCallback ?? refresh}
-              page={pageData.page}
-              withoutExpandButton={
-                Boolean(pageData.handleRequestOnExpand) ||
-                pageData.withoutExpandButton
-              }
-            />
-          </div>
-        )}
-
+        <div className={filterMenuClassNames}>
+          <FilterMenu
+            actionButton={pageData.filterMenuActionButton}
+            expand={expand}
+            filters={pageData.filters}
+            handleExpandAll={handleExpandAll}
+            match={match}
+            onChange={filtersChangeCallback ?? refresh}
+            page={pageData.page}
+            withoutExpandButton={
+              Boolean(pageData.handleRequestOnExpand) ||
+              pageData.withoutExpandButton
+            }
+          />
+        </div>
         <div className="table-container">
           {children ? (
             children

--- a/src/layout/Content/content.scss
+++ b/src/layout/Content/content.scss
@@ -57,5 +57,9 @@
     display: flex;
     align-items: center;
     padding: 4px 24px;
+
+    &_hidden {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
https://trello.com/c/QkEwPSrT/1086-jobs-on-opening-job-monitor-details-panel-filter-resets

- **Jobs**: Filters were reset when navigating into a specific job and back to the job list.

In-release (GA)
Continuing https://github.com/mlrun/ui/pull/830 [v0.8.0-rc5](https://github.com/mlrun/ui/releases/tag/v0.8.0-rc5) ML-1151