### PR TITLE
Fix [Jobs] Add fix for jobs routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,6 +111,7 @@ const App = () => {
             <Route
               path={[
                 '/projects/:projectName/jobs/:pageTab/:jobName/:jobId/:tab',
+                '/projects/:projectName/jobs/:pageTab/:jobId/:tab',
                 '/projects/:projectName/jobs/:pageTab/:jobName',
                 '/projects/:projectName/jobs/:pageTab'
               ]}

--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -82,7 +82,10 @@ const DetailsView = React.forwardRef(
                 to={location => {
                   const urlArray = location.pathname.split('/')
 
-                  return urlArray.slice(0, -2).join('/')
+                  return (
+                    getCloseDetailsLink(selectedItem.name) ??
+                    urlArray.slice(0, -2).join('/')
+                  )
                 }}
                 onClick={() => {
                   if (detailsStore.changes.counter > 0) {
@@ -214,12 +217,13 @@ const DetailsView = React.forwardRef(
           <Link
             data-testid="details-close-btn"
             to={
-              getCloseDetailsLink ??
-              `/projects/${
-                match.params.projectName
-              }/${pageData.page.toLowerCase()}${
-                match.params.pageTab ? `/${match.params.pageTab}` : ''
-              }`
+              getCloseDetailsLink
+                ? getCloseDetailsLink(selectedItem.name)
+                : `/projects/${
+                    match.params.projectName
+                  }/${pageData.page.toLowerCase()}${
+                    match.params.pageTab ? `/${match.params.pageTab}` : ''
+                  }`
             }
             onClick={() => {
               if (detailsStore.changes.counter > 0) {

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -644,7 +644,9 @@ const Jobs = ({
       editableItem={editableItem}
       fetchCurrentJob={fetchCurrentJob}
       functionsStore={functionsStore}
-      getCloseDetailsLink={() => getCloseDetailsLink(match, 'jobName')}
+      getCloseDetailsLink={() =>
+        getCloseDetailsLink(match, match.params.jobName ? 'jobName' : 'pageTab')
+      }
       jobRuns={jobRuns}
       jobs={jobs}
       handleActionsMenuClick={handleActionsMenuClick}

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -636,6 +636,16 @@ const Jobs = ({
       })
   }
 
+  const generateCloseDetailsLink = name => {
+    return match.params.jobName
+      ? getCloseDetailsLink(match, 'jobName')
+      : match.url
+          .split('/')
+          .splice(0, match.path.split('/').indexOf(':pageTab') + 1)
+          .concat(name)
+          .join('/')
+  }
+
   return (
     <JobsView
       actionsMenu={actionsMenu}
@@ -644,9 +654,7 @@ const Jobs = ({
       editableItem={editableItem}
       fetchCurrentJob={fetchCurrentJob}
       functionsStore={functionsStore}
-      getCloseDetailsLink={() =>
-        getCloseDetailsLink(match, match.params.jobName ? 'jobName' : 'pageTab')
-      }
+      getCloseDetailsLink={generateCloseDetailsLink}
       jobRuns={jobRuns}
       jobs={jobs}
       handleActionsMenuClick={handleActionsMenuClick}
@@ -665,14 +673,6 @@ const Jobs = ({
       selectedJob={selectedJob}
       setEditableItem={setEditableItem}
       setWorkflowsViewMode={setWorkflowsViewMode}
-      tableTop={
-        match.params.jobName
-          ? {
-              link: `/projects/${match.params.projectName}/jobs/${match.params.pageTab}`,
-              text: match.params.jobName
-            }
-          : null
-      }
       toggleConvertedYaml={toggleConvertedYaml}
       workflow={workflow}
       workflowJobsIds={workflowJobsIds}

--- a/src/components/Jobs/JobsView.js
+++ b/src/components/Jobs/JobsView.js
@@ -39,7 +39,6 @@ const JobsView = ({
   selectedJob,
   setEditableItem,
   setWorkflowsViewMode,
-  tableTop,
   toggleConvertedYaml,
   workflow,
   workflowJobsIds,
@@ -60,7 +59,14 @@ const JobsView = ({
         pageData={pageData}
         refresh={refreshJobs}
         selectedItem={selectedJob}
-        tableTop={tableTop}
+        tableTop={
+          match.params.jobName
+            ? {
+                link: `/projects/${match.params.projectName}/jobs/${match.params.pageTab}`,
+                text: match.params.jobName
+              }
+            : null
+        }
       >
         {match.params.workflowId ? (
           <Workflow
@@ -151,8 +157,7 @@ const JobsView = ({
 
 JobsView.defaultProps = {
   confirmData: null,
-  editableItem: null,
-  tableTop: null
+  editableItem: null
 }
 
 JobsView.propTypes = {
@@ -181,10 +186,6 @@ JobsView.propTypes = {
   selectedJob: PropTypes.object.isRequired,
   setEditableItem: PropTypes.func.isRequired,
   setWorkflowsViewMode: PropTypes.func.isRequired,
-  tableTop: PropTypes.shape({
-    link: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired
-  }),
   toggleConvertedYaml: PropTypes.func.isRequired,
   workflow: PropTypes.object.isRequired,
   workflowJobsIds: PropTypes.arrayOf(PropTypes.string).isRequired,


### PR DESCRIPTION
- **Jobs**: Add backward compatibility for old url path to job runs details.
  Related to Jira: [ML-1735](https://jira.iguazeng.com/browse/ML-1735) and [ML-1569](https://jira.iguazeng.com/browse/ML-1569)
  Related to: [Fix [Project] Wrong redirection on clicking the job link #1079](https://github.com/mlrun/ui/pull/1079) and [Impl [Jobs] Jobs screen - runs display #1071](https://github.com/mlrun/ui/pull/1071)