### PR TITLE
Fix [ChipCell] prevent component re-render on tabs hover

### DIFF
--- a/src/layout/Page/PageView.js
+++ b/src/layout/Page/PageView.js
@@ -28,7 +28,8 @@ export default function PageView() {
 
   useEffect(() => {
     if (mainRef) {
-      mainRef.current.addEventListener(transitionEndEventName, () => {
+      mainRef.current.addEventListener(transitionEndEventName, event => {
+        if (event.target !== mainRef.current) return
         window.dispatchEvent(new CustomEvent('mainResize'))
       })
     }


### PR DESCRIPTION
- **ChipCell**: prevent component re-render on tabs hover
   In Jobs ==> Monitor Jobs: Hover on `Tabs` or `Breadcrumbs`, the `mainResize` event is fired causing the `ChipCell` component to re-render 