### PR TITLE
Fix [Artifacts] add existing tag name warning

### DIFF
--- a/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
+++ b/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
@@ -145,14 +145,13 @@ const AddArtifactTagPopUp = ({
                     label="Artifact tag"
                     focused
                     required
-                    validationRules={[
-                      ...getValidationRules('common.tag'),
-                      {
+                    validator={value =>
+                      existingTags.includes(value) && {
                         name: 'uniqueness',
-                        label: 'Tag already exists',
-                        pattern: value => !existingTags.includes(value)
+                        label: 'Tag already exists'
                       }
-                    ]}
+                    }
+                    validationRules={getValidationRules('common.tag')}
                   />
                 </div>
               </div>

--- a/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
+++ b/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
@@ -145,13 +145,13 @@ const AddArtifactTagPopUp = ({
                     label="Artifact tag"
                     focused
                     required
-                    validator={value =>
-                      existingTags.includes(value) && {
+                    validationRules={getValidationRules('common.tag', [
+                      {
                         name: 'uniqueness',
-                        label: 'Tag already exists'
+                        label: 'Tag name must be unquie',
+                        pattern: value => !existingTags.includes(value)
                       }
-                    }
-                    validationRules={getValidationRules('common.tag')}
+                    ])}
                   />
                 </div>
               </div>


### PR DESCRIPTION
- **Artifacts**: add existing tag name warning

   Before:
   ![image](https://user-images.githubusercontent.com/63646693/203372684-48167feb-04e8-426f-84ae-e8694d251c8d.png)

   After:
   <img width="530" alt="Screen Shot 2022-11-24 at 10 10 01" src="https://user-images.githubusercontent.com/63646693/203727877-416a69b5-78d4-4e7d-9d51-5f5236e6410c.png">



   