### PR TITLE
Fix [Jobs] Run now button looks like drop down

### DIFF
--- a/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
+++ b/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
@@ -20,7 +20,7 @@ import { createJobsScheduleTabContent } from '../../../utils/createJobsContent'
 import { scheduledJobsActionCreator } from './scheduledJobs.util'
 
 import { ReactComponent as Yaml } from 'igz-controls/images/yaml.svg'
-import { ReactComponent as Dropdown } from 'igz-controls/images/dropdown.svg'
+import { ReactComponent as Run } from 'igz-controls/images/run.svg'
 import { ReactComponent as Edit } from 'igz-controls/images/edit.svg'
 import { ReactComponent as Delete } from 'igz-controls/images/delete.svg'
 
@@ -217,7 +217,7 @@ const ScheduledJobs = ({
     return job => [
       {
         label: 'Run now',
-        icon: <Dropdown className="action_cell__run-icon" />,
+        icon: <Run className="action_cell__run-icon" />,
         onClick: handleRunJob
       },
       {


### PR DESCRIPTION
- **Jobs**: Run now button looks like drop down
   Jira: [ML-2285](https://jira.iguazeng.com/browse/ML-2285)
   Before:
   ![Screen Shot 2022-06-13 at 11 17 04](https://user-images.githubusercontent.com/63646693/173310212-623ea955-01d4-4f91-84eb-2d624a087f85.png)
   
   After:
   ![Screen Shot 2022-06-13 at 11 17 29](https://user-images.githubusercontent.com/63646693/173310291-0c065507-0a07-417c-ab81-ea60d18a5d77.png)


   

   