### PR TITLE
Fix [Consumer group] drill down text when 0 streams

### DIFF
--- a/src/components/ConsumerGroups/ConsumerGroups.js
+++ b/src/components/ConsumerGroups/ConsumerGroups.js
@@ -12,7 +12,6 @@ import filtersActions from '../../actions/filters'
 import nuclioActions from '../../actions/nuclio'
 import { GROUP_BY_NONE } from '../../constants'
 import { generatePageData } from './consumerGroups.util.js'
-import { getNoDataMessage } from '../../layout/Content/content.util'
 
 const ConsumerGroups = ({ match, nuclioStore, setFilters }) => {
   const [filteredV3ioStreams, setFilteredV3ioStreams] = useState([])
@@ -55,7 +54,7 @@ const ConsumerGroups = ({ match, nuclioStore, setFilters }) => {
       />
       {!nuclioStore.v3ioStreams.loading &&
         nuclioStore.v3ioStreams.parsedData.length === 0 && (
-          <NoData message={getNoDataMessage()} />
+          <NoData message="You haven’t created any consumer group yet" />
         )}
       {nuclioStore.v3ioStreams.loading && <Loader />}
     </>


### PR DESCRIPTION
- **Consumer group** drill down text when 0 streams
   Jira: [ML-2101](https://jira.iguazeng.com/browse/ML-2101)
   
   Before:
   <img width="1457" alt="Screen Shot 2022-04-17 at 16 31 04" src="https://user-images.githubusercontent.com/63646693/163716536-ef607c60-2921-4a2b-9a24-60aab28680f0.png">
   
   After:
   ![image](https://user-images.githubusercontent.com/63646693/163716555-b6a5a171-cc73-4bc9-837c-61d9dc2f8d57.png)

 