### PR TITLE
Fix [Models] Downloaded model file from "Project-> models" has base64 format instead of pkl

### DIFF
--- a/src/common/Download/Download.js
+++ b/src/common/Download/Download.js
@@ -65,7 +65,8 @@ const Download = ({ fileName, path, setNotification, user }) => {
         cancelToken: new axios.CancelToken(cancel => {
           downloadRef.current.cancel = cancel
         }),
-        params: { path }
+        params: { path },
+        responseType: 'arraybuffer'
       }
 
       if (path.startsWith('/User')) {


### PR DESCRIPTION
- **Models**: Downloaded model file from "Project-> models" has base64 format instead of pkl
   Jira: https://jira.iguazeng.com/browse/ML-2241