### PR TITLE
Fix [General] Projects screen is empty - 'SyntaxError: Unexpected token '<' (at main.d5697fce.js:1:1)'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM quay.io/mlrun/node:12-alpine as build-stage
+FROM quay.io/mlrun/node:14.18.1-alpine as build-stage
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mlrun.ui",
   "version": "1.0.0",
   "private": true,
-  "homepage": "/",
+  "homepage": "/mlrun",
   "dependencies": {
     "@monaco-editor/react": "^4.1.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,6 +3,7 @@
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
 process.env.NODE_ENV = 'development';
+process.env.PUBLIC_URL = '/';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
- **General**: Projects screen is empty - 'SyntaxError: Unexpected token '<' (at main.d5697fce.js:1:1)'
   Jira: https://jira.iguazeng.com/browse/ML-2156
   Before:
   ![image](https://user-images.githubusercontent.com/74406479/167605227-69381928-96f2-44e2-b1e3-732e0caf3a91.png)
   
   After:
   <img width="1690" alt="Screen Shot 2022-05-10 at 13 41 42" src="https://user-images.githubusercontent.com/63646693/167610887-dbfdf7ef-59e6-4ef0-8111-c28e8f01dcc6.png">


   
