### PR TITLE
Fix [Project Monitor] Redirect to 'Projects' screen instead of staying in current project upon 'Register artifact'

### DIFF
--- a/src/components/Project/ProjectMonitorView.js
+++ b/src/components/Project/ProjectMonitorView.js
@@ -56,9 +56,7 @@ const ProjectMonitorView = ({
       ? 'models'
       : artifactKind === 'dataset'
       ? `feature-store/${DATASETS_TAB}`
-      : artifactKind === 'file'
-      ? 'files'
-      : 'artifacts'
+      : 'files'
   }`
 
   return (


### PR DESCRIPTION
- **Artifacts**: redirect to 'Projects' screen instead of staying in current project upon 'Register artifact'
  Jira: https://jira.iguazeng.com/browse/ML-1596