### PR TITLE
[CI] BackPort Pull Unstable Image Version Prefix From MLRun [1.0.x]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,13 +37,13 @@ jobs:
       id: git_info
       run: |
         echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short=8 $GITHUB_SHA)"
-        echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+        echo "::set-output name=unstable_version_prefix::$(curl https://raw.githubusercontent.com/mlrun/mlrun/${GITHUB_REF##*/}/automation/version/unstable_version_prefix)"
     - name: Set computed versions params
       id: computed_params
       run: |
         echo "::set-output name=mlrun_version::$( \
           input_mlrun_version=${{ github.event.inputs.version }} && \
-          default_mlrun_version=$(echo ${{ steps.git_info.outputs.latest_version }}-${{ steps.git_info.outputs.mlrun_commit_hash }}) && \
+          default_mlrun_version=$(echo ${{ steps.git_info.outputs.unstable_version_prefix }}-${{ steps.git_info.outputs.mlrun_commit_hash }}) && \
           echo ${input_mlrun_version:-`echo $default_mlrun_version`})"
         echo "::set-output name=mlrun_docker_repo::$( \
           input_docker_repo=${{ github.event.inputs.docker_repo }} && \


### PR DESCRIPTION
Back port for https://github.com/mlrun/ui/pull/1348 