### PR TITLE
Fix [Consumer groups] No data in consumer group report due to wrong API request

### DIFF
--- a/src/utils/createConsumerGroupsContent.js
+++ b/src/utils/createConsumerGroupsContent.js
@@ -18,7 +18,7 @@ const createConsumerGroupsContent = (content, params) => {
         },
         streamPath: {
           id: `streamPath.${identifier}`,
-          value: contentItem?.streamPath,
+          value: contentItem?.containerName + contentItem?.streamPath,
           class: 'table-cell-1'
         },
         realTimeFunction: {

--- a/src/utils/parseV3ioStreams.js
+++ b/src/utils/parseV3ioStreams.js
@@ -11,7 +11,7 @@ export const parseV3ioStreams = consumerGroups => {
 
     return {
       ...consumerGroupData,
-      streamPath: consumerGroupData.containerName + streamPath,
+      streamPath,
       functionName,
       streamName,
       ui: {


### PR DESCRIPTION
- **Consumer groups**: No data in consumer group report due to wrong API request
   related To: #1191 
   Jira: [ML-2060](https://jira.iguazeng.com/browse/ML-2060)
   
   Before:
   ![image](https://user-images.githubusercontent.com/63646693/162946457-0411a3d1-2d33-4521-8a85-bbcb0d427795.png)
   
   After:
   <img width="1108" alt="Screen Shot 2022-04-12 at 14 04 24" src="https://user-images.githubusercontent.com/63646693/162946563-3400b2b8-d8f7-4d86-a638-d50cf07d2a5b.png">

