### PR TITLE
Fix [Models] Wrong naming convention for Model URI in overview screen

### DIFF
--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -22,11 +22,15 @@ export const generateUri = (item, tab) => {
 }
 
 export const getArtifactReference = item => {
-  let reference = ''
+  let reference = `#${item.iter || 0}`
 
-  if (!isNil(item.iter)) reference += `#${item.iter}`
-  if (!isNil(item.tag)) reference += `:${item.tag}`
-  if (!isNil(item.tree)) reference += `@${item.tree}`
+  if (!isNil(item.tag)) {
+    reference += `:${item.tag}`
+  } else if (!isNil(item.tree)) {
+    reference += `@${item.tree}`
+  } else {
+    reference += ':latest'
+  }
 
   return reference
 }


### PR DESCRIPTION
- **Models**: Wrong naming convention for Model URI in overview screen
   Jira: https://jira.iguazeng.com/browse/ML-2242
   Before:
   ![image](https://user-images.githubusercontent.com/90618337/171805432-f587f645-d409-4f80-b6aa-c676a4d4061d.png)
   
   After:
   ![image](https://user-images.githubusercontent.com/90618337/171805499-7d1975cd-1f44-44f2-bc9e-bde2bca7c065.png)