### PR TITLE
Impl [UI] Change to use versioned API paths

### DIFF
--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import qs from 'qs'
 
 export const mainHttpClient = axios.create({
-  baseURL: `${process.env.PUBLIC_URL}/api`,
+  baseURL: `${process.env.PUBLIC_URL}/api/v1`,
 
   // serialize a param with an array value as a repeated param, for example:
   // { label: ['host', 'owner=admin'] } => 'label=host&label=owner%3Dadmin'


### PR DESCRIPTION
- **API**: Change to use versioned API paths
  - For example: instead of sending GET to /api/projects to list the projects, send it to /api/v1/projects
  
  https://jira.iguazeng.com/browse/ML-1808
  ![image](https://user-images.githubusercontent.com/25711177/156380381-a7518a5c-ebab-4194-b447-6764a335378f.png)
