### PR TITLE
Fix [Jobs] Wrong parsing of parameters

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -181,7 +181,7 @@ export const generateJobsContent = selectedItem => {
       value: formatDatetime(selectedItem.updated, 'N/A')
     },
     parameters: {
-      value: selectedItem.parameters
+      value: selectedItem.parametersChips
     },
     function: {
       value: selectedItem.function

--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -65,8 +65,8 @@ const DetailsInfoView = React.forwardRef(
               let target_path = null
 
               if (pageData.page === JOBS_PAGE) {
-                if (detailsStore.infoContent[header.id]?.value === selectedItem.parameters) {
-                  chipsData.chips = selectedItem.parameters
+                if (detailsStore.infoContent[header.id]?.value === selectedItem.parametersChips) {
+                  chipsData.chips = selectedItem.parametersChips
                   chipsData.chipOptions = getChipOptions('parameters')
                 } else if (
                   detailsStore.infoContent[header.id]?.value === selectedItem.resultsChips

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -107,7 +107,7 @@ export const generateEditableItem = (functionData, job) => {
           inputs: job.inputs ?? {},
           output_path: job.outputPath,
           param_file: job.param_file ?? '',
-          parameters: generateKeyValues(job.parameters ?? {}),
+          parameters: generateKeyValues(job.parametersChips ?? {}),
           secret_sources: job.secret_sources ?? [],
           selector: job.selector ?? 'max.',
           tuning_strategy: job.tuning_strategy ?? 'list'

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -88,7 +88,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
         {
           header: 'Parameters',
           id: `parameters.${identifierUnique}`,
-          value: job.parameters,
+          value: job.parametersChips,
           class: 'table-cell-1 table-cell-small',
           type: 'parameters'
         },
@@ -289,7 +289,7 @@ export const createJobsWorkflowsTabContent = (
               {
                 header: 'Parameters',
                 id: `parameters.${identifierUnique}`,
-                value: job.parameters,
+                value: job.parametersChips,
                 class: 'table-cell-1',
                 type: 'parameters',
                 hidden: isSelectedItem

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -4,10 +4,11 @@ export const parseKeyValues = (object = {}) =>
     : Object.entries(object).map(([key, value]) => {
         return Array.isArray(value) && value.every(item => item)
           ? `${key}: [${value.map(arrayItem => {
-              return ` {${Object.entries(arrayItem).map(
-                ([arrayItemKey, arrayItemValue]) =>
-                  ` ${arrayItemKey}: ${arrayItemValue} `
-              )}} `
+              return typeof arrayItem === 'object'
+                ? ` {${Object.entries(arrayItem).map(
+                    ([arrayItemKey, arrayItemValue]) => ` ${arrayItemKey}: ${arrayItemValue} `
+                  )}} `
+                : ` ${arrayItem} `
             })}]`
           : typeof value === 'object' && value !== null
           ? `${key}: {${Object.entries(value).map(

--- a/src/utils/parseJob.js
+++ b/src/utils/parseJob.js
@@ -35,7 +35,11 @@ export const parseJob = (job, tab) => {
       name: job.metadata.name,
       outputPath: job.spec.output_path,
       owner: job.metadata.labels?.owner,
-      parameters: parseKeyValues(job.spec.parameters || {}),
+      parameters: job.spec.parameters || {},
+      parametersChips: [
+        ...parseKeyValues(job.spec.parameters || {}),
+        ...parseKeyValues(job.spec.hyperparams || {})
+      ],
       project: job.metadata.project,
       results: job.status.results || {},
       resultsChips: parseKeyValues(job.status.results || {}),


### PR DESCRIPTION
- **Jobs**: Wrong parsing of parameters
- **Monitor Jobs**: The Parameters data is missing in the Job overview screen for job with Hyper param
   Jira: https://jira.iguazeng.com/browse/ML-2475
   Related to: https://jira.iguazeng.com/browse/ML-2432
   Before:
   ![image](https://user-images.githubusercontent.com/90618337/183864985-075c82ac-412c-46c3-90a9-59d60f310309.png)
   After:
   ![image](https://user-images.githubusercontent.com/90618337/183865160-25816cdb-e283-43e1-a62c-7e15138c3cd5.png)
