### PR TITLE
Fix [Jobs] Monitor Jobs crash when undefined (reading 'value') [Backport 0.10.x]

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -108,7 +108,7 @@ const Table = ({
     } else if (filtersStore.groupBy === GROUP_BY_WORKFLOW) {
       let groupWorkflowItem = map(groupedContent, (jobs, workflowId) =>
         workflows.find(workflow => workflow.id === workflowId)
-      )
+      ).filter(workflow => workflow)
 
       setTableContent(state => ({
         ...state,

--- a/src/components/Table/TableView.js
+++ b/src/components/Table/TableView.js
@@ -142,6 +142,24 @@ const TableView = ({
                   return null
               }
             })
+          ) : groupFilter === GROUP_BY_WORKFLOW &&
+            groupLatestItem.find(latestItem => !isEmpty(latestItem)) ? (
+            groupLatestItem.map((workflow, index) => {
+              return (
+                <JobsTableRow
+                  actionsMenu={actionsMenu}
+                  key={index}
+                  content={content}
+                  handleExpandRow={handleExpandRow}
+                  handleSelectItem={handleSelectItem}
+                  isGroupedByWorkflow
+                  match={match}
+                  rowItem={workflow}
+                  selectedItem={selectedItem}
+                  workflows={workflows}
+                />
+              )
+            })
           ) : groupLatestItem.find(latestItem => !isEmpty(latestItem)) ? (
             tableContent.map((group, i) => {
               switch (pageData.page) {


### PR DESCRIPTION
(cherry picked from commit 67d270b19dcbf184978fcc24b5483e4d994e7371)
Backport: [Fix [Jobs] Monitor Jobs crash when undefined (reading 'value') #1110](https://github.com/mlrun/ui/pull/1110)