### PR TITLE
Impl [UI] Replace "demo=true" flag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import {
 import Page from './layout/Page/Page'
 import Loader from './common/Loader/Loader'
 
-import { useMode } from './hooks/demoMode.hook'
+import { useMode } from './hooks/mode.hook'
 import {
   FEATURE_SETS_TAB,
   MODELS_TAB,

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import {
 import Page from './layout/Page/Page'
 import Loader from './common/Loader/Loader'
 
+import { useMode } from './hooks/demoMode.hook'
 import {
   FEATURE_SETS_TAB,
   MODELS_TAB,
@@ -51,10 +52,8 @@ const AddToFeatureVectorPage = React.lazy(() =>
 )
 
 const App = () => {
-  // TODO: Remove after ProjectOverview is Done.
-  const search = window.location.search
-  const isDemo =
-    new URLSearchParams(search).get('demo')?.toLowerCase() === 'true'
+  const { isDemoMode } = useMode()
+
   return (
     <Router basename={process.env.PUBLIC_URL}>
       <Page>
@@ -65,7 +64,7 @@ const App = () => {
               exact
               render={routeProps => <Projects {...routeProps} />}
             />
-            {!isDemo && (
+            {!isDemoMode && (
               <Redirect
                 exact
                 from="/projects/:projectName"

--- a/src/common/Breadcrumbs/Breadcrumbs.js
+++ b/src/common/Breadcrumbs/Breadcrumbs.js
@@ -9,7 +9,7 @@ import RoundedIcon from '../RoundedIcon/RoundedIcon'
 
 import { ReactComponent as ArrowIcon } from '../../images/arrow.svg'
 
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import { generateProjectScreens } from './breadcrumbs.util'
 import { generateProjectsList } from '../../utils/projects'
 import projectsAction from '../../actions/projects'

--- a/src/common/Breadcrumbs/Breadcrumbs.js
+++ b/src/common/Breadcrumbs/Breadcrumbs.js
@@ -9,7 +9,7 @@ import RoundedIcon from '../RoundedIcon/RoundedIcon'
 
 import { ReactComponent as ArrowIcon } from '../../images/arrow.svg'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import { generateProjectScreens } from './breadcrumbs.util'
 import { generateProjectsList } from '../../utils/projects'
 import projectsAction from '../../actions/projects'
@@ -20,12 +20,12 @@ import './breadcrums.scss'
 const Breadcrumbs = ({ match, onClick, projectStore, fetchProjectsNames }) => {
   const [showScreensList, setShowScreensList] = useState(false)
   const [showProjectsList, setShowProjectsList] = useState(false)
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
   const breadcrumbsRef = useRef()
 
   const projectScreens = useMemo(() => {
-    return generateProjectScreens(match, isDemoMode)
-  }, [isDemoMode, match])
+    return generateProjectScreens(match, isStagingMode)
+  }, [isStagingMode, match])
   const projectsList = useMemo(() => {
     return generateProjectsList(projectStore.projectsNames.data)
   }, [projectStore.projectsNames.data])

--- a/src/common/Breadcrumbs/breadcrumbs.util.js
+++ b/src/common/Breadcrumbs/breadcrumbs.util.js
@@ -1,4 +1,4 @@
-export const generateProjectScreens = (match, isDemoMode) => [
+export const generateProjectScreens = match => [
   {
     label: 'Project Monitoring',
     id: 'monitor'

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -46,7 +46,7 @@ import {
   TAG_FILTER_ALL_ITEMS,
   TAG_FILTER_LATEST
 } from '../../constants'
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import { useOpenPanel } from '../../hooks/openPanel.hook'
 import { useGetTagOptions } from '../../hooks/useGetTagOptions.hook'
 
@@ -91,7 +91,7 @@ const FeatureStore = ({
       : fetchFeatureSetsTags,
     pageData.filters
   )
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
   const openPanelByDefault = useOpenPanel()
   const [content, setContent] = useState([])
   const [selectedItem, setSelectedItem] = useState({})
@@ -428,7 +428,7 @@ const FeatureStore = ({
           getPopUpTemplate,
           tableStore.isTablePanelOpen,
           !isEveryObjectValueEmpty(selectedItem),
-          isDemoMode
+          isStagingMode
         )
       }
     })
@@ -438,7 +438,7 @@ const FeatureStore = ({
     handleRemoveFeatureSet,
     handleRemoveFeatureVector,
     handleRequestOnExpand,
-    isDemoMode,
+    isStagingMode,
     match.params.pageTab,
     onDeleteFeatureVector,
     selectedItem,

--- a/src/components/FeatureStore/FeatureStore.js
+++ b/src/components/FeatureStore/FeatureStore.js
@@ -46,7 +46,7 @@ import {
   TAG_FILTER_ALL_ITEMS,
   TAG_FILTER_LATEST
 } from '../../constants'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import { useOpenPanel } from '../../hooks/openPanel.hook'
 import { useGetTagOptions } from '../../hooks/useGetTagOptions.hook'
 

--- a/src/components/FeatureStore/featureStore.util.js
+++ b/src/components/FeatureStore/featureStore.util.js
@@ -241,7 +241,7 @@ export const generatePageData = (
   getPopUpTemplate,
   isTablePanelOpen,
   isSelectedItem,
-  isDemoMode
+  isStagingMode
 ) => {
   let data = {
     details: {
@@ -282,7 +282,7 @@ export const generatePageData = (
       FEATURE_VECTORS_TAB,
       onDeleteFeatureVector
     )
-    data.hidePageActionMenu = !isDemoMode
+    data.hidePageActionMenu = !isStagingMode
     data.actionsMenuHeader = createFeatureVectorTitle
     data.filters = featureVectorsFilters
     data.tableHeaders = featureVectorsTableHeaders(isSelectedItem)

--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -37,7 +37,7 @@ import {
   SECONDARY_BUTTON,
   TAG_LATEST
 } from '../../constants'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 import { ReactComponent as Delete } from '../../images/delete.svg'
 import { ReactComponent as Run } from '../../images/run.svg'

--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -37,7 +37,7 @@ import {
   SECONDARY_BUTTON,
   TAG_LATEST
 } from '../../constants'
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 
 import { ReactComponent as Delete } from '../../images/delete.svg'
 import { ReactComponent as Run } from '../../images/run.svg'
@@ -64,7 +64,7 @@ const Functions = ({
   const [taggedFunctions, setTaggedFunctions] = useState([])
   const [functionsPanelIsOpen, setFunctionsPanelIsOpen] = useState(false)
   let fetchFunctionLogsTimeout = useRef(null)
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   const refreshFunctions = useCallback(
     filters => {
@@ -135,7 +135,7 @@ const Functions = ({
           setEditableItem(func)
         },
         hidden:
-          !getFunctionsEditableTypes(isDemoMode).includes(item?.type) ||
+          !getFunctionsEditableTypes(isStagingMode).includes(item?.type) ||
           !FUNCTIONS_EDITABLE_STATES.includes(item?.state?.value)
       },
       {

--- a/src/components/FunctionsPage/functions.util.js
+++ b/src/components/FunctionsPage/functions.util.js
@@ -27,10 +27,10 @@ export const FUNCTIONS_EDITABLE_STATES = [
   ...FUNCTIONS_READY_STATES,
   ...FUNCTIONS_FAILED_STATES
 ]
-export const getFunctionsEditableTypes = isDemoMode => {
+export const getFunctionsEditableTypes = isStagingMode => {
   const editableTypes = [FUNCTION_TYPE_JOB, FUNCTION_TYPE_LOCAL, '']
 
-  if (isDemoMode) {
+  if (isStagingMode) {
     editableTypes.push(FUNCTION_TYPE_SERVING)
   }
 

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -5,7 +5,7 @@ import { find, isEmpty, cloneDeep } from 'lodash'
 
 import JobsView from './JobsView'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import { useYaml } from '../../hooks/yaml.hook'
 import {
   actionCreator,
@@ -81,7 +81,7 @@ const Jobs = ({
   const [itemIsSelected, setItemIsSelected] = useState(false)
   const [jobRuns, setJobRuns] = useState([])
   const [dateFilter, setDateFilter] = useState(['', ''])
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   const dispatch = useDispatch()
   let fetchFunctionLogsTimeout = useRef(null)
@@ -286,7 +286,7 @@ const Jobs = ({
   const pageData = useCallback(
     generatePageData(
       match.params.pageTab,
-      isDemoMode,
+      isStagingMode,
       onRemoveScheduledJob,
       handleRunJob,
       handleEditScheduleJob,
@@ -310,7 +310,7 @@ const Jobs = ({
       match.params.workflowId,
       match.params.jobName,
       appStore.frontendSpec.jobs_dashboard_url,
-      isDemoMode,
+      isStagingMode,
       selectedJob,
       selectedFunction,
       onAbortJob,

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -5,7 +5,7 @@ import { find, isEmpty, cloneDeep } from 'lodash'
 
 import JobsView from './JobsView'
 
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import { useYaml } from '../../hooks/yaml.hook'
 import {
   actionCreator,

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -224,7 +224,7 @@ const generateTabs = () => {
 
 export const generatePageData = (
   pageTab,
-  isDemoMode,
+  isStagingMode,
   removeScheduledJob,
   handleSubmitJob,
   handleEditScheduleJob,
@@ -290,7 +290,7 @@ export const generatePageData = (
     filters: filtersByTab(pageTab, jobName) ?? [],
     page,
     tableHeaders: generateTableHeaders(pageTab, workflowId, isSelectedItem),
-    tabs: generateTabs(isDemoMode),
+    tabs: generateTabs(isStagingMode),
     withoutExpandButton: pageTab === MONITOR_WORKFLOWS_TAB && !workflowId
   }
 }

--- a/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
+++ b/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import JobsPanelAdvancedView from './JobsPanelAdvancedView'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 
 import {
   initialState,
@@ -26,7 +26,7 @@ const JobsPanelAdvanced = ({
   const [validation, setValidation] = useState({
     secretsSourceValue: true
   })
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   const handleAddNewItem = () => {
     let data = {}
@@ -143,7 +143,7 @@ const JobsPanelAdvanced = ({
       handleDeleteItems={handleDeleteItems}
       handleEditItems={handleEditItems}
       handleResetForm={handleResetForm}
-      isDemoMode={isDemoMode}
+      isStagingMode={isStagingMode}
       match={match}
       panelDispatch={panelDispatch}
       panelState={panelState}

--- a/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
+++ b/src/components/JobsPanelAdvanced/JobsPanelAdvanced.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import JobsPanelAdvancedView from './JobsPanelAdvancedView'
 
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 import {
   initialState,

--- a/src/components/JobsPanelAdvanced/JobsPanelAdvancedView.js
+++ b/src/components/JobsPanelAdvanced/JobsPanelAdvancedView.js
@@ -15,7 +15,7 @@ const JobsPanelAdvancedView = ({
   handleDeleteItems,
   handleEditItems,
   handleResetForm,
-  isDemoMode,
+  isStagingMode,
   match,
   panelDispatch,
   panelState,
@@ -34,7 +34,7 @@ const JobsPanelAdvancedView = ({
         />
       </JobsPanelSection>
 
-      {isDemoMode && (
+      {isStagingMode && (
         <JobsPanelSection title="Secrets">
           <JobsPanelAdvancedTable
             addNewItem={advancedState.addNewSecret}
@@ -90,7 +90,7 @@ JobsPanelAdvancedView.propTypes = {
   handleDeleteItems: PropTypes.func.isRequired,
   handleEditItems: PropTypes.func.isRequired,
   handleResetForm: PropTypes.func.isRequired,
-  isDemoMode: PropTypes.bool.isRequired,
+  isStagingMode: PropTypes.bool.isRequired,
   match: PropTypes.shape({}).isRequired,
   panelDispatch: PropTypes.func.isRequired,
   panelState: PropTypes.shape({}).isRequired,

--- a/src/components/Project/ProjectMonitor.js
+++ b/src/components/Project/ProjectMonitor.js
@@ -15,7 +15,6 @@ import {
   handleFetchProjectError
 } from './project.utils'
 import { areNuclioStreamsEnabled } from '../../utils/helper'
-import { useDemoMode } from '../../hooks/demoMode.hook'
 
 const ProjectMonitor = ({
   featureStore,
@@ -48,7 +47,6 @@ const ProjectMonitor = ({
   const [confirmData, setConfirmData] = useState(null)
 
   const history = useHistory()
-  const isDemoMode = useDemoMode()
 
   const nuclioStreamsAreEnabled = useMemo(
     () => areNuclioStreamsEnabled(frontendSpec),
@@ -248,7 +246,6 @@ const ProjectMonitor = ({
       handleDeployFunctionSuccess={handleDeployFunctionSuccess}
       handleLaunchIDE={handleLaunchIDE}
       history={history}
-      isDemoMode={isDemoMode}
       isNewFunctionPopUpOpen={isNewFunctionPopUpOpen}
       isPopupDialogOpen={isPopupDialogOpen}
       match={match}

--- a/src/components/Project/ProjectMonitorView.js
+++ b/src/components/Project/ProjectMonitorView.js
@@ -19,7 +19,7 @@ import ConfirmDialog from '../../common/ConfirmDialog/ConfirmDialog'
 import { DATASETS, PANEL_CREATE_MODE } from '../../constants'
 import { launchIDEOptions } from './project.utils'
 import { formatDatetime } from '../../utils'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 import { ReactComponent as RefreshIcon } from '../../images/refresh.svg'
 

--- a/src/components/Project/ProjectMonitorView.js
+++ b/src/components/Project/ProjectMonitorView.js
@@ -19,6 +19,7 @@ import ConfirmDialog from '../../common/ConfirmDialog/ConfirmDialog'
 import { DATASETS, PANEL_CREATE_MODE } from '../../constants'
 import { launchIDEOptions } from './project.utils'
 import { formatDatetime } from '../../utils'
+import { useMode } from '../../hooks/demoMode.hook'
 
 import { ReactComponent as RefreshIcon } from '../../images/refresh.svg'
 
@@ -50,6 +51,7 @@ const ProjectMonitorView = ({
   showFunctionsPanel,
   v3ioStreams
 }) => {
+  const { isDemoMode } = useMode()
   const registerArtifactLink = `/projects/${match.params.projectName}/${
     artifactKind === 'model'
       ? 'models'
@@ -154,7 +156,7 @@ const ProjectMonitorView = ({
                 projectSummary={projectSummary}
                 title="Artifacts"
               />
-              {nuclioStreamsAreEnabled && (
+              {isDemoMode && nuclioStreamsAreEnabled && (
                 <ProjectSummaryCard
                   counterValue={Object.keys(v3ioStreams.data).length ?? 0}
                   link={`/projects/${match.params.projectName}/monitor/consumer-groups`}

--- a/src/components/Project/ProjectOverview/ProjectOverview.js
+++ b/src/components/Project/ProjectOverview/ProjectOverview.js
@@ -19,8 +19,6 @@ import { handlePath, getInitialCards } from './ProjectOverview.util'
 import { handleFetchProjectError } from '../project.utils'
 import { getDateAndTimeByFormat } from '../../../utils/'
 
-import { useDemoMode } from '../../../hooks/demoMode.hook'
-
 import { ReactComponent as ArrowIcon } from '../../../images/arrow.svg'
 
 import './ProjectOverview.scss'
@@ -30,7 +28,6 @@ const ProjectOverview = ({ fetchProject, history, match, project }) => {
   const [confirmData, setConfirmData] = useState(null)
   const [modal, setModal] = useState({ isOpen: false, name: '' })
 
-  const isDemoMode = useDemoMode()
   const { projectName } = match.params
 
   const cards = useMemo(() => {
@@ -74,7 +71,7 @@ const ProjectOverview = ({ fetchProject, history, match, project }) => {
     })
   }
 
-  const handlePathExecution = handlePath(history, handleModalToggle, isDemoMode)
+  const handlePathExecution = handlePath(history, handleModalToggle)
 
   const handleActionsViewToggle = index => {
     if (selectedActionsIndex === index) {

--- a/src/components/Project/ProjectOverview/ProjectOverview.util.js
+++ b/src/components/Project/ProjectOverview/ProjectOverview.util.js
@@ -205,18 +205,10 @@ export const getInitialCards = projectName => {
   }
 }
 
-export const calcIsDemoPrefix = (path, isDemoMode) => {
-  let prefix = path.includes('?') ? '&' : '?'
-  return isDemoMode ? prefix.concat('demo=true') : ''
-}
-
-export const handlePath = (history, cb, isDemoMode) => ({
-  target,
-  externalLink
-}) => {
+export const handlePath = (history, cb) => ({ target, externalLink }) => {
   return target.indexOf('/') < 0
     ? cb(target.toLowerCase())
     : externalLink
     ? (window.top.location.href = target)
-    : history.push(`${target}${calcIsDemoPrefix(target, isDemoMode)}`)
+    : history.push(target)
 }

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash'
 
 import TableView from './TableView'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import createJobsContent from '../../utils/createJobsContent'
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { generateTableContent } from '../../utils/generateTableContent'
@@ -47,7 +47,7 @@ const Table = ({
   const tableContentRef = useRef(null)
   const tablePanelRef = useRef(null)
   const tableHeadRef = useRef(null)
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   const workflows = useSelector(state => {
     return pageData.page === JOBS_PAGE && state.workflowsStore.workflows.data
@@ -90,7 +90,7 @@ const Table = ({
       pageData.page,
       tableStore.isTablePanelOpen,
       match.params,
-      isDemoMode,
+      isStagingMode,
       !isEveryObjectValueEmpty(selectedItem)
     )
 
@@ -114,7 +114,7 @@ const Table = ({
           workflows,
           !isEveryObjectValueEmpty(selectedItem),
           match.params,
-          isDemoMode,
+          isStagingMode,
           true
         )
       }))
@@ -130,7 +130,7 @@ const Table = ({
     content,
     filtersStore.groupBy,
     groupedContent,
-    isDemoMode,
+    isStagingMode,
     match.params,
     pageData.mainRowItemsCount,
     pageData.page,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash'
 
 import TableView from './TableView'
 
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import createJobsContent from '../../utils/createJobsContent'
 import { isEveryObjectValueEmpty } from '../../utils/isEveryObjectValueEmpty'
 import { generateTableContent } from '../../utils/generateTableContent'

--- a/src/elements/ContentMenu/ContentMenu.js
+++ b/src/elements/ContentMenu/ContentMenu.js
@@ -3,13 +3,9 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
-
 import './contentMenu.scss'
 
 const ContentMenu = ({ activeTab, match, screen, tabs, onClick }) => {
-  const isDemoMode = useDemoMode()
-
   const handleClick = (e, tabId) => {
     e.preventDefault()
     onClick(tabId)
@@ -33,9 +29,7 @@ const ContentMenu = ({ activeTab, match, screen, tabs, onClick }) => {
                       ? '/'
                       : `/projects/${
                           match.params.projectName
-                        }/${screen.toLowerCase()}/${tab.id}${
-                          isDemoMode ? '?demo=true' : ''
-                        }`
+                        }/${screen.toLowerCase()}/${tab.id}`
                   }
                   className={tab.icon && 'content-menu__item-icon'}
                   onClick={onClick && (e => handleClick(e, tab.id))}

--- a/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
+++ b/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
@@ -6,7 +6,7 @@ import FunctionsPanelEnvironmentVariablesView from './FunctionsPanelEnvironmentV
 import functionsActions from '../../actions/functions'
 import { parseEnvVariables } from '../../utils/parseEnvironmentVariables'
 import { generateEnvVariable } from '../../utils/generateEnvironmentVariable'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 const FunctionsPanelEnvironmentVariables = ({
   functionsStore,

--- a/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
+++ b/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariables.js
@@ -6,21 +6,21 @@ import FunctionsPanelEnvironmentVariablesView from './FunctionsPanelEnvironmentV
 import functionsActions from '../../actions/functions'
 import { parseEnvVariables } from '../../utils/parseEnvironmentVariables'
 import { generateEnvVariable } from '../../utils/generateEnvironmentVariable'
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 
 const FunctionsPanelEnvironmentVariables = ({
   functionsStore,
   setNewFunctionEnv
 }) => {
   const [envVariables, setEnvVariables] = useState([])
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   useEffect(() => {
     setEnvVariables(parseEnvVariables(functionsStore.newFunction.spec.env))
   }, [functionsStore.newFunction.spec.env])
 
   const handleAddNewEnv = env => {
-    if (isDemoMode) {
+    if (isStagingMode) {
       const generatedVariable = generateEnvVariable(env)
 
       setNewFunctionEnv([
@@ -33,7 +33,7 @@ const FunctionsPanelEnvironmentVariables = ({
   }
 
   const handleEditEnv = env => {
-    if (isDemoMode) {
+    if (isStagingMode) {
       const generatedVariables = env.map(variable =>
         generateEnvVariable(variable)
       )
@@ -54,7 +54,7 @@ const FunctionsPanelEnvironmentVariables = ({
   }
 
   const handleDeleteEnv = env => {
-    if (isDemoMode) {
+    if (isStagingMode) {
       const generatedVariables = env.map(item => generateEnvVariable(item))
 
       setNewFunctionEnv([...generatedVariables])
@@ -71,7 +71,7 @@ const FunctionsPanelEnvironmentVariables = ({
       handleAddNewEnv={handleAddNewEnv}
       handleDeleteEnv={handleDeleteEnv}
       handleEditEnv={handleEditEnv}
-      isDemoMode={isDemoMode}
+      isStagingMode={isStagingMode}
     />
   )
 }

--- a/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariablesView.js
+++ b/src/elements/FunctionsPanelEnvironmentVariables/FunctionsPanelEnvironmentVariablesView.js
@@ -12,9 +12,9 @@ const FunctionsPanelEnvironmentVariablesView = ({
   handleAddNewEnv,
   handleDeleteEnv,
   handleEditEnv,
-  isDemoMode
+  isStagingMode
 }) => {
-  return isDemoMode ? (
+  return isStagingMode ? (
     <EnvironmentVariables
       envVariables={envVariables}
       handleAddNewEnv={handleAddNewEnv}
@@ -66,7 +66,7 @@ FunctionsPanelEnvironmentVariablesView.propTypes = {
   handleAddNewEnv: PropTypes.func.isRequired,
   handleDeleteEnv: PropTypes.func.isRequired,
   handleEditEnv: PropTypes.func.isRequired,
-  isDemoMode: PropTypes.bool.isRequired
+  isStagingMode: PropTypes.bool.isRequired
 }
 
 export default FunctionsPanelEnvironmentVariablesView

--- a/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntime.js
+++ b/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntime.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 
 import FunctionsPanelRuntimeView from './FunctionsPanelRuntimeView'
 
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 const FunctionsPanelRuntime = ({
   defaultData,

--- a/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntime.js
+++ b/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntime.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 
 import FunctionsPanelRuntimeView from './FunctionsPanelRuntimeView'
 
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 
 const FunctionsPanelRuntime = ({
   defaultData,
@@ -13,13 +13,13 @@ const FunctionsPanelRuntime = ({
   setValidation,
   validation
 }) => {
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   return (
     <FunctionsPanelRuntimeView
       defaultData={defaultData}
       functionsStore={functionsStore}
-      isDemoMode={isDemoMode}
+      isStagingMode={isStagingMode}
       sections={sections}
       setValidation={setValidation}
       validation={validation}

--- a/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntimeView.js
+++ b/src/elements/FunctionsPanelRuntime/FunctionsPanelRuntimeView.js
@@ -11,7 +11,7 @@ import './functionsPanelRuntime.scss'
 const FunctionsPanelRuntimeView = ({
   defaultData,
   functionsStore,
-  isDemoMode,
+  isStagingMode,
   sections,
   setValidation,
   validation
@@ -27,7 +27,7 @@ const FunctionsPanelRuntimeView = ({
               defaultData={defaultData}
               key={section.id}
             />
-          ) : section.id === 'secrets' && isDemoMode ? (
+          ) : section.id === 'secrets' && isStagingMode ? (
             <FunctionsPanelSecrets defaultData={defaultData} key={section.id} />
           ) : section.id === 'advanced' ? (
             <FunctionsPanelAdvanced
@@ -46,7 +46,7 @@ const FunctionsPanelRuntimeView = ({
 FunctionsPanelRuntimeView.propTypes = {
   defaultData: PropTypes.shape({}).isRequired,
   functionsStore: PropTypes.shape({}).isRequired,
-  isDemoMode: PropTypes.bool.isRequired,
+  isStagingMode: PropTypes.bool.isRequired,
   sections: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   setValidation: PropTypes.func.isRequired,
   validation: PropTypes.shape({}).isRequired

--- a/src/elements/JobsPanelEnvironmentVariables/JobsPanelEnvironmentVariables.js
+++ b/src/elements/JobsPanelEnvironmentVariables/JobsPanelEnvironmentVariables.js
@@ -9,7 +9,7 @@ import { parseEnvVariables } from '../../utils/parseEnvironmentVariables'
 import { generateEnvVariable } from '../../utils/generateEnvironmentVariable'
 import jobsActions from '../../actions/jobs'
 import KeyValueTable from '../../common/KeyValueTable/KeyValueTable'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import { ENV_VARIABLE_TYPE_VALUE } from '../../constants'
 
 import './jobsPanelEnviromnetVariables.scss'

--- a/src/elements/JobsPanelEnvironmentVariables/JobsPanelEnvironmentVariables.js
+++ b/src/elements/JobsPanelEnvironmentVariables/JobsPanelEnvironmentVariables.js
@@ -9,7 +9,7 @@ import { parseEnvVariables } from '../../utils/parseEnvironmentVariables'
 import { generateEnvVariable } from '../../utils/generateEnvironmentVariable'
 import jobsActions from '../../actions/jobs'
 import KeyValueTable from '../../common/KeyValueTable/KeyValueTable'
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import { ENV_VARIABLE_TYPE_VALUE } from '../../constants'
 
 import './jobsPanelEnviromnetVariables.scss'
@@ -21,11 +21,11 @@ const JobsPanelEnvironmentVariables = ({
   previousPanelEnvData,
   setNewJobEnvironmentVariables
 }) => {
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
 
   const handleAddNewEnv = env => {
     const generatedVariable = generateEnvVariable(
-      isDemoMode
+      isStagingMode
         ? env
         : {
             name: env.key,
@@ -51,7 +51,7 @@ const JobsPanelEnvironmentVariables = ({
   const handleEditEnv = env => {
     let variables = []
 
-    if (isDemoMode) {
+    if (isStagingMode) {
       variables = env.map(item => generateEnvVariable(item))
     } else {
       const parsedEnv = parseEnvVariables(panelEnvData.map(env => env.data))
@@ -81,7 +81,7 @@ const JobsPanelEnvironmentVariables = ({
   const handleDeleteEnv = env => {
     let variables = []
 
-    if (isDemoMode) {
+    if (isStagingMode) {
       variables = env.map(item => generateEnvVariable(item))
     } else {
       const parsedEnv = parseEnvVariables(panelEnvData.map(env => env.data))
@@ -105,7 +105,7 @@ const JobsPanelEnvironmentVariables = ({
 
   return (
     <>
-      {isDemoMode ? (
+      {isStagingMode ? (
         <EnvironmentVariables
           envVariables={parseEnvVariables(panelEnvData.map(env => env.data))}
           handleAddNewEnv={handleAddNewEnv}

--- a/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
+++ b/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
@@ -10,7 +10,7 @@ import Input from '../../common/Input/Input'
 
 import functionsActions from '../../actions/functions'
 import { DEFAULT_RUNTIME, runtimeOptions } from './newFuctionPopUp.util'
-import { useDemoMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/demoMode.hook'
 import { useOpenPanel } from '../../hooks/openPanel.hook'
 import { getValidationRules } from '../../utils/validationService'
 
@@ -37,7 +37,7 @@ const NewFunctionPopUp = ({
     isNameValid: true,
     isTagValid: true
   })
-  const isDemoMode = useDemoMode()
+  const { isStagingMode } = useMode()
   const openPanelByDefault = useOpenPanel()
   const newFunctionBtn = useRef(null)
   const popUpClassNames = classnames(
@@ -148,7 +148,7 @@ const NewFunctionPopUp = ({
             floatingLabel
             label="Runtime"
             onClick={selectRuntime}
-            options={runtimeOptions(isDemoMode)}
+            options={runtimeOptions(isStagingMode)}
             selectedId={data.runtime}
           />
           <div className="pop-up-dialog__footer-container">

--- a/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
+++ b/src/elements/NewFunctionPopUp/NewFunctionPopUp.js
@@ -10,7 +10,7 @@ import Input from '../../common/Input/Input'
 
 import functionsActions from '../../actions/functions'
 import { DEFAULT_RUNTIME, runtimeOptions } from './newFuctionPopUp.util'
-import { useMode } from '../../hooks/demoMode.hook'
+import { useMode } from '../../hooks/mode.hook'
 import { useOpenPanel } from '../../hooks/openPanel.hook'
 import { getValidationRules } from '../../utils/validationService'
 

--- a/src/elements/NewFunctionPopUp/newFuctionPopUp.util.js
+++ b/src/elements/NewFunctionPopUp/newFuctionPopUp.util.js
@@ -1,4 +1,4 @@
-export const runtimeOptions = isDemoMode => [
+export const runtimeOptions = isStagingMode => [
   {
     id: 'job',
     label: 'Job'
@@ -6,7 +6,7 @@ export const runtimeOptions = isDemoMode => [
   {
     id: 'serving',
     label: 'Serving',
-    hidden: !isDemoMode
+    hidden: !isStagingMode
   }
 ]
 

--- a/src/hooks/demoMode.hook.js
+++ b/src/hooks/demoMode.hook.js
@@ -1,15 +1,37 @@
-import { useLocation } from 'react-router-dom'
 import { useLayoutEffect, useState } from 'react'
+import localStorageService from '../utils/localStorageService'
+import { isURLMode } from '../utils/helper'
 
-import { isDemoMode } from '../utils/helper'
+/**
+ * @hook
+ * Returns an appliction `mode` object
+ *
+ * isDemoMode = Not ready for production or testing (Missing UI or BE). shows all the code for staging + demo
+ *
+ * isStagingMode = When ready for testing but not for production. Specific for staging
+ *
+ * @returns {Object} Object
+ *
+ * @example
+ *
+ * { isDemoMode: true | false, isStagingMode: true | false}
+ */
 
-export const useDemoMode = () => {
-  const [isDemo, setIsDemo] = useState(false)
-  const location = useLocation()
+export const useMode = () => {
+  const [mode, setMode] = useState(localStorageService.getStorageValue('mode'))
+  const urlMode = isURLMode(window.location.search)
 
   useLayoutEffect(() => {
-    setIsDemo(isDemoMode(location.search))
-  }, [location.search])
+    if (urlMode) {
+      localStorageService.setStorageValue('mode', urlMode)
+      setMode(urlMode)
+    }
+  }, [urlMode])
 
-  return isDemo
+  return {
+    isDemoMode: mode === 'demo' || false,
+    isStagingMode: mode === 'staging' || mode === 'demo' || false
+  }
 }
+
+// mode = "demo" | "staging"

--- a/src/hooks/mode.hook.js
+++ b/src/hooks/mode.hook.js
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react'
 import localStorageService from '../utils/localStorageService'
-import { isURLMode } from '../utils/helper'
+import { getUrlMode } from '../utils/helper'
 
 /**
  * @hook
@@ -10,27 +10,27 @@ import { isURLMode } from '../utils/helper'
  *
  * isStagingMode = When ready for testing but not for production. Specific for staging
  *
- * @returns {Object} Object
+ * @returns {{isDemoMode: boolean, isStagingMode: boolean}}
  *
  * @example
  *
- * { isDemoMode: true | false, isStagingMode: true | false}
+ * { isDemoMode: boolean, isStagingMode: boolean}
  */
 
 export const useMode = () => {
   const [mode, setMode] = useState(localStorageService.getStorageValue('mode'))
-  const urlMode = isURLMode(window.location.search)
+  const urlMode = getUrlMode(window.location.search)
 
   useLayoutEffect(() => {
     if (urlMode) {
-      localStorageService.setStorageValue('mode', urlMode)
+      localStorageService.setStorageValue('mode', JSON.stringify(urlMode))
       setMode(urlMode)
     }
   }, [urlMode])
 
   return {
-    isDemoMode: mode === 'demo' || false,
-    isStagingMode: mode === 'staging' || mode === 'demo' || false
+    isDemoMode: mode === 'demo',
+    isStagingMode: mode === 'staging' || mode === 'demo'
   }
 }
 

--- a/src/hooks/mode.hook.js
+++ b/src/hooks/mode.hook.js
@@ -14,7 +14,7 @@ import { getUrlMode } from '../utils/helper'
  *
  * @example
  *
- * { isDemoMode: boolean, isStagingMode: boolean}
+ * { isDemoMode: false, isStagingMode: true }
  */
 
 export const useMode = () => {

--- a/src/layout/Page/Page.js
+++ b/src/layout/Page/Page.js
@@ -1,16 +1,11 @@
-import React, { useLayoutEffect, useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-import { useDemoMode } from '../../hooks/demoMode.hook'
 
 import PageView from './PageView'
 import appActions from '../../actions/app'
 
 const Page = ({ children, fetchFrontendSpec, history }) => {
-  const isDemoMode = useDemoMode()
-
-  const [savedDemoMode, setSavedDemoMode] = useState(isDemoMode)
-
   useEffect(() => {
     fetchFrontendSpec()
 
@@ -18,20 +13,6 @@ const Page = ({ children, fetchFrontendSpec, history }) => {
 
     return () => clearInterval(interval)
   }, [fetchFrontendSpec])
-
-  useEffect(() => {
-    if (isDemoMode) {
-      setSavedDemoMode(true)
-    }
-  }, [isDemoMode])
-
-  useLayoutEffect(() => {
-    if (savedDemoMode && !isDemoMode) {
-      history.replace({
-        search: '?demo=true'
-      })
-    }
-  }, [history, isDemoMode, savedDemoMode])
 
   return <PageView>{children}</PageView>
 }

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -17,7 +17,7 @@ const createJobsContent = (
   content,
   isSelectedItem,
   params,
-  isDemoMode,
+  isStagingMode,
   groupedByWorkflow
 ) => {
   return content.map(contentItem => {
@@ -121,7 +121,7 @@ const createJobsContent = (
               ? contentItem.uid || contentItem?.id
               : contentItem.name,
             class: 'jobs_medium',
-            type: type === 'workflow' && !isDemoMode ? 'hidden' : '',
+            type: type === 'workflow' && !isStagingMode ? 'hidden' : '',
             identifier: getJobIdentifier(contentItem),
             identifierUnique: identifierUnique,
             getLink: tab => {

--- a/src/utils/generateTableContent.js
+++ b/src/utils/generateTableContent.js
@@ -29,7 +29,7 @@ export const generateTableContent = (
   page,
   isTablePanelOpen,
   params,
-  isDemoMode,
+  isStagingMode,
   isSelectedItem
 ) => {
   if (
@@ -42,7 +42,7 @@ export const generateTableContent = (
             group,
             isSelectedItem,
             params,
-            isDemoMode,
+            isStagingMode,
             groupFilter === GROUP_BY_WORKFLOW
           )
         : page === FUNCTIONS_PAGE ||
@@ -70,7 +70,7 @@ export const generateTableContent = (
       : page === CONSUMER_GROUPS_PAGE
       ? createConsumerGroupsContent(content, params)
       : page === JOBS_PAGE
-      ? createJobsContent(content, isSelectedItem, params, isDemoMode, false)
+      ? createJobsContent(content, isSelectedItem, params, isStagingMode, false)
       : page === ARTIFACTS_PAGE ||
         page === FILES_PAGE ||
         page === DATASETS_PAGE ||

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -2,7 +2,7 @@ export const isDemoMode = search => {
   return new URLSearchParams(search).get('demo')?.toLowerCase() === 'true'
 }
 
-export const isURLMode = search => {
+export const getUrlMode = search => {
   return new URLSearchParams(search).get('mode')?.toLowerCase()
 }
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -2,6 +2,10 @@ export const isDemoMode = search => {
   return new URLSearchParams(search).get('demo')?.toLowerCase() === 'true'
 }
 
+export const isURLMode = search => {
+  return new URLSearchParams(search).get('mode')?.toLowerCase()
+}
+
 export const isPanelOpened = search => {
   return new URLSearchParams(search).get('openPanel')?.toLowerCase() === 'true'
 }

--- a/src/utils/localStorageService.js
+++ b/src/utils/localStorageService.js
@@ -7,7 +7,7 @@ const getStorageValue = (key, defaultValue) => {
 }
 
 const setStorageValue = (key, defaultValue) => {
-  localStorage.setItem(key, JSON.stringify(defaultValue))
+  localStorage.setItem(key, defaultValue)
 }
 
 export default {

--- a/src/utils/localStorageService.js
+++ b/src/utils/localStorageService.js
@@ -7,7 +7,7 @@ const getStorageValue = (key, defaultValue) => {
 }
 
 const setStorageValue = (key, defaultValue) => {
-  localStorage.setItem(key, defaultValue)
+  localStorage.setItem(key, JSON.stringify(defaultValue))
 }
 
 export default {

--- a/src/utils/parseUri.js
+++ b/src/utils/parseUri.js
@@ -1,3 +1,11 @@
+import {
+  DATASETS,
+  FEATURE_SETS_TAB,
+  FEATURE_VECTORS_TAB,
+  MODELS_TAB,
+  MONITOR_JOBS_TAB
+} from '../constants'
+
 /**
  * Parses a URI of MLRun store and returns an object with the different URI parts, all as strings.
  * `kind` should be one of: `'artifacts'`, `'models'`, `'datasets'`, `'feature-vectors'`, `'feature-sets'`, `'jobs'` or `'functions'`.
@@ -48,13 +56,6 @@
  *         tag:       undefined,
  *         uid:       '24fce79e709f9b3fe5e8251a39e67c678d94c20c' }
  */
-import {
-  DATASETS,
-  FEATURE_SETS_TAB,
-  FEATURE_VECTORS_TAB,
-  MODELS_TAB,
-  MONITOR_JOBS_TAB
-} from '../constants'
 
 const parseUri = uri =>
   (uri ?? '').match(
@@ -70,6 +71,7 @@ const kindToScreen = {
   jobs: `jobs/${MONITOR_JOBS_TAB}`,
   models: `models/${MODELS_TAB}`
 }
+
 const generateLinkPath = (uri = '') => {
   const { kind, project, key, tag, uid } = parseUri(uri)
   const screen = kindToScreen[kind] ?? 'files'

--- a/tests/features/step-definitions/steps.js
+++ b/tests/features/step-definitions/steps.js
@@ -84,7 +84,7 @@ Given('open url', async function() {
 
 When('turn on demo mode', async function() {
   const url = await this.driver.getCurrentUrl()
-  await navigateToPage(this.driver, `${url}?demo=true`)
+  await navigateToPage(this.driver, `${url}?demo=true`) // TODO: Logic changed. by localStorage (key:"mode", value: "demo" | "staging") and not params
 })
 
 Then('additionally redirect by INVALID-TAB', async function() {

--- a/tests/features/step-definitions/steps.js
+++ b/tests/features/step-definitions/steps.js
@@ -82,9 +82,24 @@ Given('open url', async function() {
   await navigateToPage(this.driver, `http://${test_url}:${test_port}`)
 })
 
+/*
+   Changes Log:
+  turning on demo mode by URL param check of `demo=true` has been deprecated.
+
+  Now: `demo` flag replaced with `mode` flag that can be set with either 2 modes
+  - `mode=demo` = Not ready for production or testing (Missing UI or BE). shows all the code for staging + demo
+  - `mode=staging` = When ready for testing but not for production. Specific for staging
+  once `mode` flag (URL param) is passed, it is saved to localStorage and check is done NOW by localStorage `mode` value
+
+  ** TODO **
+  1. Change `demo=true` to `mode=demo` in 'turn on demo mode' test case and adjust test cases
+  2. Create another test cases for "turn on staging mode" with `mode=staging`
+
+*/
+
 When('turn on demo mode', async function() {
   const url = await this.driver.getCurrentUrl()
-  await navigateToPage(this.driver, `${url}?demo=true`) // TODO: Logic changed. by localStorage (key:"mode", value: "demo" | "staging") and not params
+  await navigateToPage(this.driver, `${url}?demo=true`) // TODO: see above
 })
 
 Then('additionally redirect by INVALID-TAB', async function() {


### PR DESCRIPTION
-  **UI**: Replacing test by "demo=true" to "mode" demo | staging
   Jira: [ML-1963](https://jira.iguazeng.com/browse/ML-1963) 

    When a feature is still being developed and not ready for production is is hidden behind a flag.
    In order to show the feature, for demo purposes, `demo=true` URL param is passed.

    **Old Usage**:
    `?demo=true`
     - User sets `demo=true" as a url param / query string
     - JS is showing components by checking if url demo=true flag exists 
 
     Drawback: Requires setting multiple times. MLRun is losing `demo=true` param while navigating in dashboard (Iguazio app), therefore requiring setting it again while navigating back to MLRun (Projects).

    **Current Usage**:
    set query string:
    `?mode=demo` OR `?mode=staging`
        - `mode=demo` = Not ready for production or testing (Missing UI or BE). shows all the code for staging + demo.
        - `mode=staging` = When ready for testing but not for production. Specific for staging.

    - User sets `mode` query string
    - The mode is saved to localStorage as key=mode value="demo" or "staging"
    - JS is showing components by checking localStorage
  
   Advantage: Requires setting once. The `mode` will stay persistent even when losing the URL param `mode`.
     ![image](https://user-images.githubusercontent.com/63646693/160782338-e45561b6-4849-4509-ae7e-782035ca7bda.png)
     ![image](https://user-images.githubusercontent.com/63646693/160782355-6ee16c67-f5e3-4f06-8647-6179e9639c3a.png)

   In order to exit the mode and view the app without a flag, Either delete `mode` key from localStorage or by typing in the 
  URL
   `?mode=""`
   <img width="207" alt="Screen Shot 2022-03-30 at 11 04 28" src="https://user-images.githubusercontent.com/63646693/160782594-bb0d7799-0122-41d7-a3ca-cb0a110df3a1.png">


 
   
