### PR TITLE
Impl [Feature Vectors] Improve add/edit Alias Behavior

### DIFF
--- a/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
+++ b/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
@@ -7,8 +7,6 @@ import { parseFeatureTemplate } from '../../utils/parseFeatureTemplate'
 import Input from '../../common/Input/Input'
 import ConfirmDialog from '../../common/ConfirmDialog/ConfirmDialog'
 import RoundedIcon from '../../common/RoundedIcon/RoundedIcon'
-import Tooltip from '../../common/Tooltip/Tooltip'
-import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
 
 import { headers } from './detailsRequestedFeatures.utils.js'
 import { handleFinishEdit } from '../Details/details.util.js'
@@ -20,7 +18,7 @@ import {
 } from './detailsRequestedFeaturesReducer.js'
 import { DANGER_BUTTON, TERTIARY_BUTTON } from '../../constants'
 
-import { ReactComponent as AddIcon } from '../../images/add-circle.svg'
+import { ReactComponent as AddIcon } from '../../images/add.svg'
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
 import { ReactComponent as Close } from '../../images/close.svg'
 import { ReactComponent as Delete } from '../../images/delete.svg'
@@ -297,11 +295,11 @@ const DetailsRequestedFeatures = ({
                 ) : (
                   <>
                     <div className="item-requested-features__table-cell cell_alias">
-                      {alias ? (
+                      {alias && (
                         <div className="cell_alias__input-wrapper">
                           <span>{alias}</span>
                           <RoundedIcon
-                            className={!alias ? 'visiblity-hidden' : ''}
+                            className={!alias ? 'visibility-hidden' : ''}
                             onClick={() =>
                               handleItemClick(
                                 'features',
@@ -316,30 +314,25 @@ const DetailsRequestedFeatures = ({
                             <EditIcon />
                           </RoundedIcon>
                         </div>
-                      ) : (
-                        <Tooltip
-                          template={
-                            <TextTooltipTemplate text="Click to add an alias" />
-                          }
-                        >
-                          <span
-                            className="pointer"
-                            onClick={() =>
-                              handleItemClick(
-                                'features',
-                                'input',
-                                currentData,
-                                index,
-                                featureTemplate
-                              )
-                            }
-                          >
-                            <AddIcon />
-                          </span>
-                        </Tooltip>
                       )}
                     </div>
                     <div className="cell_actions">
+                      <RoundedIcon
+                        className={alias && 'visibility-hidden'}
+                        onClick={() =>
+                          handleItemClick(
+                            'features',
+                            'input',
+                            currentData,
+                            index,
+                            featureTemplate
+                          )
+                        }
+                        tooltipText="Click to add an alias"
+                      >
+                        <AddIcon />
+                      </RoundedIcon>
+
                       <RoundedIcon
                         onClick={() => setConfirmDialogData({ index, feature })}
                         tooltipText="Delete"

--- a/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
+++ b/src/components/DetailsRequestedFeatures/DetailsRequestedFeatures.js
@@ -6,6 +6,7 @@ import { parseFeatureTemplate } from '../../utils/parseFeatureTemplate'
 
 import Input from '../../common/Input/Input'
 import ConfirmDialog from '../../common/ConfirmDialog/ConfirmDialog'
+import RoundedIcon from '../../common/RoundedIcon/RoundedIcon'
 import Tooltip from '../../common/Tooltip/Tooltip'
 import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTemplate'
 
@@ -19,8 +20,11 @@ import {
 } from './detailsRequestedFeaturesReducer.js'
 import { DANGER_BUTTON, TERTIARY_BUTTON } from '../../constants'
 
+import { ReactComponent as AddIcon } from '../../images/add-circle.svg'
 import { ReactComponent as Checkmark } from '../../images/checkmark.svg'
+import { ReactComponent as Close } from '../../images/close.svg'
 import { ReactComponent as Delete } from '../../images/delete.svg'
+import { ReactComponent as EditIcon } from '../../images/edit.svg'
 
 import './detailsRequestedFeatures.scss'
 
@@ -97,7 +101,7 @@ const DetailsRequestedFeatures = ({
   }
 
   const handleItemClick = (field, fieldType, info, index, featureTemplate) => {
-    if (isNil(editableItemIndex)) {
+    if (isNil(editableItemIndex) || editableItemIndex !== index) {
       setEditableItemIndex(index)
       detailsRequestedFeaturesDispatch({
         type: detailsRequestedFeaturesActions.SET_EDIT_MODE,
@@ -260,52 +264,91 @@ const DetailsRequestedFeatures = ({
                   {feature}
                 </div>
                 {editableItemIndex === index ? (
-                  <div className="item-requested-features__table-cell cell_alias">
-                    <div className="cell_alias__input-wrapper">
-                      <Input
-                        className="input"
-                        focused
-                        onChange={alias => handleAliasChange(index, alias)}
-                        type="text"
-                        value={alias}
-                      />
-                      <Tooltip template={<TextTooltipTemplate text="Apply" />}>
-                        <Checkmark
-                          className="details-item__apply-btn"
-                          onClick={() =>
-                            onFinishEdit(['features', 'label_feature'])
-                          }
+                  <>
+                    <div className="item-requested-features__table-cell cell_alias">
+                      <div className="cell_alias__input-wrapper">
+                        <Input
+                          className="input"
+                          focused
+                          onChange={alias => handleAliasChange(index, alias)}
+                          type="text"
+                          value={alias}
                         />
-                      </Tooltip>
+                      </div>
                     </div>
-                  </div>
+                    <div className="cell_actions cell_actions-visible">
+                      <RoundedIcon
+                        onClick={() =>
+                          onFinishEdit(['features', 'label_feature'])
+                        }
+                        tooltipText="Apply"
+                      >
+                        <Checkmark className="details-item__apply-btn" />
+                      </RoundedIcon>
+
+                      <RoundedIcon
+                        onClick={() => setEditableItemIndex(null)}
+                        tooltipText="Discard changes"
+                      >
+                        <Close />
+                      </RoundedIcon>
+                    </div>
+                  </>
                 ) : (
-                  <div
-                    className="item-requested-features__table-cell cell_alias"
-                    onClick={() =>
-                      handleItemClick(
-                        'features',
-                        'input',
-                        currentData,
-                        index,
-                        featureTemplate
-                      )
-                    }
-                  >
-                    <Tooltip
-                      template={<TextTooltipTemplate text="Click to edit" />}
-                    >
-                      <div>{alias}</div>
-                    </Tooltip>
-                  </div>
+                  <>
+                    <div className="item-requested-features__table-cell cell_alias">
+                      {alias ? (
+                        <div className="cell_alias__input-wrapper">
+                          <span>{alias}</span>
+                          <RoundedIcon
+                            className={!alias ? 'visiblity-hidden' : ''}
+                            onClick={() =>
+                              handleItemClick(
+                                'features',
+                                'input',
+                                currentData,
+                                index,
+                                featureTemplate
+                              )
+                            }
+                            tooltipText="Click to edit"
+                          >
+                            <EditIcon />
+                          </RoundedIcon>
+                        </div>
+                      ) : (
+                        <Tooltip
+                          template={
+                            <TextTooltipTemplate text="Click to add an alias" />
+                          }
+                        >
+                          <span
+                            className="pointer"
+                            onClick={() =>
+                              handleItemClick(
+                                'features',
+                                'input',
+                                currentData,
+                                index,
+                                featureTemplate
+                              )
+                            }
+                          >
+                            <AddIcon />
+                          </span>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <div className="cell_actions">
+                      <RoundedIcon
+                        onClick={() => setConfirmDialogData({ index, feature })}
+                        tooltipText="Delete"
+                      >
+                        <Delete />
+                      </RoundedIcon>
+                    </div>
+                  </>
                 )}
-                <div className="cell_delete">
-                  <Tooltip template={<TextTooltipTemplate text="Delete" />}>
-                    <Delete
-                      onClick={() => setConfirmDialogData({ index, feature })}
-                    />
-                  </Tooltip>
-                </div>
               </div>
             )
           })}

--- a/src/components/DetailsRequestedFeatures/detailsRequestedFeatures.scss
+++ b/src/components/DetailsRequestedFeatures/detailsRequestedFeatures.scss
@@ -35,6 +35,7 @@
           padding: 8px 17px;
 
           &-wrapper {
+            margin-right: 5px;
             width: 100%;
           }
         }
@@ -53,13 +54,17 @@
         color: $topaz;
       }
 
-      &_delete {
+      &_actions {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
-        width: 30px;
-        cursor: pointer;
+        flex: 0 1;
+        flex-direction: row;
+        justify-content: flex-end;
         opacity: 0;
+        min-width: 80px;
+
+        &-visible {
+          opacity: 1;
+        }
       }
     }
 
@@ -68,9 +73,9 @@
         max-width: 180px;
       }
 
-      &_delete {
-        flex: 0 0 30px;
-        min-width: auto;
+      &_actions {
+        flex: 0 1 auto;
+        min-width: 80px;
       }
     }
 
@@ -80,7 +85,7 @@
       border-bottom: $secondaryBorder;
 
       &:hover {
-        .cell_delete {
+        .cell_actions {
           opacity: 1;
           transition: all 0.3s;
         }

--- a/src/components/DetailsRequestedFeatures/detailsRequestedFeatures.utils.js
+++ b/src/components/DetailsRequestedFeatures/detailsRequestedFeatures.utils.js
@@ -3,5 +3,5 @@ export const headers = [
   { label: 'Feature set', id: 'feature-set' },
   { label: 'Feature', id: 'feature' },
   { label: 'Alias', id: 'alias' },
-  { label: '', id: 'delete' }
+  { label: '', id: 'actions' }
 ]

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -372,7 +372,7 @@ export const navigateToDetailsPane = (
     featureSets.allData.length > 0
   ) {
     content = featureSets.selectedRowData.content[name] || featureSets.allData
-  } else if (match.params.pageTab === FEATURES_TAB && features.length > 0) {
+  } else if (match.params.pageTab === FEATURES_TAB && features?.length > 0) {
     content = [...features, ...entities]
   } else if (
     match.params.pageTab === FEATURE_VECTORS_TAB &&

--- a/src/elements/AddToFeatureVectorPopUp/AddToFeatureVectorPopUp.js
+++ b/src/elements/AddToFeatureVectorPopUp/AddToFeatureVectorPopUp.js
@@ -175,11 +175,11 @@ const AddToFeatureVectorPopUp = ({
         label={action.label}
         tooltip={
           action.tooltip ||
-          (featureStore.features?.allData.length === 0
+          (featureStore.features?.allData?.length === 0
             ? 'No features in the project.'
             : '')
         }
-        disabled={action.disabled || !featureStore.features?.allData.length}
+        disabled={action.disabled || !featureStore.features?.allData?.length}
         onClick={handleAddToFeatureVector}
       />
       {isPopUpOpen && (

--- a/src/elements/CreateFeatureVectorPopUp/CreateFeatureVectorPopUp.js
+++ b/src/elements/CreateFeatureVectorPopUp/CreateFeatureVectorPopUp.js
@@ -71,7 +71,6 @@ const CreateFeatureVectorPopUp = ({
               setTagTooltipIsHidden(true)
               setFeatureVectorTag(value)
             }}
-            pattern="^(?=[\S\s]{1,56}$)([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$"
             required
             type="text"
             validationRules={getValidationRules('common.tag')}

--- a/src/elements/FeaturesTablePanel/featuresTablePanel.scss
+++ b/src/elements/FeaturesTablePanel/featuresTablePanel.scss
@@ -61,6 +61,7 @@
     justify-content: flex-end;
     width: 100%;
     padding: 10px 15px;
+    background-color: $white;
   }
 
   .features-panel__divider {

--- a/src/elements/ProjectCard/ProjectCardView.js
+++ b/src/elements/ProjectCard/ProjectCardView.js
@@ -52,7 +52,7 @@ const ProjectCardView = React.forwardRef(
 
             <div
               className={`project-card__header-sub-title project-card__info ${
-                !project.spec.owner ? 'visiblity-hidden' : ''
+                !project.spec.owner ? 'visibility-hidden' : ''
               } `}
             >
               <span>Owner:</span>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -350,7 +350,7 @@ textarea {
   }
 }
 
-.visiblity-hidden {
+.visibility-hidden {
   visibility: hidden;
 }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -354,6 +354,10 @@ textarea {
   visibility: hidden;
 }
 
+.pointer {
+  cursor: pointer;
+}
+
 .graph-container {
   display: flex;
   flex: 1 1;


### PR DESCRIPTION
- **Feature Vectors**: Improve add/edit Alias Behavior
  Jira: [ML-1941](https://jira.iguazeng.com/browse/ML-1941)
   - Hover on the FV row will display a "Delete" Icon
   - If a FV "alias" cell is empty
     - Add an indication (+ Icon) and a tooltip "Click to add an alias".
     - Clicking the + icon will change to an input field and Hide the "Delete" row Icon.
  - If a FV has an alias
    - Display FV "alias" instead of the + Icon.
    - Place an "edit" icon and tooltip "Click to edit" next to the FV alias.
    - Click on the "edit" icon will change to an input field filled with the FV alias.
  - If a FV alias field is being edited, clicking "+" or "Edit" icons of another FV alias will change the current field to its initial state and discard changes to it if made.
  - If a FV alias is being added/edited - Add "Apply" and "Discard changes" icons next to the input field + hide the row "Delete" Icon

  Before:
  ![image](https://user-images.githubusercontent.com/63646693/159738134-3a47e82e-e623-41c1-8bbd-473edcec2b38.png)
  ![image](https://user-images.githubusercontent.com/63646693/159738204-2c41f791-6dab-482f-b328-cda2051d1e3d.png)

  After:  
  <img width="510" alt="Screen Shot 2022-03-24 at 11 04 21" src="https://user-images.githubusercontent.com/63646693/159880790-7808c562-1be2-4097-baad-e69f0ec4ecc5.png">
  <img width="469" alt="Screen Shot 2022-03-24 at 11 04 59" src="https://user-images.githubusercontent.com/63646693/159880903-4df4ebb3-d82d-423e-8d12-6a0ea764b7bb.png">





