### PR TITLE
Fix [Feature store] Preview scroll, Feature set column width

### DIFF
--- a/src/components/ArtifactsPreview/artifactsPreview.scss
+++ b/src/components/ArtifactsPreview/artifactsPreview.scss
@@ -53,7 +53,7 @@
       display: flex;
       flex-direction: column;
       min-width: 100%;
-      max-height: 500px;
+      max-height: 340px;
     }
 
     &-row {

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -103,19 +103,16 @@ export const createFeatureSetsRowData = (featureSet, project, isSelectedItem, sh
       {
         id: `entity.${identifierUnique}`,
         header: 'Entities',
-        value:
-          featureSet.entities
-            ?.slice(0, 2)
-            .map(entity => entity.name)
-            .join(', ') ?? '',
-        class: 'table-cell-1',
+        value: featureSet.entities?.slice(0, 2).map(entity => entity.name) || '',
+        type: 'labels',
+        class: 'table-cell-2',
         hidden: isSelectedItem
       },
       { ...getFeatureSetTargetCellValue(featureSet.targets, isSelectedItem) },
       {
         id: `buttonCopy.${identifierUnique}`,
         value: '',
-        class: 'table-cell-small artifacts__icon',
+        class: 'table-cell-1 artifacts__icon',
         type: 'buttonCopyURI',
         actionHandler: (item, tab) => copyToClipboard(generateUri(item, tab)),
         hidden: isSelectedItem
@@ -142,9 +139,9 @@ export const createFeaturesRowData = (feature, isTablePanelOpen, showExpandButto
         header: 'Feature Name',
         type: feature.ui.type,
         value: feature.name,
-        class: 'table-cell-3',
+        class: 'table-cell-2',
         expandedCellContent: {
-          class: 'table-cell-3',
+          class: 'table-cell-2',
           value: feature.metadata?.tag
         },
         showExpandButton
@@ -153,7 +150,7 @@ export const createFeaturesRowData = (feature, isTablePanelOpen, showExpandButto
         id: `feature_set.${identifierUnique}`,
         header: 'Feature set',
         value: feature.metadata?.name,
-        class: 'table-cell-2',
+        class: 'table-cell-1',
         getLink: tab =>
           generateLinkToDetailsPanel(
             feature.metadata?.project,
@@ -164,7 +161,7 @@ export const createFeaturesRowData = (feature, isTablePanelOpen, showExpandButto
             tab
           ),
         expandedCellContent: {
-          class: 'table-cell-2',
+          class: 'table-cell-1',
           value: ''
         },
         rowExpanded: {
@@ -189,14 +186,14 @@ export const createFeaturesRowData = (feature, isTablePanelOpen, showExpandButto
         id: `entity.${identifierUnique}`,
         header: 'Entities',
         type: 'labels',
-        value: feature.spec?.entities.map(entity => entity.name),
-        class: 'table-cell-4'
+        value: feature.spec?.entities.map(entity => entity.name) || '',
+        class: 'table-cell-2'
       },
       {
         id: `description.${identifierUnique}`,
         header: 'Description',
         value: feature.description,
-        class: 'table-cell-3',
+        class: 'table-cell-2',
         hidden: isTablePanelOpen
       },
       {
@@ -215,7 +212,7 @@ export const createFeaturesRowData = (feature, isTablePanelOpen, showExpandButto
         id: `validator.${identifierUnique}`,
         header: 'Validator',
         value: <FeatureValidator validator={feature.validator} />,
-        class: 'table-cell-3',
+        class: 'table-cell-2',
         type: 'component',
         hidden: isTablePanelOpen
       },
@@ -257,7 +254,7 @@ const getFeatureSetTargetCellValue = (targets, isSelectedItem, identifierUnique)
     )
     .sort((icon, otherIcon) => (icon.tooltip < otherIcon.tooltip ? -1 : 1)),
   id: `targets.${identifierUnique}`,
-  class: 'table-cell-1 artifacts__targets-icon',
+  class: 'table-cell-2 artifacts__targets-icon',
   type: 'icons',
   hidden: isSelectedItem
 })


### PR DESCRIPTION
- **Feature store**:  Preview scroll, Feature set column width
   Before:
  <img width="1209" alt="Screen Shot 2022-07-11 at 13 27 21" src="https://user-images.githubusercontent.com/63646693/178244689-3a66e7a4-1b66-4449-9ae0-c845c2eb1793.png">
  <img width="1453" alt="Screen Shot 2022-07-11 at 13 30 37" src="https://user-images.githubusercontent.com/63646693/178245230-5bb777f1-f2c5-4004-bbdb-69d8d98dd0ef.png">

   After:
   <img width="1263" alt="Screen Shot 2022-07-11 at 13 30 01" src="https://user-images.githubusercontent.com/63646693/178245115-44e2d699-81ad-48b9-8767-6e18ad622eb1.png">
   <img width="1499" alt="Screen Shot 2022-07-11 at 13 31 05" src="https://user-images.githubusercontent.com/63646693/178245300-16e974c3-65b7-4fce-8d0a-4cdfb876ac28.png">


   