### PR TITLE
Fix [UI] artifact/model registered via UI is using old format

### DIFF
--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -128,7 +128,9 @@ const artifactsApi = {
   },
   registerArtifact: (project, data) =>
     mainHttpClient.post(
-      `/projects/${project}/artifacts/${data.uid}/${data.key || data.metadata.key}`,
+      `/projects/${project}/artifacts/${data.uid || data.metadata?.tree}/${
+        data.key || data.metadata.key
+      }`,
       data
     ),
   updateArtifact: (project, data) =>

--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -127,7 +127,10 @@ const artifactsApi = {
     return fetchArtifacts(project, filters, { params: { category: 'model', format: 'full' } }, true)
   },
   registerArtifact: (project, data) =>
-    mainHttpClient.post(`/projects/${project}/artifacts/${data.uid}/${data.key}`, data),
+    mainHttpClient.post(
+      `/projects/${project}/artifacts/${data.uid}/${data.key || data.metadata.key}`,
+      data
+    ),
   updateArtifact: (project, data) =>
     mainHttpClient.post(
       `/projects/${project}/artifacts/${data.uid || data.metadata?.tree}/${

--- a/src/common/TargetPath/TargetPath.js
+++ b/src/common/TargetPath/TargetPath.js
@@ -20,7 +20,7 @@ such restriction.
 import React, { useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
-import { isNil, pick, uniqBy } from 'lodash'
+import { get, isNil, uniqBy } from 'lodash'
 import { OnChange } from 'react-final-form-listeners'
 import PropTypes from 'prop-types'
 
@@ -60,7 +60,7 @@ const TargetPath = ({
 
   const handleOnChange = (selectValue, inputValue) => {
     if (isNil(inputValue)) {
-      setFieldState('formState.values.target_path.path', { modified: false })
+      setFieldState(get(formState.values, name), { modified: false })
     }
 
     if (selectValue === MLRUN_STORAGE_INPUT_PATH_SCHEME && !isNil(inputValue)) {
@@ -69,8 +69,7 @@ const TargetPath = ({
   }
 
   const validatePath = allValues => {
-    const { pathType, value } = pick(allValues.target_path.fieldInfo, ['pathType', 'value'])
-
+    const { pathType, value } = get(allValues, formStateFieldInfo)
     return isPathInputInvalid(pathType, value)
   }
 
@@ -92,7 +91,9 @@ const TargetPath = ({
   ])
 
   useEffect(() => {
-    if (formState.values.target_path.fieldInfo.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME) {
+    if (
+      get(formState.values, `${formStateFieldInfo}.pathType`) === MLRUN_STORAGE_INPUT_PATH_SCHEME
+    ) {
       setDataInputState(prev => ({
         ...prev,
         comboboxMatches: generateComboboxMatchesList(
@@ -128,7 +129,7 @@ const TargetPath = ({
     dataInputState.projects,
     dataInputState.storePathType,
     dispatch,
-    formState.values.target_path.fieldInfo.pathType,
+    get(formState.values, `${formStateFieldInfo}.pathType`),
     setDataInputState
   ])
 
@@ -236,13 +237,18 @@ const TargetPath = ({
       <FormCombobox
         density={density}
         hideSearchInput={!dataInputState.inputStorePathTypeEntered}
-        inputPlaceholder={pathPlaceholders[formState.values.target_path.fieldInfo?.pathType] ?? ''}
+        inputPlaceholder={
+          pathPlaceholders[get(formState.values, `${formStateFieldInfo}.pathType`)] ?? ''
+        }
         invalidText={`Field must be in "${
-          pathTips(dataInputState.storePathType)[formState.values.target_path.fieldInfo?.pathType]
+          pathTips(dataInputState.storePathType)[
+            get(formState.values, `${formStateFieldInfo}.pathType`)
+          ]
         }" format`}
         label={label}
         maxSuggestedMatches={
-          formState.values.target_path.fieldInfo.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME
+          get(formState.values, `${formStateFieldInfo}.pathType`) ===
+          MLRUN_STORAGE_INPUT_PATH_SCHEME
             ? 3
             : 2
         }
@@ -252,7 +258,8 @@ const TargetPath = ({
         selectOptions={comboboxSelectList}
         selectPlaceholder={selectPlaceholder}
         suggestionList={
-          formState.values.target_path.fieldInfo.pathType === MLRUN_STORAGE_INPUT_PATH_SCHEME
+          get(formState.values, `${formStateFieldInfo}.pathType`) ===
+          MLRUN_STORAGE_INPUT_PATH_SCHEME
             ? dataInputState.comboboxMatches
             : []
         }

--- a/src/components/RegisterArtifactModal/RegisterArtifactModal.js
+++ b/src/components/RegisterArtifactModal/RegisterArtifactModal.js
@@ -52,23 +52,27 @@ const RegisterArtifactModal = ({
   const { isDemoMode } = useMode()
   const initialValues = {
     kind: artifactKind !== 'artifact' ? artifactKind.toLowerCase() : 'general',
-    description: '',
-    key: '',
-    labels: [],
-    target_path: isDemoMode
-      ? {
-          fieldInfo: {
-            pathType: ''
-          },
-          path: ''
-        }
-      : ''
+    metadata: {
+      description: '',
+      key: '',
+      labels: []
+    },
+    spec: {
+      target_path: isDemoMode
+        ? {
+            fieldInfo: {
+              pathType: ''
+            },
+            path: ''
+          }
+        : ''
+    }
   }
   const formRef = React.useRef(
     createForm({
       initialValues,
-      onSubmit: () => {},
-      mutators: { ...arrayMutators, setFieldState }
+      mutators: { ...arrayMutators, setFieldState },
+      onSubmit: () => {}
     })
   )
   const location = useLocation()
@@ -79,25 +83,23 @@ const RegisterArtifactModal = ({
     const data = {
       kind: values.kind === 'general' ? '' : values.kind,
       metadata: {
-        labels: convertChipsData(values.labels),
-        key: values.key,
+        labels: convertChipsData(values.metadata.labels),
+        key: values.metadata.key,
         project: projectName,
         tree: uid
       },
       project: projectName,
       spec: {
-        db_key: values.key,
+        db_key: values.metadata.key,
         producer: {
           kind: 'api',
           uri: window.location.host
         },
-        target_path: isDemoMode ? values.target_path.path : values.target_path
+        target_path: isDemoMode ? values.spec.target_path.path : values.spec.target_path
       },
       status: {},
       uid
     }
-
-    if (data) return console.log(data)
 
     return artifactApi
       .registerArtifact(projectName, data)

--- a/src/components/RegisterArtifactModal/RegisterArtifactModal.js
+++ b/src/components/RegisterArtifactModal/RegisterArtifactModal.js
@@ -51,9 +51,10 @@ const RegisterArtifactModal = ({
 }) => {
   const { isDemoMode } = useMode()
   const initialValues = {
-    description: '',
     kind: artifactKind !== 'artifact' ? artifactKind.toLowerCase() : 'general',
+    description: '',
     key: '',
+    labels: [],
     target_path: isDemoMode
       ? {
           fieldInfo: {
@@ -61,8 +62,7 @@ const RegisterArtifactModal = ({
           },
           path: ''
         }
-      : '',
-    labels: []
+      : ''
   }
   const formRef = React.useRef(
     createForm({
@@ -77,20 +77,27 @@ const RegisterArtifactModal = ({
   const registerArtifact = values => {
     const uid = uuidv4()
     const data = {
-      uid,
-      key: values.key,
-      db_key: values.key,
-      tree: uid,
-      target_path: isDemoMode ? values.target_path.path : values.target_path,
-      description: values.description,
       kind: values.kind === 'general' ? '' : values.kind,
-      labels: convertChipsData(values.labels),
+      metadata: {
+        labels: convertChipsData(values.labels),
+        key: values.key,
+        project: projectName,
+        tree: uid
+      },
       project: projectName,
-      producer: {
-        kind: 'api',
-        uri: window.location.host
-      }
+      spec: {
+        db_key: values.key,
+        producer: {
+          kind: 'api',
+          uri: window.location.host
+        },
+        target_path: isDemoMode ? values.target_path.path : values.target_path
+      },
+      status: {},
+      uid
     }
+
+    if (data) return console.log(data)
 
     return artifactApi
       .registerArtifact(projectName, data)

--- a/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
+++ b/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
@@ -84,7 +84,7 @@ const RegisterArtifactModalForm = ({
         <div className="form-col-2">
           <FormInput
             label="Name"
-            name="key"
+            name="metadata.key"
             required
             tip="Artifact names in the same project must be unique"
             validationRules={getValidationRules('artifact.name')}
@@ -97,21 +97,21 @@ const RegisterArtifactModalForm = ({
         )}
       </div>
       <div className="form-row">
-        <FormTextarea label="Description" maxLength={500} name="description" />
+        <FormTextarea label="Description" maxLength={500} name="metadata.description" />
       </div>
       <div className="form-row">
         {isDemoMode ? (
           <TargetPath
             formState={formState}
-            formStateFieldInfo="target_path.fieldInfo"
+            formStateFieldInfo="spec.target_path.fieldInfo"
             label="Target Path"
-            name="target_path.path"
+            name="spec.target_path.path"
             required
             selectPlaceholder="Path Scheme"
             setFieldState={setFieldState}
           />
         ) : (
-          <FormInput label="Target Path" name="target_path" required />
+          <FormInput label="Target Path" name="spec.target_path" required />
         )}
       </div>
       <div className="form-row">
@@ -121,7 +121,7 @@ const RegisterArtifactModalForm = ({
           initialValues={initialValues}
           isEditMode
           label="labels"
-          name="labels"
+          name="metadata.labels"
           shortChips
           visibleChipsMaxLength="2"
           validationRules={{

--- a/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
+++ b/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
@@ -106,7 +106,6 @@ const RegisterArtifactModalForm = ({
             formStateFieldInfo="target_path.fieldInfo"
             label="Target Path"
             name="target_path.path"
-            onChangeListenerName="target_path.fieldInfo.pathType"
             required
             selectPlaceholder="Path Scheme"
             setFieldState={setFieldState}

--- a/src/elements/RegisterModelPopUp/RegisterModelPopUp.js
+++ b/src/elements/RegisterModelPopUp/RegisterModelPopUp.js
@@ -44,23 +44,27 @@ import './registerModelPopUp.scss'
 function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }) {
   const { isDemoMode } = useMode()
   const initialValues = {
-    description: undefined,
-    labels: [],
-    key: undefined,
-    target_path: isDemoMode
-      ? {
-          fieldInfo: {
-            pathType: ''
-          },
-          path: ''
-        }
-      : undefined
+    metadata: {
+      description: undefined,
+      labels: [],
+      key: undefined
+    },
+    spec: {
+      target_path: isDemoMode
+        ? {
+            fieldInfo: {
+              pathType: ''
+            },
+            path: ''
+          }
+        : undefined
+    }
   }
   const formRef = React.useRef(
     createForm({
-      onSubmit: () => {},
+      initialValues,
       mutators: { ...arrayMutators, setFieldState },
-      initialValues: initialValues
+      onSubmit: () => {}
     })
   )
   const location = useLocation()
@@ -70,32 +74,32 @@ function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }
 
   const registerModel = values => {
     const uid = uuidv4()
+
     const data = {
       kind: 'model',
       metadata: {
-        description: values.description,
-        labels: convertChipsData(values.labels),
-        key: values.key,
+        ...values.metadata,
+        labels: convertChipsData(values.metadata.labels),
         project: projectName,
         tree: uid
       },
       project: projectName,
       spec: {
-        db_key: values.key,
+        db_key: values.metadata.key,
         producer: {
           kind: 'api',
           uri: window.location.host
         },
-        target_path: isDemoMode ? values.target_path.path : values.target_path
+        target_path: isDemoMode ? values.spec.target_path.path : values.spec.target_path
       },
       status: {},
       uid
     }
 
-    if (values.target_path?.path?.includes('/') || values.target_path?.includes('/')) {
+    if (values.spec.target_path?.path?.includes('/') || values.spec.target_path?.includes('/')) {
       const path = isDemoMode
-        ? values.target_path.path.split(/([^/]*)$/)
-        : values.targetPath.split(/([^/]*)$/)
+        ? values.spec.target_path.path.split(/([^/]*)$/)
+        : values.spec.target_path.split(/([^/]*)$/)
 
       data.spec.target_path = path[0]
       data.spec.model_file = path[1]
@@ -152,48 +156,48 @@ function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }
         return (
           <Modal
             actions={getModalActions(formState)}
-            className="register-model"
+            className="register-model form"
             location={location}
             onClose={handleCloseModal}
             show={isOpen}
             size={MODAL_SM}
             title="Register model"
           >
-            <div className="register-model__row">
+            <div className="form-row">
               <FormInput
                 label="Name"
-                name="key"
+                name="metadata.key"
                 required
                 tip="Artifacts names in the same project must be unique."
+                validationRules={getValidationRules('artifact.name')}
               />
             </div>
-            <div className="register-model__row">
-              <FormTextarea name="description" label="Description" maxLength={500} />
+            <div className="form-row">
+              <FormTextarea name="metadata.description" label="Description" maxLength={500} />
             </div>
-            <div className="register-model__row">
+            <div className="form-row">
               {isDemoMode ? (
                 <TargetPath
                   formState={formState}
-                  formStateFieldInfo="target_path.fieldInfo"
+                  formStateFieldInfo="spec.target_path.fieldInfo"
                   label="Target Path"
-                  name="target_path.path"
-                  onChangeListenerName="target_path.fieldInfo.pathType"
+                  name="spec.target_path.path"
                   required
                   selectPlaceholder="Path Scheme"
                   setFieldState={formState.form.mutators.setFieldState}
                 />
               ) : (
-                <FormInput name="target_path" label="Target path" required />
+                <FormInput name="spec.target_path" label="Target path" required />
               )}
             </div>
-            <div className="register-model__row">
+            <div className="form-row">
               <FormChipCell
                 chipOptions={getChipOptions('metrics')}
                 formState={formState}
                 initialValues={initialValues}
                 isEditMode
                 label="labels"
-                name="labels"
+                name="metadata.labels"
                 shortChips
                 visibleChipsMaxLength="2"
                 validationRules={{

--- a/src/elements/RegisterModelPopUp/RegisterModelPopUp.js
+++ b/src/elements/RegisterModelPopUp/RegisterModelPopUp.js
@@ -46,7 +46,7 @@ function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }
   const initialValues = {
     description: undefined,
     labels: [],
-    modelName: undefined,
+    key: undefined,
     target_path: isDemoMode
       ? {
           fieldInfo: {
@@ -68,31 +68,37 @@ function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }
   const filtersStore = useSelector(store => store.filtersStore)
   const dispatch = useDispatch()
 
-  const registerModel = value => {
+  const registerModel = values => {
     const uid = uuidv4()
     const data = {
-      uid: uid,
-      key: value.modelName,
-      db_key: value.modelName,
-      labels: convertChipsData(value.labels),
-      tree: uid,
-      target_path: isDemoMode ? value.target_path.path : value.target_path,
-      description: value.description,
       kind: 'model',
+      metadata: {
+        description: values.description,
+        labels: convertChipsData(values.labels),
+        key: values.key,
+        project: projectName,
+        tree: uid
+      },
       project: projectName,
-      producer: {
-        kind: 'api',
-        uri: window.location.host
-      }
+      spec: {
+        db_key: values.key,
+        producer: {
+          kind: 'api',
+          uri: window.location.host
+        },
+        target_path: isDemoMode ? values.target_path.path : values.target_path
+      },
+      status: {},
+      uid
     }
 
-    if (value.target_path?.path?.includes('/') || value.target_path?.includes('/')) {
+    if (values.target_path?.path?.includes('/') || values.target_path?.includes('/')) {
       const path = isDemoMode
-        ? value.target_path.path.split(/([^/]*)$/)
-        : value.targetPath.split(/([^/]*)$/)
+        ? values.target_path.path.split(/([^/]*)$/)
+        : values.targetPath.split(/([^/]*)$/)
 
-      data.target_path = path[0]
-      data.model_file = path[1]
+      data.spec.target_path = path[0]
+      data.spec.model_file = path[1]
     }
 
     return artifactApi
@@ -156,7 +162,7 @@ function RegisterModelPopUp({ actions, isOpen, onResolve, projectName, refresh }
             <div className="register-model__row">
               <FormInput
                 label="Name"
-                name="modelName"
+                name="key"
                 required
                 tip="Artifacts names in the same project must be unique."
               />

--- a/src/elements/RegisterModelPopUp/registerModelPopUp.scss
+++ b/src/elements/RegisterModelPopUp/registerModelPopUp.scss
@@ -1,8 +1,4 @@
 .register-model {
-  &__row {
-    margin-bottom: 20px;
-  }
-
   .chips-wrapper {
     flex-wrap: wrap;
   }


### PR DESCRIPTION
- **UI**: artifact/model registered via UI is using old format
  Fixed:
   - `TargetPath.js`: Can receive a root key or deep nested
   - `Register Model`: Added name validation 
   - `Register artifact/model`: Send body in new structure
   
  Before:
   <img width="661" alt="Screen Shot 2022-10-26 at 14 11 29" src="https://user-images.githubusercontent.com/63646693/198011701-297c80bb-6420-476a-b504-f1c7db1ef8a7.png">
   <img width="631" alt="Screen Shot 2022-10-26 at 14 06 13" src="https://user-images.githubusercontent.com/63646693/198010684-647ef1e7-0cf1-446f-b561-a9371bb45c69.png">
  
  After:
   <img width="665" alt="Screen Shot 2022-10-26 at 14 11 58" src="https://user-images.githubusercontent.com/63646693/198011786-4e0affa2-9f2e-4b8a-a786-c8a87232bdd5.png">
  <img width="812" alt="Screen Shot 2022-10-26 at 14 08 13" src="https://user-images.githubusercontent.com/63646693/198011070-498597d1-f0f9-47fe-9541-2cfde7659966.png">
