### PR TITLE
Fix [Artifacts] "Show Details" for artifacts with no "latest" tag is broken and forwards to the main projects screen

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifactsView.js
+++ b/src/components/DetailsArtifacts/DetailsArtifactsView.js
@@ -23,7 +23,7 @@ const DetailsArtifactsView = ({
   noData,
   preview,
   showArtifact,
-  showPreview
+  showPreview,
 }) => {
   return (
     <div className="item-artifacts">
@@ -34,13 +34,14 @@ const DetailsArtifactsView = ({
           const artifactScreenLinks = {
             model: `/projects/${
               match.params.projectName
-            }/models/${MODELS_TAB}/${artifact.db_key ||
-              artifact.key}/${artifact.tag ??
-              TAG_FILTER_LATEST}/${iteration}/overview`,
-            dataset: `/projects/${
-              match.params.projectName
-            }/${DATASETS}/${artifact.db_key || artifact.key}/${artifact.tag ??
-              TAG_FILTER_LATEST}/${iteration}/overview`
+            }/models/${MODELS_TAB}/${artifact.db_key || artifact.key}/${
+              artifact.tag ?? TAG_FILTER_LATEST
+            }${iteration ? `/${iteration}` : ''}/overview`,
+            dataset: `/projects/${match.params.projectName}/${DATASETS}/${
+              artifact.db_key || artifact.key
+            }/${artifact.tag ?? TAG_FILTER_LATEST}${
+              iteration ? `/${iteration}` : ''
+            }/overview`,
           }
 
           return (
@@ -87,11 +88,11 @@ const DetailsArtifactsView = ({
                       target="_blank"
                       to={
                         artifactScreenLinks[artifact.kind] ??
-                        `/projects/${
-                          match.params.projectName
-                        }/files/${artifact.db_key ||
-                          artifact.key}/${artifact.tag ??
-                          TAG_FILTER_LATEST}/${iteration}/overview`
+                        `/projects/${match.params.projectName}/files/${
+                          artifact.db_key || artifact.key
+                        }/${artifact.tag ?? TAG_FILTER_LATEST}${
+                          iteration ? `/${iteration}` : ''
+                        }/overview`
                       }
                     >
                       <DetailsIcon />
@@ -140,7 +141,7 @@ DetailsArtifactsView.propTypes = {
   noData: PropTypes.bool.isRequired,
   preview: PropTypes.shape({}).isRequired,
   showArtifact: PropTypes.func.isRequired,
-  showPreview: PropTypes.func.isRequired
+  showPreview: PropTypes.func.isRequired,
 }
 
 export default DetailsArtifactsView

--- a/src/components/DetailsArtifacts/detailsArtifacts.util.js
+++ b/src/components/DetailsArtifacts/detailsArtifacts.util.js
@@ -10,7 +10,7 @@ export const getJobAccordingIteration = (
 ) => {
   const selectedJob =
     allJobsData.find(
-      job =>
+      (job) =>
         job.metadata.uid === selectedItem.uid &&
         job.metadata.iteration === +iteration
     ) || {}
@@ -23,10 +23,10 @@ export const getJobAccordingIteration = (
   return selectedJob
 }
 
-export const generateContent = selectedJob => {
-  return selectedJob.artifacts.map(artifact => {
+export const generateContent = (selectedJob) => {
+  return selectedJob.artifacts.map((artifact) => {
     let generatedPreviewData = {
-      preview: []
+      preview: [],
     }
 
     if (artifact.extra_data) {
@@ -38,13 +38,15 @@ export const generateContent = selectedJob => {
       key: artifact.key,
       kind: artifact.kind,
       db_key: artifact.db_key,
+      iter: artifact.iter,
       preview: generatedPreviewData.preview,
       size: artifact.size ? prettyBytes(artifact.size) : 'N/A',
       target_path: artifact.target_path,
+      tag: artifact.tag,
       tree: artifact.tree,
       user: selectedJob?.labels
-        ?.find(item => item.match(/v3io_user|owner/g))
-        ?.replace(/(v3io_user|owner): /, '')
+        ?.find((item) => item.match(/v3io_user|owner/g))
+        ?.replace(/(v3io_user|owner): /, ''),
     }
 
     if (artifact.schema) {
@@ -52,7 +54,7 @@ export const generateContent = selectedJob => {
         ...generatedArtifact,
         header: artifact.header,
         preview: artifact.preview,
-        schema: artifact.schema
+        schema: artifact.schema,
       }
     }
 


### PR DESCRIPTION
- **Artifacts**: "Show Details" for artifacts with no "latest" tag is broken and forwards to the main projects screen
   Backported to `1.0.x` from #1362 
   Jira: https://jira.iguazeng.com/browse/ML-2477