### PR TITLE
Fix [Projects] Missing time indication for failed job/functions in the projects view

### DIFF
--- a/src/elements/ProjectCard/projectCard.util.js
+++ b/src/elements/ProjectCard/projectCard.util.js
@@ -48,7 +48,8 @@ export const generateProjectStatistic = (
         projectSummary.runs_failed_recent_count + failedNuclioFunctions > 0
           ? 'failed'
           : 'default',
-      counterTooltip: 'ML jobs and Nuclio functions',
+      counterTooltip:
+        'Failed ML jobs and nuclio functions in the last 24 hours',
       label: 'Failed',
       labelClassName: 'wrap',
       loading: projectsSummaryLoading || nuclioFunctionsLoading,


### PR DESCRIPTION
- **Projects**: Missing time indication for failed job/functions in the projects view
  * Fix the tooltip on hover on the "failed" icon: "Failed ML jobs and nuclio functions in the last 24 hours"
  
  Jira: [ML-1877](https://jira.iguazeng.com/browse/ML-1877)
  <img width="666" alt="Screen Shot 2022-03-10 at 19 24 09" src="https://user-images.githubusercontent.com/63646693/157719919-51bccc07-d7b6-46f3-b70f-536a2713cc20.png">
 