### PR TITLE
Fix [Feature Vector] User with 'viewer' role has access to delete and update alias of features from FV

### DIFF
--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -18,7 +18,8 @@ import {
   NAME_FILTER,
   SECONDARY_BUTTON,
   TAG_FILTER,
-  TREE_FILTER
+  TREE_FILTER,
+  STATUS_CODE_FORBIDDEN
 } from '../../constants'
 import { generateArtifacts } from '../../utils/generateArtifacts'
 import { filterArtifacts } from '../../utils/filterArtifacts'
@@ -585,11 +586,14 @@ export const handleApplyDetailsChanges = (
         return response
       })
     })
-    .catch(() => {
+    .catch(error => {
       setNotification({
-        status: 400,
+        status: error.response?.status || 400,
         id: Math.random(),
-        message: 'Failed to update',
+        message:
+          error.response?.status === STATUS_CODE_FORBIDDEN
+            ? 'Permission denied.'
+            : 'Failed to update.',
         retry: handleApplyDetailsChanges
       })
     })


### PR DESCRIPTION
- **Feature Vector**: User with 'viewer' role has access to delete and update alias of features from FV
  - pop up a message: "Permission denied"
  https://jira.iguazeng.com/browse/ML-1505

  ![Screenshot from 2022-02-10 18-54-45](https://user-images.githubusercontent.com/58301139/153456892-72c919e8-0861-43d1-b3b3-0608de3cd55c.png)
