### PR TITLE
Fix [Models] No data for data for Unique, Top and Freq in the Statistics tab

### DIFF
--- a/src/components/FeatureStore/FeatureSets/featureSets.util.js
+++ b/src/components/FeatureStore/FeatureSets/featureSets.util.js
@@ -31,7 +31,8 @@ export const generateFeatureSetsDetailsMenu = selectedItem => [
     label: 'statistics',
     id: 'statistics',
     hidden: !selectedItem?.stats,
-    tip: 'Statistics reflect the data for the latest ingestion'
+    tip:
+      'Statistics reflect the data for the latest ingestion. \n Note that some values may be empty due to the use of different engines for calculating statistics'
   },
   {
     label: 'analysis',

--- a/src/components/Models/models.util.js
+++ b/src/components/Models/models.util.js
@@ -102,7 +102,9 @@ export const generateModelsDetailsMenu = selectedModel => [
     hidden:
       !selectedModel.item?.stats &&
       !selectedModel.item?.feature_stats &&
-      !selectedModel.item?.feature_vector
+      !selectedModel.item?.feature_vector,
+    tip:
+      'Note that some values may be empty due to the use of different engines for calculating statistics'
   }
 ]
 


### PR DESCRIPTION
- **Models**: No data for data for Unique, Top and Freq in the Statistics tab
   Jira: [ML-2194](https://jira.iguazeng.com/browse/ML-2194)
   
   Before:
   <img width="1200" alt="Screen Shot 2022-08-14 at 13 46 11" src="https://user-images.githubusercontent.com/63646693/184533287-c0f0ffe6-eeb8-4586-bc0e-4ff9c7c8ce3b.png">
   
   After:
   ![image](https://user-images.githubusercontent.com/63646693/184533298-62807b46-d42a-4605-bb85-05fa75501ea9.png)
      
   ![image](https://user-images.githubusercontent.com/63646693/184534733-211ca779-1139-46ea-85ef-754737e0acf9.png)



   