### PR TITLE
[Build] Backport support running as rootless [1.0.x]

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git
+.github
+nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,20 +19,29 @@ RUN echo ${COMMIT_HASH} > ./build/COMMIT_HASH && \
     echo ${DATE} > ./build/BUILD_DATE
 
 # production stage
-FROM quay.io/mlrun/nginx:stable-alpine as production-stage
+FROM gcr.io/iguazio/nginx-unprivileged:1.21-alpine as production-stage
 
-RUN apk update && \
-	apk upgrade && \
-	rm -rf /var/cache/apk/*
+USER root
+# escalate permissions to update packages
+RUN apk update --no-cache && apk upgrade --no-cache
+# we are inheriting $UID and $GID from the base image, you can find more information here:
+# https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
+USER $UID
 
 COPY --from=build-stage /app/build /usr/share/nginx/html
 COPY config.json.tmpl /usr/share/nginx/html/
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.conf.tmpl /etc/nginx/conf.d/
 COPY nginx/run_nginx /etc/nginx/
-EXPOSE 80
 
-ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:80}" \
+USER root
+# update build files permissions so they would be accessible to the running user
+RUN chown -R $UID:0 /usr/share/nginx/html && chmod -R g+w /usr/share/nginx/html && chmod 777 /etc/nginx/run_nginx
+USER $UID
+
+EXPOSE 8090
+
+ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:8090}" \
     MLRUN_BETA_MODE="${MLRUN_BETA_MODE:-enabled}" \
     MLRUN_FUNCTION_CATALOG_URL="${MLRUN_FUNCTION_CATALOG_URL:-https://raw.githubusercontent.com}" \
     MLRUN_FUNCTION_CATALOG_PATH="${MLRUN_FUNCTION_CATALOG_PATH:-/mlrun/functions/master}" \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can pass the following environment variables to the `docker run` command to 
 
 | Name  | Description |
 | ----- | ----------- |
-| `MLRUN_API_PROXY_URL` | Sets the base URL of the backend API<br />Default: `http://localhost:80`<br />Example: `http://17.220.101.245:30080` |
+| `MLRUN_API_PROXY_URL` | Sets the base URL of the backend API<br />Default: `http://localhost:8090`<br />Example: `http://17.220.101.245:30080` |
 | `MLRUN_NUCLIO_MODE` | Sets the MLRun Nuclio integration mode<br />Default: `disabled`<br />Example: `enabled` |
 | `MLRUN_NUCLIO_API_URL` | Sets the base URL of the Nuclio API<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
 | `MLRUN_NUCLIO_UI_URL` | Sets the base URL of the Nuclio UI<br />Default: `http://localhost:8070`<br />Example: `http://17.220.101.245:30070` |
@@ -39,7 +39,7 @@ You can pass the following environment variables to the `docker run` command to 
 
 Example:
 
-`docker run -it -d -p 4000:80 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com -e MLRUN_FUNCTION_CATALOG_PATH=/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
+`docker run -it -d -p 8090:8090 --rm --name mlrun-ui -e MLRUN_API_PROXY_URL=http://17.220.101.245:30080 -e MLRUN_NUCLIO_MODE=enabled -e MLRUN_NUCLIO_API_URL=http://17.220.101.245:30070 -e MLRUN_NUCLIO_UI_URL=http://17.220.101.245:30070 -e MLRUN_FUNCTION_CATALOG_URL=https://raw.githubusercontent.com -e MLRUN_FUNCTION_CATALOG_PATH=/mlrun/functions/master -e MLRUN_V3IO_ACCESS_KEY=a7097c94-6e8f-436d-9717-a84abe2861d1 quay.io/mlrun/mlrun-ui:0.4.9`
 
 ### Docker container contents
 

--- a/nginx/nginx.conf.tmpl
+++ b/nginx/nginx.conf.tmpl
@@ -5,7 +5,7 @@ map $http_x_v3io_session_key $v3io_session_key {
 
 server {
 
-  listen 80;
+  listen 8090;
 
   include resolvers.conf;
 


### PR DESCRIPTION
(cherry picked from commit 256e5e8745fc0eafcd7420e7f5beb982f6941f06)