### PR TITLE
Fix [Models] No data for Model framework in the Model overview screen

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -26,7 +26,7 @@ import {
   FEATURE_VECTORS_TAB,
   FILES_PAGE,
   MODEL_ENDPOINTS_TAB,
-  MODELS_PAGE
+  MODELS_TAB
 } from '../../constants'
 import { formatDatetime, generateLinkPath } from '../../utils'
 
@@ -129,7 +129,7 @@ export const generateArtifactsContent = (detailsType, selectedItem) => {
         value: formatDatetime(new Date(selectedItem.updated), 'N/A')
       },
       framework: {
-        value: detailsType === MODELS_PAGE ? selectedItem.framework ?? '' : null
+        value: detailsType === MODELS_TAB ? selectedItem.framework ?? '' : null
       },
       algorithm: {
         value: selectedItem.algorithm


### PR DESCRIPTION
- **Models**: No data for Model framework in the Model overview screen
   Jira: https://jira.iguazeng.com/browse/ML-2193
   Before:
   ![image](https://user-images.githubusercontent.com/90618337/168793997-bb8c07c6-8798-425a-81b7-b0a20363cfe9.png)

   After:
   ![image](https://user-images.githubusercontent.com/90618337/168793920-edf70917-0bfd-46f2-82b9-5e9be53c70f1.png)
