### PR TITLE
[Files] Size: Showing "0 Bytes" instead of "N/A" when no data

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -269,7 +269,7 @@ const createFilesRowData = (artifact, project, isSelectedItem) => {
       hidden: isSelectedItem
     },
     size: {
-      value: convertBytes(artifact.size || 0),
+      value: artifact.size ? convertBytes(artifact.size) : 'N/A',
       class: 'artifacts_small',
       hidden: isSelectedItem
     },


### PR DESCRIPTION
https://trello.com/c/5BEvIChr/1099-files-size-showing-0-bytes-instead-of-n-a-when-no-data

- **Files**: The content in cells of the “Size” column was “0 Bytes” instead of “N/A” when there is no data provided regarding the file‘s size.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/138869621-25134e72-1b99-4d8a-9457-697c86879241.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/138869726-108ff6fc-e3f1-4eef-9c0e-4071bbc59546.png)

Jira ticket ML-1302