### PR TITLE
Fix [Feature set] std column on statistics page is empty after ingest with spark engine

### DIFF
--- a/src/components/DetailsStatistics/detailsStatistics.util.js
+++ b/src/components/DetailsStatistics/detailsStatistics.util.js
@@ -2,72 +2,74 @@ import React from 'react'
 
 import { Tooltip, TextTooltipTemplate } from 'igz-controls/components'
 
+import { roundFloats } from '../../utils/roundFloats'
+
 import { ReactComponent as Primary } from 'igz-controls/images/ic-key.svg'
 import { ReactComponent as LabelColumn } from 'igz-controls/images/ic_target-with-dart.svg'
 
 export const generateStatistics = selectedItem => {
-  return Object.entries(
-    (selectedItem?.stats || selectedItem.feature_stats) ?? {}
-  ).map(([name, metrics]) => {
-    return {
-      entityIcon: {
-        value: (
-          <Tooltip template={<TextTooltipTemplate text="Entity" />}>
-            <Primary />
-          </Tooltip>
-        ),
-        type: 'icon',
-        hidden: !selectedItem.entities?.some(entity => entity.name === name)
-      },
-      labelColumnIcon: {
-        value: (
-          <Tooltip template={<TextTooltipTemplate text="Label column" />}>
-            <LabelColumn />
-          </Tooltip>
-        ),
-        type: 'icon',
-        hidden: selectedItem.label_column !== name
-      },
-      name: {
-        value: name ?? '',
-        type: 'text'
-      },
-      count: {
-        value: metrics?.count ?? '',
-        type: 'text'
-      },
-      mean: {
-        value: metrics?.mean ?? '',
-        type: 'text'
-      },
-      std: {
-        value: metrics?.std?.toFixed(8) ?? '',
-        type: 'text'
-      },
-      min: {
-        value: metrics?.min ?? '',
-        type: 'text'
-      },
-      max: {
-        value: metrics?.max ?? '',
-        type: 'text'
-      },
-      unique: {
-        value: metrics?.unique ?? '',
-        type: 'text'
-      },
-      top: {
-        value: metrics?.top ?? '',
-        type: 'text'
-      },
-      freq: {
-        value: metrics?.freq ?? '',
-        type: 'text'
-      },
-      histogram: {
-        value: metrics?.hist ?? [[], []],
-        type: 'chart'
+  return Object.entries((selectedItem?.stats || selectedItem.feature_stats) ?? {}).map(
+    ([name, metrics]) => {
+      return {
+        entityIcon: {
+          value: (
+            <Tooltip template={<TextTooltipTemplate text="Entity" />}>
+              <Primary />
+            </Tooltip>
+          ),
+          type: 'icon',
+          hidden: !selectedItem.entities?.some(entity => entity.name === name)
+        },
+        labelColumnIcon: {
+          value: (
+            <Tooltip template={<TextTooltipTemplate text="Label column" />}>
+              <LabelColumn />
+            </Tooltip>
+          ),
+          type: 'icon',
+          hidden: selectedItem.label_column !== name
+        },
+        name: {
+          value: name ?? '',
+          type: 'text'
+        },
+        count: {
+          value: metrics?.count ?? '',
+          type: 'text'
+        },
+        mean: {
+          value: metrics?.mean ?? '',
+          type: 'text'
+        },
+        std: {
+          value: roundFloats(metrics.std ?? metrics.stddev, 8),
+          type: 'text'
+        },
+        min: {
+          value: metrics?.min ?? '',
+          type: 'text'
+        },
+        max: {
+          value: metrics?.max ?? '',
+          type: 'text'
+        },
+        unique: {
+          value: metrics?.unique ?? '',
+          type: 'text'
+        },
+        top: {
+          value: metrics?.top ?? '',
+          type: 'text'
+        },
+        freq: {
+          value: metrics?.freq ?? '',
+          type: 'text'
+        },
+        histogram: {
+          value: metrics?.hist ?? [[], []],
+          type: 'chart'
+        }
       }
     }
-  })
+  )
 }

--- a/src/utils/roundFloats.js
+++ b/src/utils/roundFloats.js
@@ -1,2 +1,7 @@
-export const roundFloats = (value, precision) =>
-  Number.isNaN(+value) || Number.isInteger(+value) ? value : (+value).toFixed(precision ?? 2)
+export const roundFloats = (value, precision) => {
+  const floatNumber = parseFloat(value)
+
+  if (isNaN(floatNumber)) return ''
+
+  return parseFloat(floatNumber.toFixed(precision ?? 2))
+}

--- a/src/utils/roundFloats.js
+++ b/src/utils/roundFloats.js
@@ -1,7 +1,2 @@
-export const roundFloats = (value, precision) => {
-  const floatNumber = parseFloat(value)
-
-  if (isNaN(floatNumber)) return ''
-
-  return parseFloat(floatNumber.toFixed(precision ?? 2))
-}
+export const roundFloats = (value, precision) =>
+  Number.isNaN(+value) || Number.isInteger(+value) ? value : (+value).toFixed(precision ?? 2)

--- a/src/utils/roundFloats.js
+++ b/src/utils/roundFloats.js
@@ -1,4 +1,7 @@
-export const roundFloats = (value, precision) =>
-  Number.isNaN(+value) || Number.isInteger(+value)
-    ? value
-    : (+value).toFixed(precision ?? 2)
+export const roundFloats = (value, precision) => {
+  const floatNumber = parseFloat(value)
+
+  if (isNaN(floatNumber)) return ''
+
+  return parseFloat(floatNumber.toFixed(precision ?? 2))
+}


### PR DESCRIPTION
- **Feature set** std column on statistics page is empty after ingest with spark engine
   **Fix:** 
   - They contain the stddev label instead of std
   - All values are of type string, even where a numeric would be expected (e.g. "-1.234" instead of -1.234)
   
  Jira: [ML-2463](https://jira.iguazeng.com/browse/ML-2463)
   