### PR TITLE
Impl [Real-time Pipelines] Avoid presentation of duplicated names

### DIFF
--- a/src/common/ReactFlow/mlReactFlow.scss
+++ b/src/common/ReactFlow/mlReactFlow.scss
@@ -15,14 +15,14 @@
 }
 
 @mixin primaryNode {
-  background-color: $white;
   color: $malibu;
+  background-color: $white;
   border-color: $malibu;
 }
 
 @mixin secondaryNode {
-  background-color: $white;
   color: $orchid;
+  background-color: $white;
   border-color: $orchid;
 }
 
@@ -38,14 +38,18 @@
 .react-flow__renderer {
   z-index: 5;
 
+  &:active {
+    cursor: grab;
+  }
+
   .react-flow__node {
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 5px 10px;
     font-size: 14px;
-    border-width: 2px;
     border-style: solid;
+    border-width: 2px;
     border-radius: 8px;
     cursor: unset;
 
@@ -60,8 +64,8 @@
     }
 
     .react-flow__node-sub-label {
-      opacity: 0.8;
       font-size: 0.9em;
+      opacity: 0.8;
     }
 
     &.input-node {
@@ -115,11 +119,11 @@
     }
 
     .react-flow__handle {
-      pointer-events: auto;
       width: 12px;
       height: 12px;
       background: $white;
       border: 2px solid $bombay;
+      pointer-events: auto;
 
       &-top {
         top: -6px;

--- a/src/components/Models/Models.js
+++ b/src/components/Models/Models.js
@@ -249,9 +249,8 @@ const Models = ({
   useEffect(() => {
     if (match.params.pageTab === MODEL_ENDPOINTS_TAB) {
       setFilters({ groupBy: GROUP_BY_NONE, sortBy: 'function' })
-    } else if (match.params.pageTab === REAL_TIME_PIPELINES_TAB) {
-      setFilters({ groupBy: GROUP_BY_NONE })
     } else if (
+      match.params.pageTab === REAL_TIME_PIPELINES_TAB ||
       filtersStore.tag === TAG_FILTER_ALL_ITEMS ||
       filtersStore.tag === TAG_FILTER_LATEST
     ) {

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -253,6 +253,10 @@ const realTimePipelinesTableHeaders = () => [
   {
     header: 'Type',
     class: 'functions_big'
+  },
+  {
+    header: '',
+    class: 'action_cell'
   }
 ]
 export const tabs = [

--- a/src/components/Pipeline/Pipeline.js
+++ b/src/components/Pipeline/Pipeline.js
@@ -94,8 +94,13 @@ const Pipeline = ({ content, match }) => {
           data: {
             subType: PRIMARY_NODE,
             label: graph.class_args?.name ?? '',
-            subLabel: '« router »'
+            subLabel: '« router »',
+            isSelectable: true,
+            customData: graph
           },
+          className: classnames(
+            selectedStep.id === mainRouterStepId && 'selected'
+          ),
           position: { x: 0, y: 0 }
         })
       }

--- a/src/components/Pipeline/PipelineView.js
+++ b/src/components/Pipeline/PipelineView.js
@@ -21,7 +21,7 @@ const PipelineView = ({
   setSelectedStep,
   stepIsSelected
 }) => {
-  const linkBackTitle = pipeline?.nuclio_name || pipeline?.name
+  const linkBackTitle = pipeline?.name
   const graphViewClassNames = classnames('graph-view')
 
   return (
@@ -73,7 +73,13 @@ const PipelineView = ({
                 ) : (
                   <>
                     <div className="graph-pane__row-label">{rowData.label}</div>
-                    <div className="graph-pane__row-value">{rowData.value}</div>
+                    <div className="graph-pane__row-value">
+                      <Tooltip
+                        template={<TextTooltipTemplate text={rowData.value} />}
+                      >
+                        {rowData.value}
+                      </Tooltip>
+                    </div>
                   </>
                 )}
               </div>

--- a/src/components/Pipeline/pipeline.scss
+++ b/src/components/Pipeline/pipeline.scss
@@ -47,7 +47,7 @@
         }
 
         &-value {
-          width: 100%;
+          overflow: hidden;
         }
       }
     }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -11,7 +11,12 @@ import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { generateTableContent } from '../../utils/generateTableContent'
 import { generateGroupLatestItem } from '../../utils/generateGroupLatestItem'
 import { ACTIONS_MENU } from '../../types'
-import { GROUP_BY_NONE, GROUP_BY_WORKFLOW, JOBS_PAGE } from '../../constants'
+import {
+  GROUP_BY_NAME,
+  GROUP_BY_NONE,
+  GROUP_BY_WORKFLOW,
+  JOBS_PAGE
+} from '../../constants'
 import tableActions from '../../actions/table'
 
 import './table.scss'
@@ -89,7 +94,7 @@ const Table = ({
       !isEveryObjectValueEmpty(selectedItem)
     )
 
-    if (filtersStore.groupBy === 'name') {
+    if (filtersStore.groupBy === GROUP_BY_NAME) {
       setTableContent({
         content: generatedTableContent,
         groupLatestItem: generateGroupLatestItem(

--- a/src/components/Table/TableView.js
+++ b/src/components/Table/TableView.js
@@ -78,7 +78,7 @@ const TableView = ({
                 case ARTIFACTS_PAGE:
                 case FILES_PAGE:
                 case MODELS_PAGE:
-                  return match.params.pageTab !== REAL_TIME_PIPELINES_TAB ? (
+                  return (
                     <ArtifactsTableRow
                       actionsMenu={actionsMenu}
                       content={content}
@@ -88,16 +88,6 @@ const TableView = ({
                       rowItem={rowItem}
                       pageData={pageData}
                       selectedItem={selectedItem}
-                    />
-                  ) : (
-                    <FunctionsTableRow
-                      actionsMenu={actionsMenu}
-                      key={i}
-                      content={content}
-                      match={match}
-                      rowItem={rowItem}
-                      selectedItem={selectedItem}
-                      handleSelectItem={handleSelectItem}
                     />
                   )
                 case FEATURE_STORE_PAGE:
@@ -158,7 +148,19 @@ const TableView = ({
                 case ARTIFACTS_PAGE:
                 case FILES_PAGE:
                 case MODELS_PAGE:
-                  return (
+                  return match.params.pageTab === REAL_TIME_PIPELINES_TAB ? (
+                    <FunctionsTableRow
+                      actionsMenu={actionsMenu}
+                      key={i}
+                      content={content}
+                      handleExpandRow={handleExpandRow}
+                      handleSelectItem={handleSelectItem}
+                      match={match}
+                      rowItem={groupLatestItem[i]}
+                      selectedItem={selectedItem}
+                      tableContent={group}
+                    />
+                  ) : (
                     <ArtifactsTableRow
                       actionsMenu={actionsMenu}
                       content={content}

--- a/src/elements/FunctionsTableRow/FunctionsTableRow.js
+++ b/src/elements/FunctionsTableRow/FunctionsTableRow.js
@@ -83,23 +83,27 @@ const FunctionsTableRow = ({
                 >
                   {Object.values(func).map((value, i) => {
                     return (
-                      <TableCell
-                        data={i === 0 ? func.updated : value}
-                        item={subRowCurrentItem}
-                        link={
-                          i === 0 &&
-                          `/projects/${match.params.projectName}/functions/${
-                            subRowCurrentItem?.hash
-                          }${
-                            match.params.tab
-                              ? `/${match.params.tab}`
-                              : `/${detailsMenu[0].id}`
-                          }`
-                        }
-                        key={value.id}
-                        selectItem={handleSelectItem}
-                        selectedItem={selectedItem}
-                      />
+                      !value.hidden && (
+                        <TableCell
+                          data={i === 0 && func.updated ? func.updated : value}
+                          item={subRowCurrentItem}
+                          link={
+                            value.getLink
+                              ? value.getLink(currentItem?.hash)
+                              : i === 0 &&
+                                `/projects/${
+                                  match.params.projectName
+                                }/functions/${subRowCurrentItem?.hash}${
+                                  match.params.tab
+                                    ? `/${match.params.tab}`
+                                    : `/${detailsMenu[0].id}`
+                                }`
+                          }
+                          key={value.id}
+                          selectItem={handleSelectItem}
+                          selectedItem={selectedItem}
+                        />
+                      )
                     )
                   })}
                   <div className="table-body__cell action_cell">

--- a/src/elements/TableLinkCell/TableLinkCell.js
+++ b/src/elements/TableLinkCell/TableLinkCell.js
@@ -6,7 +6,11 @@ import classnames from 'classnames'
 import Tooltip from '../../common/Tooltip/Tooltip'
 import TextTooltipTemplate from '../TooltipTemplate/TextTooltipTemplate'
 
-import { FEATURE_SETS_TAB, FEATURE_VECTORS_TAB } from '../../constants'
+import {
+  FEATURE_SETS_TAB,
+  FEATURE_VECTORS_TAB,
+  REAL_TIME_PIPELINES_TAB
+} from '../../constants'
 import { formatDatetime, truncateUid } from '../../utils'
 
 import { ReactComponent as Arrow } from '../../images/arrow.svg'
@@ -22,10 +26,7 @@ const TableLinkCell = ({
   expandLink,
   handleExpandRow
 }) => {
-  const tableCellClassNames = classnames(
-    'table-body__cell',
-    data.type === 'date' ? 'jobs_medium' : data.class
-  )
+  const tableCellClassNames = classnames('table-body__cell', data.class)
   const itemNameCLassNames = classnames(
     'link',
     'item-name',
@@ -61,7 +62,9 @@ const TableLinkCell = ({
             </Tooltip>
           </span>
           {link.match(
-            new RegExp(`functions|${FEATURE_SETS_TAB}|${FEATURE_VECTORS_TAB}`)
+            new RegExp(
+              `functions|${FEATURE_SETS_TAB}|${FEATURE_VECTORS_TAB}|${REAL_TIME_PIPELINES_TAB}`
+            )
           ) &&
             data.value !== item.tag && (
               <Tooltip

--- a/src/utils/createFunctionsContent.js
+++ b/src/utils/createFunctionsContent.js
@@ -11,7 +11,7 @@ const createFunctionsContent = (functions, isSelectedItem, params) =>
       ? {
           name: {
             id: `name.${identifierUnique}`,
-            value: func.nuclio_name || func.name,
+            value: func.name,
             class: 'functions_medium',
             identifier: getFunctionIdentifier(func),
             identifierUnique: getFunctionIdentifier(func, true),
@@ -26,6 +26,13 @@ const createFunctionsContent = (functions, isSelectedItem, params) =>
             value: func.graph?.kind === 'router' ? 'Router' : 'Flow',
             class: 'functions_big',
             type: 'type'
+          },
+          updated: {
+            id: `updated.${identifierUnique}`,
+            value: formatDatetime(new Date(func.updated), 'N/A'),
+            class: 'functions_medium',
+            type: 'date',
+            hidden: true
           }
         }
       : {


### PR DESCRIPTION
Part of: #865
 **Real-time Pipelines]**: Avoid presentation of duplicated names
  https://jira.iguazeng.com/browse/ML-1710
- Duplicated names fix: -add a collapsible row with the same logic as in "function" screen. Filter out non tags versions and show on expand row
![image](https://user-images.githubusercontent.com/25711177/152328214-01c23867-a720-4fe2-91c0-24bf87cc614a.png)

- Make the "Router" clickable, once clicked open the right panel with some information (class name, type).
![image](https://user-images.githubusercontent.com/25711177/152328243-ef22b917-8afd-4e3b-a855-27e755e67b9c.png)
