### PR TITLE
[Projects] [UI] The 'N/A' presents for all projects counters even though the project-summaries API finished successfully

### DIFF
--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -737,7 +737,8 @@ export default (state = initialState, { type, payload }) => {
         projectsSummary: {
           ...state.projectsSummary,
           data: payload,
-          loading: false
+          loading: false,
+          error: null
         }
       }
     case FETCH_PROJECT_SUMMARY_BEGIN:


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-1662
- **Projects**: The 'N/A' presents for all projects counters even though the project-summaries API finished successfully.
                          