### PR TITLE
Fix [Jobs] State column is empty in Results tab

### DIFF
--- a/src/utils/roundFloats.js
+++ b/src/utils/roundFloats.js
@@ -1,7 +1,9 @@
 export const roundFloats = (value, precision) => {
   const floatNumber = parseFloat(value)
 
-  if (isNaN(floatNumber)) return ''
+  if (isNaN(floatNumber)) {
+    return value ? value : ''
+  }
 
   return parseFloat(floatNumber.toFixed(precision ?? 2))
 }


### PR DESCRIPTION
- **Jobs**: State column is empty in Results tab
   Related to Fix: #1361 
   Jira: [ML-2492](https://jira.iguazeng.com/browse/ML-2492)

   Part of:
- **UI**: Label value is not being displayed   
   https://jira.iguazeng.com/browse/ML-2490
      
   Before:
   <img width="1502" alt="Screen Shot 2022-08-07 at 16 47 38" src="https://user-images.githubusercontent.com/63646693/183293913-b25c8ae4-96ab-4a80-96a8-5fadff658d13.png">
   
   After:  
   <img width="1518" alt="Screen Shot 2022-08-07 at 16 47 51" src="https://user-images.githubusercontent.com/63646693/183293923-47cb97f0-bf68-406f-a7c2-8c33c767a877.png">
   
      Before:
   ![image](https://user-images.githubusercontent.com/90618337/183409358-f043570a-372b-460a-9676-bb8a59524360.png)
   After:
   ![image](https://user-images.githubusercontent.com/90618337/183409321-9c49a1ed-cad4-48e0-ac85-3d1ca09370b1.png)

 