### PR TITLE
[Jobs][Monitor Workflows] workload name is cut although there is a lot of space

### DIFF
--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -192,6 +192,7 @@
 
         span {
           display: block;
+          width: 100%;
         }
       }
 

--- a/src/elements/TableLinkCell/tableLinkCell.scss
+++ b/src/elements/TableLinkCell/tableLinkCell.scss
@@ -9,9 +9,6 @@
 
     .item {
       &-name {
-        min-width: 100%;
-        max-width: 125px;
-
         &.function-name {
           max-width: 120px;
         }


### PR DESCRIPTION
https://trello.com/c/M6YnA8dx/1204-jobsmonitor-workflows-workload-name-is-cut-although-there-is-a-lot-of-space