### PR TITLE
Fix [Models] Real-time pipeline view the rectangle are too small

### DIFF
--- a/src/common/ReactFlow/mlReactFlow.scss
+++ b/src/common/ReactFlow/mlReactFlow.scss
@@ -61,6 +61,7 @@
       position: relative;
       width: 100%;
       text-align: center;
+      font-size: 1.5rem;
     }
 
     .react-flow__node-sub-label {

--- a/src/common/ReactFlow/mlReactFlow.util.js
+++ b/src/common/ReactFlow/mlReactFlow.util.js
@@ -3,8 +3,8 @@ import dagre from 'dagre'
 import { isEdge, isNode, Position } from 'react-flow-renderer'
 
 export const getLayoutedElements = (elements, direction = 'TB') => {
-  const elWidth = 130
-  const elHeight = 50
+  const elWidth = 300
+  const elHeight = 80
   const dagreGraph = new dagre.graphlib.Graph()
   const isHorizontal = direction === 'LR'
 

--- a/src/layout/Content/content.scss
+++ b/src/layout/Content/content.scss
@@ -47,7 +47,6 @@
     display: flex;
     flex: 1 1;
     flex-direction: column;
-    min-width: 900px;
   }
 
   &_with-menu {


### PR DESCRIPTION
- **Models**: Real-time pipeline view the rectangle are too small
  Jira: [ML-1779](https://jira.iguazeng.com/browse/ML-1779)
 
  Before:  
  ![image-2022-02-17-14-35-06-684](https://user-images.githubusercontent.com/63646693/154954410-a6504894-4f90-48fa-8c44-eaaf78f7ca63.png)

  After:
  ![Screen Shot 2022-02-21 at 15 16 13](https://user-images.githubusercontent.com/63646693/154962659-82926d4b-4d72-4ebf-a2c9-a630999a0266.png)

 