### PR TITLE
Fix [Project] Wrong redirection on clicking the `job` link

### DIFF
--- a/src/elements/ProjectJobs/projectJobs.utils.js
+++ b/src/elements/ProjectJobs/projectJobs.utils.js
@@ -63,7 +63,9 @@ export const getJobsTableData = (jobs, match) => {
       return {
         name: {
           value: job[0].metadata.name,
-          link: `/projects/${match.params.projectName}/jobs/${MONITOR_JOBS_TAB}/${job[0].metadata.uid}/overview`,
+          link:
+            `/projects/${match.params.projectName}/jobs/${MONITOR_JOBS_TAB}/${job[0].metadata.name}/` +
+            `${job[0].metadata.uid}/overview`,
           className: 'table-cell_big'
         },
         type: {


### PR DESCRIPTION
- **Project**:  Wrong redirection on clicking the `job` link
  Pressing on job name link from a Project overview screen navigates to main projects page

  https://jira.iguazeng.com/browse/ML-1735