### PR TITLE
Fix [Project settings] scrolling should be inside suggestion list in 'Invite new members' screen

### DIFF
--- a/src/common/ChipInput/chipInput.scss
+++ b/src/common/ChipInput/chipInput.scss
@@ -16,11 +16,14 @@
   .suggestion-list {
     position: absolute;
     top: calc(100% + 5px);
+    left: 0;
     z-index: 5;
     width: 100%;
     background-color: $white;
     border: $primaryBorder;
     border-radius: $mainBorderRadius;
+    max-height: 200px;
+    overflow-y: auto;
 
     .suggestion-row {
       display: flex;


### PR DESCRIPTION
- **Project settings**: scrolling should be inside suggestion list in 'Invite new members' screen
   Jira: [ML-2235](https://jira.iguazeng.com/browse/ML-2235)
   Before:
   <img width="548" alt="Screen Shot 2022-05-30 at 13 06 58" src="https://user-images.githubusercontent.com/63646693/170969810-857b02e0-4f07-46f9-ae58-f5fb8ab2813c.png">

   After: 
   <img width="478" alt="Screen Shot 2022-05-30 at 13 07 28" src="https://user-images.githubusercontent.com/63646693/170969932-6790034a-867b-430e-aa2d-61ea736f8197.png">


   