### PR TITLE
Fix [MLRun] Pod priority UI values

### DIFF
--- a/src/common/Select/Select.js
+++ b/src/common/Select/Select.js
@@ -29,7 +29,8 @@ const Select = ({
   selectType,
   selectedId,
   selectedItemAction,
-  withoutBorder
+  withoutBorder,
+  withSelectedIcon
 }) => {
   const selectRef = useRef()
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
@@ -222,6 +223,7 @@ const Select = ({
                     }}
                     selectType={selectType}
                     selectedId={selectedId}
+                    withSelectedIcon={withSelectedIcon}
                   />
                 )
               })}
@@ -243,7 +245,8 @@ Select.defaultProps = {
   search: false,
   selectType: '',
   selectedId: '',
-  withoutBorder: false
+  withoutBorder: false,
+  withSelectedIcon: false
 }
 
 Select.propTypes = {
@@ -259,7 +262,8 @@ Select.propTypes = {
   search: PropTypes.bool,
   selectType: PropTypes.string,
   selectedId: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  withoutBorder: PropTypes.bool
+  withoutBorder: PropTypes.bool,
+  withSelectedIcon: PropTypes.bool
 }
 
 export default React.memo(Select)

--- a/src/components/JobsPanelResources/JobsPanelResources.js
+++ b/src/components/JobsPanelResources/JobsPanelResources.js
@@ -9,6 +9,7 @@ import {
   generateCpuValue,
   generateMemoryValue
 } from '../../utils/panelResources.util'
+import { parseFunctionPriorityLabel } from '../../utils/parseFunctionPriorityLabel'
 import { setRangeInputValidation } from './jobsPanelResources.util'
 import jobsActions from '../../actions/jobs'
 
@@ -27,7 +28,7 @@ const JobsPanelResources = ({
     return (frontendSpec.valid_function_priority_class_names ?? []).map(
       className => ({
         id: className,
-        label: className
+        label: parseFunctionPriorityLabel(className)
       })
     )
   }, [frontendSpec.valid_function_priority_class_names])

--- a/src/components/JobsPanelResources/JobsPanelResources.js
+++ b/src/components/JobsPanelResources/JobsPanelResources.js
@@ -9,7 +9,7 @@ import {
   generateCpuValue,
   generateMemoryValue
 } from '../../utils/panelResources.util'
-import { parseFunctionPriorityLabel } from '../../utils/parseFunctionPriorityLabel'
+import { generateFunctionPriorityLabel } from '../../utils/generateFunctionPriorityLabel'
 import { setRangeInputValidation } from './jobsPanelResources.util'
 import jobsActions from '../../actions/jobs'
 
@@ -28,7 +28,7 @@ const JobsPanelResources = ({
     return (frontendSpec.valid_function_priority_class_names ?? []).map(
       className => ({
         id: className,
-        label: parseFunctionPriorityLabel(className)
+        label: generateFunctionPriorityLabel(className)
       })
     )
   }, [frontendSpec.valid_function_priority_class_names])

--- a/src/components/JobsPanelResources/JobsPanelResourcesView.js
+++ b/src/components/JobsPanelResources/JobsPanelResourcesView.js
@@ -34,6 +34,7 @@ const JobsPanelResourcesView = ({
             onClick={setPriorityClassName}
             options={validFunctionPriorityClassNames}
             selectedId={panelState.priority_class_name}
+            withSelectedIcon
           />
         </JobsPanelSection>
       )}

--- a/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
+++ b/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
@@ -14,6 +14,7 @@ import {
   VOLUME_MOUNT_AUTO_TYPE,
   VOLUME_MOUNT_NONE_TYPE
 } from './functionsPanelResources.util'
+import { parseFunctionPriorityLabel } from '../../utils/parseFunctionPriorityLabel'
 import { FUNCTION_PANEL_MODE } from '../../types'
 import { PANEL_CREATE_MODE } from '../../constants'
 
@@ -86,7 +87,7 @@ const FunctionsPanelResources = ({
     return (frontendSpec.valid_function_priority_class_names ?? []).map(
       className => ({
         id: className,
-        label: className
+        label: parseFunctionPriorityLabel(className)
       })
     )
   }, [frontendSpec.valid_function_priority_class_names])

--- a/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
+++ b/src/elements/FunctionsPanelResources/FunctionsPanelResources.js
@@ -14,7 +14,7 @@ import {
   VOLUME_MOUNT_AUTO_TYPE,
   VOLUME_MOUNT_NONE_TYPE
 } from './functionsPanelResources.util'
-import { parseFunctionPriorityLabel } from '../../utils/parseFunctionPriorityLabel'
+import { generateFunctionPriorityLabel } from '../../utils/generateFunctionPriorityLabel'
 import { FUNCTION_PANEL_MODE } from '../../types'
 import { PANEL_CREATE_MODE } from '../../constants'
 
@@ -87,7 +87,7 @@ const FunctionsPanelResources = ({
     return (frontendSpec.valid_function_priority_class_names ?? []).map(
       className => ({
         id: className,
-        label: parseFunctionPriorityLabel(className)
+        label: generateFunctionPriorityLabel(className)
       })
     )
   }, [frontendSpec.valid_function_priority_class_names])

--- a/src/elements/FunctionsPanelResources/FunctionsPanelResourcesView.js
+++ b/src/elements/FunctionsPanelResources/FunctionsPanelResourcesView.js
@@ -49,6 +49,7 @@ const FunctionsPanelResourcesView = ({
             onClick={selectPodsPriorityClassName}
             options={validFunctionPriorityClassNames}
             selectedId={podsPriorityClassName}
+            withSelectedIcon
           />
         </FunctionsPanelSection>
       )}

--- a/src/utils/generateFunctionPriorityLabel.js
+++ b/src/utils/generateFunctionPriorityLabel.js
@@ -1,0 +1,6 @@
+import { capitalize } from 'lodash'
+
+export const generateFunctionPriorityLabel = id => {
+  let labelName = id.split('-').pop()
+  return capitalize(labelName)
+}

--- a/src/utils/parseFunctionPriorityLabel.js
+++ b/src/utils/parseFunctionPriorityLabel.js
@@ -1,4 +1,0 @@
-export const parseFunctionPriorityLabel = id => {
-  let labelName = id.split('-').pop()
-  return labelName.charAt(0).toUpperCase() + labelName.slice(1)
-}

--- a/src/utils/parseFunctionPriorityLabel.js
+++ b/src/utils/parseFunctionPriorityLabel.js
@@ -1,0 +1,4 @@
+export const parseFunctionPriorityLabel = id => {
+  let labelName = id.split('-').pop()
+  return labelName.charAt(0).toUpperCase() + labelName.slice(1)
+}


### PR DESCRIPTION
- **MLRun** Pod priority UI values
  The pod priority values in UI should be changed to [Low, Medium, Hight]  instead of [`igz-workload-high', ..]
  Fix Includes: 
   - Jobs and workflows => New Job
   - ML functions => New Job/Serving
  
   Jira: [ML-1966](https://jira.iguazeng.com/browse/ML-1966)

   Before: 
   <img width="363" alt="Screen Shot 2022-04-10 at 13 08 33" src="https://user-images.githubusercontent.com/63646693/162613220-11820c09-6f7b-420e-a6bd-84080cc1215f.png">

   After:
   <img width="351" alt="Screen Shot 2022-04-10 at 13 09 02" src="https://user-images.githubusercontent.com/63646693/162613239-74464cbc-7564-418a-b539-7cd6b51b3398.png">
 