### PR TITLE
[Dialogs] Visual bug when viewport is short

### DIFF
--- a/src/common/PopUpDialog/popUpDialog.scss
+++ b/src/common/PopUpDialog/popUpDialog.scss
@@ -6,6 +6,7 @@
   width: 477px;
   max-height: 90vh;
   padding: 20px;
+  overflow-y: auto;
   background-color: $white;
   border-radius: $mainBorderRadius;
   box-shadow: 0 6px 26px rgba($black, 0.2);


### PR DESCRIPTION
https://trello.com/c/i4Ejl1y9/1100-dialogs-visual-bug-when-viewport-is-short

- **Dialogs**: The content in pop-up dialogs was weirdly bleeding out of it at the bottom on short viewports.
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/139097749-39ca9f81-0500-4bf1-b1f7-808f75cc39c8.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/139097783-622cb5e7-f46a-4b96-bd09-119c8e756c78.png)

Jira ticket ML-1314