### PR TITLE
Fix [Jobs] Results tab - layout issue

### DIFF
--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -24,6 +24,10 @@
       &:hover {
         background-color: $alabaster;
       }
+
+      & > *:first-child {
+        padding-left: 40px;
+      }
     }
 
     &__body {
@@ -32,7 +36,6 @@
 
     &__body,
     &__header {
-      padding: 0 24px;
       min-width: 100%;
     }
 
@@ -79,7 +82,7 @@
       svg {
         position: absolute;
         top: 15px;
-        left: 0;
+        left: 8px;
       }
     }
   }

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -3,9 +3,10 @@
 @import '~igz-controls/scss/mixins';
 
 .table__item-results {
+  flex: 1;
   position: relative;
+  overflow: auto;
   width: 100%;
-  padding: 0 24px;
 
   .results-table {
     position: relative;
@@ -13,7 +14,6 @@
     flex-direction: column;
     align-items: flex-start;
     width: 100%;
-    overflow-x: auto;
     text-align: left;
 
     &__row {
@@ -26,6 +26,16 @@
       }
     }
 
+    &__body {
+      flex: 1;
+    }
+
+    &__body,
+    &__header {
+      padding: 0 24px;
+      min-width: 100%;
+    }
+
     &__header {
       position: sticky;
       top: 0;
@@ -34,11 +44,13 @@
 
       &-item {
         display: flex;
-        flex: 1;
+        flex: 0 0 150px;
         flex-direction: column;
         width: 150px;
 
         @include tableHeader(16px);
+
+        padding: 5px 15px 5px 25px;
       }
 
       .results-table__row:hover {
@@ -48,10 +60,10 @@
 
     &__cell {
       display: flex;
-      flex: 1;
+      flex: 0 0 150px;
       flex-direction: column;
       width: 150px;
-      padding: 19px 20px;
+      padding: 19px 15px 19px 25px;
     }
 
     i {
@@ -67,7 +79,7 @@
       svg {
         position: absolute;
         top: 15px;
-        left: -5px;
+        left: 0;
       }
     }
   }


### PR DESCRIPTION
- **Jobs**:  Results tab - layout issue
   - When List is long, horizontal scroll is at the bottom
   Jira: [ML-2410](https://jira.iguazeng.com/browse/ML-2410)
   
   Before:
   <img width="1476" alt="Screen Shot 2022-07-17 at 15 15 27" src="https://user-images.githubusercontent.com/63646693/179402431-899a6428-3f72-4974-b0f7-3ea2d21dec80.png">
   <img width="1510" alt="Screen Shot 2022-07-17 at 17 27 32" src="https://user-images.githubusercontent.com/63646693/179403020-b498b437-24c7-45eb-af2b-b1d5bfaee8e4.png">

   After:
   <img width="1514" alt="Screen Shot 2022-07-17 at 17 24 15" src="https://user-images.githubusercontent.com/63646693/179402896-e79c8daa-cb98-49eb-8920-60555c589ca6.png">
   <img width="1513" alt="Screen Shot 2022-07-17 at 17 30 09" src="https://user-images.githubusercontent.com/63646693/179403129-aab4e86b-ca16-424f-9ec2-2a2b3229121e.png">

