### PR TITLE
Impl [Build] Lock version of Node Docker base image to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:12-alpine as build-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
- **Build**: Docker image build started failing due to later versions of Node. Locked Node version 12 as the base image for building the web-app during Docker image build as part of `npm run docker`.