### PR TITLE
Fix [Jobs] MLRun-kit when re-running a job the UI automatically sets the default_artifact_path to v3io

### DIFF
--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -3,7 +3,11 @@ import { panelActions } from './panelReducer'
 import { parseDefaultContent } from '../../utils/parseDefaultContent'
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { getVolumeType } from '../../utils/panelResources.util'
-import { PANEL_DEFAULT_ACCESS_KEY, PANEL_EDIT_MODE } from '../../constants'
+import {
+  JOB_DEFAULT_OUTPUT_PATH,
+  PANEL_DEFAULT_ACCESS_KEY,
+  PANEL_EDIT_MODE
+} from '../../constants'
 import { generateEnvVariable } from '../../utils/generateEnvironmentVariable'
 import { parseEnvVariables } from '../../utils/parseEnvironmentVariables'
 
@@ -442,6 +446,10 @@ export const generateTableDataFromDefaultData = (
   panelDispatch({
     type: panelActions.SET_ACCESS_KEY,
     payload: defaultData.credentials?.access_key || PANEL_DEFAULT_ACCESS_KEY
+  })
+  panelDispatch({
+    type: panelActions.SET_OUTPUT_PATH,
+    payload: defaultData.task.spec.output_path ?? JOB_DEFAULT_OUTPUT_PATH
   })
   setNewJob({
     access_key: defaultData.credentials?.access_key || PANEL_DEFAULT_ACCESS_KEY,

--- a/src/components/JobsPanel/panelReducer.js
+++ b/src/components/JobsPanel/panelReducer.js
@@ -1,3 +1,5 @@
+import { JOB_DEFAULT_OUTPUT_PATH } from '../../constants'
+
 export const initialState = {
   access_key: '',
   cpuUnit: 'cpu',
@@ -16,7 +18,7 @@ export const initialState = {
     'nvidia.com/gpu': ''
   },
   memoryUnit: 'Bytes',
-  outputPath: 'v3io:///projects/{{run.project}}/artifacts/{{run.uid}}',
+  outputPath: JOB_DEFAULT_OUTPUT_PATH,
   previousPanelData: {
     access_key: '',
     tableData: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,6 +82,8 @@ export const FETCH_SCHEDULED_JOB_ACCESS_KEY_BEGIN =
   'FETCH_SCHEDULED_JOB_ACCESS_KEY_BEGIN'
 export const FETCH_SCHEDULED_JOB_ACCESS_KEY_END =
   'FETCH_SCHEDULED_JOB_ACCESS_KEY_END'
+export const JOB_DEFAULT_OUTPUT_PATH =
+  'v3io:///projects/{{run.project}}/artifacts/{{run.uid}}'
 export const REMOVE_JOB = 'REMOVE_JOB'
 export const REMOVE_JOB_ERROR = 'REMOVE_JOB_ERROR'
 export const REMOVE_JOB_PODS = 'REMOVE_JOB_PODS'


### PR DESCRIPTION
- **Jobs**: MLRun-kit when re-running a job the UI automatically sets the default_artifact_path to v3io
  https://jira.iguazeng.com/browse/ML-1713