### PR TITLE
Fix [UI] Projects summaries show N/A in environment without Nuclio

### DIFF
--- a/src/components/Project/ProjectMonitorView.js
+++ b/src/components/Project/ProjectMonitorView.js
@@ -157,7 +157,11 @@ const ProjectMonitorView = ({
               />
               {nuclioStreamsAreEnabled && (
                 <ProjectSummaryCard
-                  counterValue={Object.keys(v3ioStreams.data).length || 'N/A'}
+                  counterValue={
+                    isNuclioModeDisabled
+                      ? 'N/A'
+                      : Object.keys(v3ioStreams.data).length ?? 0
+                  }
                   link={`/projects/${match.params.projectName}/monitor${
                     !isNuclioModeDisabled ? '/consumer-groups' : ''
                   }`}

--- a/src/elements/ProjectSummaryCard/ProjectSummaryCard.js
+++ b/src/elements/ProjectSummaryCard/ProjectSummaryCard.js
@@ -46,7 +46,8 @@ ProjectSummaryCard.defaultProps = {
 }
 
 ProjectSummaryCard.propTypes = {
-  counterValue: PropTypes.number.isRequired,
+  counterValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
   link: PropTypes.string.isRequired,
   projectSummary: PropTypes.object.isRequired,
   title: PropTypes.string.isRequired,


### PR DESCRIPTION
- **UI** Projects summaries show N/A in environment without Nuclio
   Related To: #1223 
   Jira: https://jira.iguazeng.com/browse/ML-2106