### PR TITLE
Fix [Consumer Groups] Filter by name should be case insensitive

### DIFF
--- a/src/components/ConsumerGroup/ConsumerGroup.js
+++ b/src/components/ConsumerGroup/ConsumerGroup.js
@@ -66,7 +66,7 @@ const ConsumerGroup = ({
   useEffect(() => {
     setFilteredV3ioStreamShardLags(
       nuclioStore.v3ioStreamShardLags.parsedData.filter(shardLag =>
-        filterByName ? shardLag.shardLagId.includes(filterByName) : true
+        filterByName ? shardLag.shardLagId.toLowerCase().includes(filterByName) : true
       )
     )
   }, [nuclioStore.v3ioStreamShardLags.parsedData, filterByName])

--- a/src/components/ConsumerGroups/ConsumerGroups.js
+++ b/src/components/ConsumerGroups/ConsumerGroups.js
@@ -25,7 +25,7 @@ const ConsumerGroups = ({ nuclioStore, setFilters }) => {
   useEffect(() => {
     setFilteredV3ioStreams(
       nuclioStore.v3ioStreams.parsedData.filter(v3ioStremData =>
-        filterByName ? v3ioStremData.consumerGroup.includes(filterByName) : true
+        filterByName ? v3ioStremData.consumerGroup.toLowerCase().includes(filterByName) : true
       )
     )
   }, [nuclioStore.v3ioStreams.parsedData, filterByName])


### PR DESCRIPTION
- **Consumer Groups**: Filter by name should be case insensitive
   Jira: https://jira.iguazeng.com/browse/ML-2176
   Before:
   ![image](https://user-images.githubusercontent.com/90618337/168111316-6c9c0676-d1fb-4f4d-9812-5908a616dd54.png)

   After:
   ![image](https://user-images.githubusercontent.com/90618337/168111255-b40dd813-b339-4532-ad76-fe2a0d5d221a.png)
