### PR TITLE
Fix [Feature vector] Create Feature vector API failed when Feature tag inсludes dot

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTitle/FeatureSetsPanelTitleView.js
@@ -72,7 +72,7 @@ const FeatureSetsPanelTitleView = ({
             }
             type="text"
             value={data.version}
-            validationRules={getValidationRules('common.tag')}
+            validationRules={getValidationRules('feature.sets.tag')}
             wrapperClassName="version"
           />
         </div>

--- a/src/utils/validationService.js
+++ b/src/utils/validationService.js
@@ -246,6 +246,13 @@ const validationRules = {
     ]
   },
   feature: {
+    sets: {
+      tag: [
+        generateRule.validCharacters('a-z A-Z 0-9 - _'),
+        generateRule.beginEndWith('a-z A-Z 0-9'),
+        generateRule.length({ max: 56 })
+      ]
+    },
     vector: {
       name: [
         generateRule.validCharacters('a-z A-Z 0-9 - _ .'),


### PR DESCRIPTION
- **Feature vector**: Create Feature vector API failed when Feature tag includes dot
  Jira: https://jira.iguazeng.com/browse/ML-1691

  Before:
  ![image](https://user-images.githubusercontent.com/78905712/160582616-5cf0556a-f8d6-4340-843d-a4421217b549.png)

  After:
  ![image](https://user-images.githubusercontent.com/78905712/160582637-6451dda9-501e-436f-97bf-edc0748188e1.png)
