### PR TITLE
Fix [Project secrets] Add Additional Information to Project Secrets screen

### DIFF
--- a/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
+++ b/src/elements/ProjectSettingsSecrets/ProjectSettingsSecretsView.js
@@ -13,7 +13,7 @@ const ProjectSettingsSecretsView = ({
   handleSecretEdit,
   isUserAllowed,
   loading,
-  secrets
+  secrets,
 }) => {
   return (
     <>
@@ -28,8 +28,16 @@ const ProjectSettingsSecretsView = ({
           <div className="settings__card-content">
             <div className="settings__card-content-col">
               <p className="settings__card-subtitle">
-                These secrets will automatically be available to all jobs
-                belonging to this project.
+                These secrets are automatically available to all jobs belonging
+                to this project that are not executed locally. See{' '}
+                <a
+                  href="https://docs.mlrun.org/en/latest/secrets.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link"
+                >
+                  Secrets
+                </a>
               </p>
               <KeyValueTable
                 addNewItem={handleAddNewSecret}
@@ -60,7 +68,7 @@ const ProjectSettingsSecretsView = ({
 ProjectSettingsSecretsView.defaultProps = {
   error: null,
   isUserAllowed: true,
-  loading: null
+  loading: null,
 }
 
 ProjectSettingsSecretsView.propTypes = {
@@ -70,7 +78,7 @@ ProjectSettingsSecretsView.propTypes = {
   handleSecretEdit: PropTypes.func.isRequired,
   isUserAllowed: PropTypes.bool.isRequired,
   loading: PropTypes.bool,
-  secrets: PropTypes.array.isRequired
+  secrets: PropTypes.array.isRequired,
 }
 
 export default ProjectSettingsSecretsView


### PR DESCRIPTION
- **Project secrets**: Add Additional Information to Project Secrets screen
    Backported to `1.0.5` from #1356 
   Jira: [ML-2444](https://jira.iguazeng.com/browse/ML-2444)
   Before:   
   ![image](https://user-images.githubusercontent.com/63646693/182377186-067552ea-8740-41ff-a065-6dde3014b584.png)
   
    After:
    <img width="741" alt="Screen Shot 2022-08-02 at 15 41 58" src="https://user-images.githubusercontent.com/63646693/182377261-bfa12970-9bff-4d0d-b138-7c6e4b11e04c.png">

     
