### PR TITLE
Fix [Feature Sets] Missing validation and tooltips in the Tag tips

### DIFF
--- a/src/common/OptionsMenu/ValidationTemplate/ValidationTemplate.module.scss
+++ b/src/common/OptionsMenu/ValidationTemplate/ValidationTemplate.module.scss
@@ -2,7 +2,7 @@
 
 .validation_option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin: 0.6rem 0;
   padding: 0 1rem;
   font-size: 0.875rem;

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
@@ -7,6 +7,8 @@ import ChipCell from '../../../common/ChipCell/ChipCell'
 import TextArea from '../../../common/TextArea/TextArea'
 import RoundedIcon from '../../../common/RoundedIcon/RoundedIcon'
 
+import { getValidationRules } from '../../../utils/validationService'
+
 import { ReactComponent as CloseIcon } from '../../../images/close.svg'
 
 import './featureSetsPanelTitle.scss'
@@ -24,16 +26,6 @@ const FeatureSetsPanelTitleView = ({
   setValidation,
   validation
 }) => {
-  const titleValidationTip = (
-    <>
-      <span>&bull; Valid characters: A-Z, a-z, 0-9, -, _, .</span>
-      <br />
-      <span>&bull; Must begin and end with: A-Z, a-z, 0-9</span>
-      <br />
-      <span>&bull; Length - max: 56</span>
-    </>
-  )
-
   return (
     <div className="panel-title feature-sets-panel__title">
       <div className="panel-title__container">
@@ -44,17 +36,15 @@ const FeatureSetsPanelTitleView = ({
             invalid={!validation.isNameValid}
             invalidText="This field is invalid"
             label="Feature Set Name"
-            maxLength={56}
             onChange={name => setData(state => ({ ...state, name }))}
             onBlur={handleNameOnBlur}
-            pattern="^(?=[\S\s]{1,56}$)([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$"
             required
             requiredText="This field is required"
             setInvalid={value =>
               setValidation(state => ({ ...state, isNameValid: value }))
             }
-            tip={titleValidationTip}
             type="text"
+            validationRules={getValidationRules('feature.vector.name')}
             value={data.name}
             wrapperClassName="name"
           />
@@ -82,6 +72,7 @@ const FeatureSetsPanelTitleView = ({
             }
             type="text"
             value={data.version}
+            validationRules={getValidationRules('feature.set.tag')}
             wrapperClassName="version"
           />
         </div>

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/featureSetsPanelTitle.scss
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/featureSetsPanelTitle.scss
@@ -40,7 +40,7 @@
 
     &.version {
       display: flex;
-      flex: 0.2;
+      flex: 0.5;
     }
   }
 }

--- a/src/utils/validationService.js
+++ b/src/utils/validationService.js
@@ -245,6 +245,12 @@ const validationRules = {
         generateRule.length({ max: 56 }),
         generateRule.required()
       ]
+    },
+    set: {
+      tag: [
+        generateRule.validCharacters('a-z A-Z 0-9 - _ .'),
+        generateRule.beginEndWith('a-z A-Z 0-9')
+      ]
     }
   },
   job: {


### PR DESCRIPTION
- **Feature Sets**: Missing validation and tooltips in the Tag tips
  Jira: [ML-1497](https://jira.iguazeng.com/browse/ML-1497)

  Fix:
  - -_. are the only special characters allowed (ex: rc-5, 1.0, 1_1)
  - Must begin and end with a-z, A-Z, 0-9 (no valid: -rc, rc.)
  <img width="260" alt="Screen Shot 2022-02-07 at 15 46 55" src="https://user-images.githubusercontent.com/63646693/152802175-4cff364e-a8ca-46a7-aee0-1999139c7d9c.png">
 