### PR TITLE
Fix [Functions] `MLRunAccessDeniedError` for creating ML Function by user where user is member with viewer role

### DIFF
--- a/src/actions/featureStore.js
+++ b/src/actions/featureStore.js
@@ -77,7 +77,7 @@ const featureStoreActions = {
           error.response.status === CONFLICT_CODE
             ? 'Adding an already-existing FeatureSet'
             : error.response.status === STATUS_CODE_FORBIDDEN
-            ? 'You are not permitted to create new feature set'
+            ? 'You are not permitted to create new feature set.'
             : error.message
 
         dispatch(featureStoreActions.createNewFeatureSetFailure(message))

--- a/src/actions/functions.js
+++ b/src/actions/functions.js
@@ -57,7 +57,8 @@ import {
   REMOVE_FUNCTION,
   SET_NEW_FUNCTION_FORCE_BUILD,
   SET_NEW_FUNCTION_PREEMTION_MODE,
-  SET_NEW_FUNCTION_PRIORITY_CLASS_NAME
+  SET_NEW_FUNCTION_PRIORITY_CLASS_NAME,
+  STATUS_CODE_FORBIDDEN
 } from '../constants'
 import { generateCategories } from '../utils/generateTemplatesCategories'
 
@@ -73,7 +74,12 @@ const functionsActions = {
         return result
       })
       .catch(error => {
-        dispatch(functionsActions.createNewFunctionFailure(error.message))
+        const message =
+          error.response.status === STATUS_CODE_FORBIDDEN
+            ? 'You are not permitted to create new function.'
+            : error.message
+
+        dispatch(functionsActions.createNewFunctionFailure(message))
 
         throw error
       })
@@ -233,7 +239,6 @@ const functionsActions = {
         return result.data.func
       })
       .catch(error => {
-        dispatch(functionsActions.getFunctionFailure(error.message))
         throw error
       })
   },

--- a/src/actions/jobs.js
+++ b/src/actions/jobs.js
@@ -265,7 +265,7 @@ const jobsActions = {
         dispatch(
           jobsActions.runNewJobFailure(
             error.response.status === STATUS_CODE_FORBIDDEN
-              ? 'You are not permitted to run new job'
+              ? 'You are not permitted to run new job.'
               : error.message
           )
         )

--- a/src/components/Jobs/Jobs.js
+++ b/src/components/Jobs/Jobs.js
@@ -687,7 +687,7 @@ const Jobs = ({
         dispatch(
           editJobFailure(
             error.response.status === STATUS_CODE_FORBIDDEN
-              ? 'You are not permitted to run new job'
+              ? 'You are not permitted to run new job.'
               : error.message
           )
         )


### PR DESCRIPTION
- **Functions**: `MLRunAccessDeniedError` for creating ML Function by user where user is member with viewer role
   Jira: https://jira.iguazeng.com/browse/ML-2085

   Before:
   ![image](https://user-images.githubusercontent.com/90618337/163422830-4cddff11-d42d-4a34-b64b-b31bd2aece04.png)

   After:
   ![image](https://user-images.githubusercontent.com/90618337/163422780-73e1cff6-72ab-4f0b-a8d6-571c8c8d9441.png)
