### PR TITLE
Fix [Function] The 'Build new image' radio button shifted to the right

### DIFF
--- a/src/elements/FunctionsPanelCode/functionsPanelCode.scss
+++ b/src/elements/FunctionsPanelCode/functionsPanelCode.scss
@@ -49,6 +49,15 @@
         max-width: 100%;
       }
     }
+
+    .radio-buttons__block {
+      display: block;
+      width: 200px;
+
+      div:not(:last-child) {
+        margin: 10px 0 43px 0;
+      }
+    }
   }
 
   .commands {
@@ -75,14 +84,5 @@
 
   &__force-build {
     margin-top: 19px;
-  }
-}
-
-.radio-buttons__block {
-  display: block;
-  width: 200px;
-
-  div:not(:last-child) {
-    margin: 10px 0 43px 0;
   }
 }


### PR DESCRIPTION
- **Function Edit **: The "Build new image" radio button field is shifted to the right
  https://jira.iguazeng.com/browse/ML-909
  ![Screen Shot 2022-01-31 at 10 07 55](https://user-images.githubusercontent.com/63646693/151766101-6238da4c-b639-4e7a-94d0-c2d6785060a9.png)
