### PR TITLE
Fix [Jobs] Clicking on artifacts return empty window and TypeError

### DIFF
--- a/src/actions/jobs.js
+++ b/src/actions/jobs.js
@@ -182,7 +182,7 @@ const jobsActions = {
           : (data || {}).runs.filter(job => job.metadata.iteration === 0)
 
         dispatch(jobsActions.fetchJobsSuccess(newJobs))
-        dispatch(jobsActions.setAllJobsData(data.runs || {}))
+        dispatch(jobsActions.setAllJobsData(data.runs || []))
 
         return newJobs
       })


### PR DESCRIPTION
- **Jobs**: Clicking on artifacts return empty window and TypeError
  https://jira.iguazeng.com/browse/ML-1869
  Before: 
  ![image](https://user-images.githubusercontent.com/90618337/157686495-218654f6-22a7-454c-816f-6999c48850db.png)
  After:
  ![image](https://user-images.githubusercontent.com/90618337/157687522-f8e1eafd-e09b-453b-86c0-10d8b3c29b65.png)