### PR TITLE
Fix [Consumer groups] Consumer Group search should be insensitive

### DIFF
--- a/src/components/ConsumerGroup/ConsumerGroup.js
+++ b/src/components/ConsumerGroup/ConsumerGroup.js
@@ -117,7 +117,7 @@ const ConsumerGroup = ({
       <div className="page-actions">
         <Search
           wrapperClassName="search-input-wrapper"
-          onChange={setFilterByName}
+          onChange={searchTerm => setFilterByName(searchTerm.toLowerCase())}
           placeholder="Search by shard name..."
           value={filterByName}
         />

--- a/src/components/ConsumerGroups/ConsumerGroups.js
+++ b/src/components/ConsumerGroups/ConsumerGroups.js
@@ -57,7 +57,7 @@ const ConsumerGroups = ({ match, nuclioStore, setFilters }) => {
       <div className="page-actions">
         <Search
           wrapperClassName="search-input-wrapper"
-          onChange={setFilterByName}
+          onChange={searchTerm => setFilterByName(searchTerm.toLowerCase())}
           placeholder="Search consumer groups..."
           value={filterByName}
         />


### PR DESCRIPTION
- **Consumer groups**: Consumer Group search should be insensitive
   Jira: [ML-2078](https://jira.iguazeng.com/browse/ML-2078)
   
   Before:
   ![image](https://user-images.githubusercontent.com/63646693/163347185-f7f4950e-7201-4301-8d0a-a804ffca0176.png)
   
   After:
   <img width="1510" alt="Screen Shot 2022-04-14 at 11 37 16" src="https://user-images.githubusercontent.com/63646693/163347308-924cdacc-e8dd-4766-95d8-3b606d8cdd50.png">

