### PR TITLE
Fix [Settings] display members count

### DIFF
--- a/src/common/KeyValueTable/keyValueTable.scss
+++ b/src/common/KeyValueTable/keyValueTable.scss
@@ -4,7 +4,7 @@ $actionsBlockWidth: 72px;
 .key-value-table {
   overflow: hidden;
   overflow-y: auto;
-  max-height: 305px;
+  max-height: 280px;
   background-color: $white;
 
   &__btn {
@@ -14,7 +14,7 @@ $actionsBlockWidth: 72px;
   .table-row {
     display: flex;
     align-items: center;
-    min-height: 61px;
+    min-height: 56px;
     border-bottom: $primaryBorder;
 
     &:not(.no-hover):hover {
@@ -45,7 +45,7 @@ $actionsBlockWidth: 72px;
   .table-cell {
     display: flex;
     align-items: center;
-    padding: 10px 5px 10px 10px;
+    padding: 8px 5px 8px 10px;
     color: $primary;
   }
 
@@ -97,7 +97,6 @@ $actionsBlockWidth: 72px;
 
     .input {
       width: 100%;
-      border-radius: unset;
 
       &_edit {
         border: $primaryBorder;

--- a/src/components/ProjectSettings/projectSettings.scss
+++ b/src/components/ProjectSettings/projectSettings.scss
@@ -50,12 +50,10 @@
       margin: 0 0 15px;
       font-weight: 500;
       font-size: 20px;
-      line-height: 16px;
     }
     &-subtitle {
       margin: 0 0 15px;
       font-weight: 400;
-      line-height: 16px;
     }
   }
 }

--- a/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
+++ b/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
@@ -221,6 +221,7 @@ const ChangeOwnerPopUp = ({
         <div className="footer-actions">
           <div className="apply-discard-buttons">
             <Button
+              disabled={!newOwnerId}
               className="pop-up-dialog__btn_cancel"
               label="Discard"
               onClick={handleOnClose}

--- a/src/elements/ProjectSettingsMembers/ProjectSettingsMembers.js
+++ b/src/elements/ProjectSettingsMembers/ProjectSettingsMembers.js
@@ -19,26 +19,26 @@ const ProjectSettingsMembers = ({
   return (
     <div className="settings__card">
       <div className="settings__card-content">
-        {projectMembershipIsEnabled && (
-          <div className="settings__card-content-col">
-            <div className="settings__members-summary">
-              <span className="settings__members-summary_icon">
-                <Users />
-              </span>
-              <span className="settings__members-summary_amount">
-                {totalMembersInProject}
-              </span>
-              member{totalMembersInProject !== 1 && 's'} has access to this
-              project
-            </div>
+        <div className="settings__card-content-col">
+          <div className="settings__members-summary">
+            <span className="settings__members-summary_icon">
+              <Users />
+            </span>
+            <span className="settings__members-summary_amount">
+              {totalMembersInProject}
+            </span>
+            member{totalMembersInProject !== 1 && 's'} has access to this
+            project
+          </div>
+          {projectMembershipIsEnabled && (
             <MembersPopUp
               changeMembersCallback={changeMembersCallback}
               membersState={membersState}
               membersDispatch={membersDispatch}
               setNotification={setNotification}
             />
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
@@ -21,7 +21,7 @@ const ProjectSettingsSecretsView = ({
           <Loader />
         ) : error ? (
           <div>
-            <h1>{error.message || error}</h1>
+            <h1>You are not allowed to read resources</h1>
           </div>
         ) : (
           <div className="settings__card-content">

--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
@@ -21,7 +21,7 @@ const ProjectSettingsSecretsView = ({
           <Loader />
         ) : error ? (
           <div>
-            <h1>You are not allowed to read resources</h1>
+            <h1>{error.message || error}</h1>
           </div>
         ) : (
           <div className="settings__card-content">


### PR DESCRIPTION
- **Project Settings**: 
  - If user is not allowed to change members, display only members count
    <img width="801" alt="Screen Shot 2022-02-24 at 12 44 12" src="https://user-images.githubusercontent.com/63646693/155509451-a8528766-b305-47ac-a1cd-352d092520c2.png">
  - Owner: Disable `Discard` button if no changes were made

