### PR TITLE
Impl [Models] Deploy model: Show only router serving functions

### DIFF
--- a/src/elements/DeployModelPopUp/DeployModelPopUp.js
+++ b/src/elements/DeployModelPopUp/DeployModelPopUp.js
@@ -36,7 +36,10 @@ const DeployModelPopUp = ({
     if (functionOptionList.length === 0) {
       fetchFunctions(model.project).then(functions => {
         const functionOptions = chain(functions)
-          .filter(func => func.kind === 'serving')
+          .filter(
+            func =>
+              func.kind === 'serving' && func?.spec?.graph?.kind === 'router'
+          )
           .uniqBy('metadata.name')
           .map(func => ({ label: func.metadata.name, id: func.metadata.name }))
           .value()
@@ -133,7 +136,7 @@ const DeployModelPopUp = ({
     >
       <div className="select-row">
         <Select
-          label="Serving function"
+          label="Serving function (router)"
           floatingLabel
           disabled={functionOptionList.length === 0}
           options={functionOptionList}


### PR DESCRIPTION
- **Models**: In “Deploy model” pop-up, rename “Serving Function” to “Serving Function (router)” and filter its dropdown list to show only functions whose graph‘s root-step is of kind router. (This is because the pop-up was not meant to handle non-router serving functions when it was originally developed.)
  Before:
  ![image](https://user-images.githubusercontent.com/13918850/139146804-d1915866-e183-47d0-ac76-e6120d20c00c.png)
  After:
  ![image](https://user-images.githubusercontent.com/13918850/139146797-5b5444ee-6a9a-422b-bd69-ac0121b1cdb9.png)

Jira ticket ML-1316