### PR TITLE
[Project Owner] User autocomplete: limit high add scroll

### DIFF
--- a/src/elements/ChangeOwnerPopUp/changeOwnerPopUp.scss
+++ b/src/elements/ChangeOwnerPopUp/changeOwnerPopUp.scss
@@ -80,6 +80,8 @@
 
   .members-list {
     width: 100%;
+    max-height: 306px;
+    overflow-y: auto;
     background-color: $white;
     border: $primaryBorder;
     border-radius: 0 0 $mainBorderRadius $mainBorderRadius;


### PR DESCRIPTION
https://trello.com/c/z9wXyn5k/1102-project-owner-user-autocomplete-limit-high-add-scroll

- **Project Overview**: In “Change owner” pop-up, added max height and scrollbar to the autocomplete suggestion list so it does not overflow the viewport.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/138913151-fcd15270-c216-4c57-b1ce-cb22b3c980ad.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/138913045-fbda5e48-5d1a-4964-a9b1-4819593f581d.png)

Jira ticket ML-1144