### PR TITLE
Fix [Project Overview] "Create RT function" should navigate to "new function" wizard

### DIFF
--- a/src/components/Project/ProjectOverview/ProjectOverview.util.js
+++ b/src/components/Project/ProjectOverview/ProjectOverview.util.js
@@ -332,7 +332,7 @@ export const getInitialCards = (projectName, navigate) => {
           icon: <RTFunctionIcon />,
           label: 'Create RT function',
           handleClick: () => ({
-            path: generateNuclioLink(`${base_url}/functions`),
+            path: generateNuclioLink(`${base_url}/create-function`),
             externalLink: true
           }),
           tooltip: ''


### PR DESCRIPTION
- **Project Overview** "Create RT function" should navigate to "new function" wizard
   Jira: [ML-2786](https://jira.iguazeng.com/browse/ML-2786)