### PR TITLE
Fix [UI] Table row - Keep 3 dots Icon visible while menu is open

### DIFF
--- a/src/common/ActionsMenu/ActionsMenu.js
+++ b/src/common/ActionsMenu/ActionsMenu.js
@@ -20,6 +20,11 @@ const ActionsMenu = ({ dataItem, menu, time }) => {
   const [renderMenu, setRenderMenu] = useState(false)
   const actionMenuRef = useRef()
   const dropDownMenuRef = useRef()
+
+  const actionMenuClassNames = classnames(
+    'actions-menu__container',
+    isShowMenu && 'actions-menu__container-active'
+  )
   const dropDownMenuClassNames = classnames(
     'actions-menu__body',
     isShowMenu && 'show'
@@ -61,7 +66,7 @@ const ActionsMenu = ({ dataItem, menu, time }) => {
     }
   }
 
-  const handleMouseLeave = () => {
+  const onMouseOut = () => {
     if (isShowMenu) {
       idTimeout = setTimeout(() => {
         setIsShowMenu(false)
@@ -90,12 +95,12 @@ const ActionsMenu = ({ dataItem, menu, time }) => {
 
   return (
     <div
-      className="actions-menu__container"
-      onMouseLeave={handleMouseLeave}
+      className={actionMenuClassNames}
+      onMouseOut={onMouseOut}
       onMouseOver={handleMouseOver}
       ref={actionMenuRef}
     >
-      <RoundedIcon onClick={showActionsList}>
+      <RoundedIcon isActive={isShowMenu} onClick={showActionsList}>
         <ActionMenuIcon />
       </RoundedIcon>
 

--- a/src/common/ActionsMenu/actionsMenu.scss
+++ b/src/common/ActionsMenu/actionsMenu.scss
@@ -6,6 +6,10 @@
   &__container {
     position: relative;
     display: none;
+
+    &-active {
+      display: block;
+    }
   }
 
   &__body {

--- a/src/common/RoundedIcon/RoundedIcon.js
+++ b/src/common/RoundedIcon/RoundedIcon.js
@@ -8,8 +8,15 @@ import TextTooltipTemplate from '../../elements/TooltipTemplate/TextTooltipTempl
 import './roundedIcon.scss'
 
 const RoundedIcon = React.forwardRef(
-  ({ children, className, disabled, id, onClick, tooltipText }, ref) => {
+  (
+    { children, className, disabled, id, isActive, onClick, tooltipText },
+    ref
+  ) => {
     const wrapperClassNames = classNames('round-icon-cp', className)
+    const IconClassNames = classNames(
+      'round-icon-cp__circle',
+      isActive && 'round-icon-cp__circle-active'
+    )
 
     return (
       <div className={wrapperClassNames} ref={ref}>
@@ -21,7 +28,7 @@ const RoundedIcon = React.forwardRef(
             onClick={onClick}
             disabled={disabled}
             id={id}
-            className="round-icon-cp__circle"
+            className={IconClassNames}
           >
             {children}
           </button>
@@ -35,6 +42,7 @@ RoundedIcon.defaultProps = {
   className: '',
   disabled: false,
   id: '',
+  isActive: false,
   onClick: () => {},
   tooltipText: ''
 }
@@ -44,6 +52,7 @@ RoundedIcon.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string,
+  isActive: PropTypes.bool,
   onClick: PropTypes.func,
   tooltipText: PropTypes.string
 }

--- a/src/common/RoundedIcon/roundedIcon.scss
+++ b/src/common/RoundedIcon/roundedIcon.scss
@@ -35,7 +35,8 @@
       content: '';
     }
 
-    &:hover {
+    &:hover,
+    &-active {
       &::before {
         opacity: 1;
       }


### PR DESCRIPTION
- **UI**: Table row - Keep 3 dots Icon visible while menu is open
   Jira: [ML-2082](https://jira.iguazeng.com/browse/ML-2082)
   
   Before:
    <img width="298" alt="Screen Shot 2022-04-14 at 16 21 35" src="https://user-images.githubusercontent.com/63646693/163399601-3763a9d6-a97b-448a-94bc-9f4f2d495a2f.png">
   
   After:
   <img width="326" alt="Screen Shot 2022-04-14 at 16 21 44" src="https://user-images.githubusercontent.com/63646693/163399634-57974bff-3deb-467e-b928-ea03d4574d84.png">
 