### PR TITLE
Impl [Config] Add `generate-rn` NPM script for release notes

### DIFF
--- a/generate-release-notes.js
+++ b/generate-release-notes.js
@@ -1,0 +1,190 @@
+#! /usr/bin/env node
+
+const { execSync } = require('child_process');
+
+// Parse command-line arguments
+const GA = 'GA';
+const RC = 'RC';
+const releaseTypes = [GA, RC];
+const defaultReleaseType = GA;
+
+const printHelp = () => {
+  console.log(`Usage:
+  release-mlrun.js <current-version> <next-version> [${GA} | ${RC}]
+
+For example:
+  release-mlrun.js 0.8.0-rc13 0.8.0-rc14 RC
+  release-mlrun.js 0.7.0 0.8.0 GA
+  release-mlrun.js 0.7.0 0.8.0
+
+Note:
+  - Do not prepend the version with a "v".
+  - If RC is not provided, the default is GA.
+`);
+};
+const [
+  currentVersion,
+  nextVersion,
+  releaseType = defaultReleaseType
+] = process.argv.slice(2);
+
+if (currentVersion === '--help') {
+  printHelp();
+  process.exit(0);
+}
+if (!currentVersion) {
+  console.error('Error: you must specify the current version\n');
+  printHelp();
+  process.exit(1);
+}
+if (currentVersion.startsWith('v')) {
+  console.error('Error: current version must not start with a "v"\n');
+  printHelp();
+  process.exit(1);
+}
+if (!nextVersion) {
+  console.error('Error: you must specify the next version\n');
+  printHelp();
+  process.exit(1);
+}
+if (nextVersion.startsWith('v')) {
+  console.error('Error: next version must not start with a "v"\n');
+  printHelp();
+  process.exit(1);
+}
+if (!releaseTypes.includes(releaseType)) {
+  console.error(`Error: release type must be one of: ${
+    releaseTypes.join(', ')}\n`);
+  printHelp();
+  process.exit(1);
+}
+
+// Expecting a strict commit message:
+// 1. Must start with one verb, such as: Fix, Impl, Revert, Cleanup
+// 2. Then a component or many components in brackets, for example: [Features]
+// 3. Then the summary
+// 4. Must end with the PR number prepended with "#" and surrounded by "(" and
+//    ")", for example: (#1234)
+// A complete commit message example:
+//   Impl [Features] Add custom message when no data (#904)
+//
+// With `git log` format used in this script, prepending a dash and short commit
+// hash:
+//   - b9de6bf Impl [Features] Add custom message when no data (#904)
+const COMMIT_MESSAGE_PATTERN = /^\- [0-9a-f]+ (?<type>\w+) (?:\[(?<component>[^\]]+)\])+\s*(?<summary>.*)\s*\(#(?<pr>\d+)\)$/;
+
+// Lines in the PR body to skip when copying body to the release notes
+const SKIP_LINES_STARTING_WITH = [
+  'https://trello.com',
+  'in-release',
+  'continuing',
+  'continues',
+  'originated',
+  'originates',
+  'originating',
+  'jira ticket'
+];
+
+try {
+  const features = [];
+  const fixes = [];
+
+  // Fetch the commit list from current version to next version (formatted)
+  const changelog = execSync(
+    `git log --pretty=format:"- %h %s" v${currentVersion}...v${nextVersion}`
+  ).toString().trim();
+  const commits = changelog === '' ? [] : changelog.split(/\r?\n/);
+  commits.forEach(commit => {
+    const {
+      type,
+      component,
+      summary,
+      pr
+    } = (commit.trim().match(COMMIT_MESSAGE_PATTERN) || {}).groups || {};
+    // not using Optional Chaining (?.) and Nullish Coalescing (??) to support
+    // Nove v10 (these operators were introduced in Node v14)
+    // After upgrading to Node v14 and up this line could be replaced with:
+    // } = commit.trim().match(COMMIT_MESSAGE_PATTERN)?.groups ?? {};
+
+    if (!component || !summary) {
+      console.error(`Error: Could not parse commit message:
+  ${commit}
+Skipping this commit.
+`);
+      return true; // continue to the next iteration of `forEach`
+    }
+
+    // By default, use commit message alone to construct the release-notes entry
+    let entry = `- **${component}**: ${summary.trim()}`;
+
+    // If successfully parsed the PR number from the commit message - attempt to
+    // use PR's body instead of commit message
+    if (pr) {
+      // Fetch the body of the PR from GitHub API
+      const prJson = JSON.parse(
+        execSync(
+          `curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/mlrun/ui/pulls/${pr}`
+        ).toString()
+      );
+      const body = prJson.body;
+
+      // For GA skip PRs marked with "In-release (GA)" or "In-release (RC)"
+      // For RC skip only PRs marked with "In-release (RC)"
+      const skip = releaseType === 'GA'
+        ? /^in[- ]?release\s+\((GA|RC)\)/mi.test(body)
+        : /^in[- ]?release\s+\([RC]\)/mi.test(body);
+      if (skip) {
+        console.log(`skipped PR ${pr}`);
+        return true; // continue to the next iteration of `forEach`
+      }
+
+      // If PR body was retrieved successfully, use it for the realease-notes
+      // entry instead of the default commit message used above (skipping some
+      // irrelevant lines from it)
+      entry = body
+        .replace(/\r\n/, '\n')
+        .split('\n')
+        .filter(line => SKIP_LINES_STARTING_WITH.every(
+          prefix => !line.toLowerCase().startsWith(prefix)
+        ))
+        .join('\n')
+        .trim();
+    }
+
+    // If commit message has the verb "Fix" — add to "Bug Fixes" section of the
+    // release notes.
+    // Otherwise add to "Features / Enhancements" section.
+    if (type === 'Fix') {
+      fixes.push(entry);
+    } else {
+      features.push(entry);
+    }
+  });
+
+  // Constrcut release notes
+  const none = 'None.';
+  const releaseNotes = `### <a name="features-and-enhancements">Features / Enhancements</a>
+${features.length > 0 ? features.join('\n') : none}
+
+### <a name="bug-fixes">Bug Fixes</a>
+${fixes.length > 0 ? fixes.join('\n') : none}
+
+### Full changelog
+${changelog || none}
+
+### Main release notes
+https://github.com/mlrun/mlrun/releases/tag/v${nextVersion}
+`;
+  // Print release notes to terminal
+  console.log(releaseNotes);
+
+  // Open edit-release page on GitHub
+  execSync(`open https://github.com/mlrun/ui/releases/edit/v${nextVersion}`);
+
+  // Copy release notes to clipboard for convenience (to paste it on GitHub)
+  // Note: `pbcopy` is for Mac OS X and won't work in Windows or Linux
+  execSync('pbcopy', { input: releaseNotes });
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "node scripts/test.js",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "docker": "docker build -t ${MLRUN_DOCKER_REGISTRY}${MLRUN_DOCKER_REPO:-mlrun}/mlrun-ui:${MLRUN_DOCKER_TAG:-latest} --build-arg COMMIT_HASH=\"`git rev-parse --short HEAD`\" --build-arg DATE=\"`date -u`\" -f Dockerfile .",
+    "generate-rn": "./generate-release-notes.js ${MLRUN_OLD_VERSION} ${MLRUN_VERSION} ${MLRUN_RELEASE_TYPE}",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "mock-server": "node scripts/mockServer.js",


### PR DESCRIPTION
- **Config**: Added a new NPM script named `generate-rn` which runs the new `./generate-release-notes.js` Node script for generating release notes between two given versions and the release type (RC or GA, to know which in-release PRs to skip).
  Usage examples:
  ```bash
  MLRUN_OLD_VERSION=0.8.0-rc13 MLRUN_VERSION=0.8.0-rc14 MLRUN_RELEASE_TYPE=RC npm run generate-rn
  ```
  ```bash
  MLRUN_OLD_VERSION=0.7.0 MLRUN_VERSION=0.8.0 MLRUN_RELEASE_TYPE=GA npm run generate-rn
  ```
  ```bash
  MLRUN_OLD_VERSION=0.7.0 MLRUN_VERSION=0.8.0 npm run generate-rn
  ```
  (defaults to GA)