### PR TITLE
Fix [Artifacts] The type is empty for General artifact created in UI

### DIFF
--- a/src/components/Datasets/DatasetsView.js
+++ b/src/components/Datasets/DatasetsView.js
@@ -70,7 +70,7 @@ const DatasetsView = React.forwardRef(
               actionsMenuHeader={actionsMenuHeader}
               onClick={() =>
                 openPopUp(RegisterArtifactModal, {
-                  artifactKind: 'artifact',
+                  artifactKind: 'dataset',
                   projectName: params.projectName,
                   refresh: handleRefresh,
                   title: actionsMenuHeader

--- a/src/components/Project/ProjectOverview/ProjectOverview.util.js
+++ b/src/components/Project/ProjectOverview/ProjectOverview.util.js
@@ -144,6 +144,7 @@ export const getInitialCards = (projectName, navigate) => {
                   label: 'Register',
                   onClick: async () => {
                     await formState.handleSubmit()
+
                     if (!formState.invalid) {
                       navigate(`${base_url}/files`)
                     }

--- a/src/components/RegisterArtifactModal/RegisterArtifactModal.js
+++ b/src/components/RegisterArtifactModal/RegisterArtifactModal.js
@@ -51,7 +51,7 @@ const RegisterArtifactModal = ({
 }) => {
   const { isDemoMode } = useMode()
   const initialValues = {
-    kind: artifactKind !== 'artifact' ? artifactKind.toLowerCase() : 'general',
+    kind: artifactKind.toLowerCase(),
     metadata: {
       description: '',
       key: '',
@@ -81,7 +81,7 @@ const RegisterArtifactModal = ({
   const registerArtifact = values => {
     const uid = uuidv4()
     const data = {
-      kind: values.kind === 'general' ? '' : values.kind,
+      kind: values.kind,
       metadata: {
         labels: convertChipsData(values.metadata.labels),
         key: values.metadata.key,

--- a/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
+++ b/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
@@ -40,7 +40,7 @@ const RegisterArtifactModalForm = ({
     () => [
       {
         label: 'General',
-        id: 'general'
+        id: 'artifact'
       },
       {
         label: 'Chart',


### PR DESCRIPTION
- **Artifacts**: The type is empty for General artifact created in UI
   Jira: [ML-2749](https://jira.iguazeng.com/browse/ML-2749)
   
   After: 
   <img width="660" alt="Screen Shot 2022-11-09 at 10 24 46" src="https://user-images.githubusercontent.com/63646693/200777329-04821f9b-a880-4df9-9e5f-942224bfd994.png">

   