### PR TITLE
Fix [Navbar] project home active state

### DIFF
--- a/src/elements/NavbarLink/NavbarLink.js
+++ b/src/elements/NavbarLink/NavbarLink.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types'
 
 import './NavbarLink.scss'
 
-const NavbarLink = ({ externalLink, icon, label, link }) => {
+const NavbarLink = ({ externalLink, icon, label, link, ...props }) => {
   return (
     <li className="nav-link">
       {externalLink ? (
@@ -32,7 +32,12 @@ const NavbarLink = ({ externalLink, icon, label, link }) => {
           <span>{label}</span>
         </a>
       ) : (
-        <NavLink to={link} className="nav-link__button btn btn-secondary" activeclassname="active">
+        <NavLink
+          to={link}
+          {...props}
+          className="nav-link__button btn btn-secondary"
+          activeclassname="active"
+        >
           {icon}
           <span>{label}</span>
         </NavLink>

--- a/src/layout/Navbar/Navbar.utils.js
+++ b/src/layout/Navbar/Navbar.utils.js
@@ -42,8 +42,9 @@ export const getLinks = (projectName, isDemoMode) => {
       icon: <DashboardIcon />,
       id: 'home',
       label: 'Project home',
-      link: `${pathname}/`,
-      hidden: !isDemoMode
+      link: `${pathname}`,
+      hidden: !isDemoMode,
+      end: true
     },
     {
       icon: <EyeIcon />,


### PR DESCRIPTION
- **Navbar**: project home active state

   Before: 
   ![Screen Shot 2022-10-31 at 15 57 09](https://user-images.githubusercontent.com/63646693/199025091-5b1a4086-5bb8-435a-968a-a783c577a778.png)
   
   After:
   ![Screen Shot 2022-10-31 at 15 57 36](https://user-images.githubusercontent.com/63646693/199025189-573fb2bd-9d34-48a9-a019-3cbbb11a249f.png)

   
