### PR TITLE
Fix [Projects] unclear error 'Failed to delete project' when user does not have enough permissions

### DIFF
--- a/src/components/ProjectsPage/Projects.js
+++ b/src/components/ProjectsPage/Projects.js
@@ -35,8 +35,7 @@ import {
 import nuclioActions from '../../actions/nuclio'
 import { setNotification } from '../../reducers/notificationReducer'
 import projectsAction from '../../actions/projects'
-import { DANGER_BUTTON, PRIMARY_BUTTON } from 'igz-controls/constants'
-import { FORBIDDEN_ERROR_STATUS_CODE } from 'igz-controls/constants'
+import { DANGER_BUTTON, FORBIDDEN_ERROR_STATUS_CODE, PRIMARY_BUTTON } from 'igz-controls/constants'
 
 import { useNuclioMode } from '../../hooks/nuclioMode.hook'
 

--- a/src/components/ProjectsPage/projectsData.js
+++ b/src/components/ProjectsPage/projectsData.js
@@ -19,7 +19,7 @@ such restriction.
 */
 import React from 'react'
 
-import { DANGER_BUTTON } from 'igz-controls/constants'
+import { DANGER_BUTTON, FORBIDDEN_ERROR_STATUS_CODE } from 'igz-controls/constants'
 
 import { ReactComponent as Yaml } from 'igz-controls/images/yaml.svg'
 import { ReactComponent as Delete } from 'igz-controls/images/delete.svg'
@@ -87,7 +87,6 @@ export const projectsSortOptions = [
   }
 ]
 export const successProjectDeletingMessage = 'Project deleted successfully'
-export const failedProjectDeletingMessage = 'Failed to delete project'
 
 export const handleDeleteProjectError = (
   error,
@@ -119,7 +118,10 @@ export const handleDeleteProjectError = (
         status: 400,
         id: Math.random(),
         retry: () => handleDeleteProject(project),
-        message: failedProjectDeletingMessage
+        message:
+          error.response?.status === FORBIDDEN_ERROR_STATUS_CODE
+            ? `You are not allowed to delete ${project.metadata.name} project`
+            : `Failed to delete ${project.metadata.name} project`
       })
     )
   }


### PR DESCRIPTION
- **Projects**: unclear error 'Failed to delete project' when user does not have enough permissions
   Backported to `1.2.x` from #1493 
   Jira: [ML-2940](https://jira.iguazeng.com/browse/ML-2940)
   
   Before:
   <img width="449" alt="Screen Shot 2022-12-06 at 14 46 51" src="https://user-images.githubusercontent.com/63646693/205916939-b2051102-693d-467d-9111-a95bfceb2320.png">

   After:
   <img width="466" alt="Screen Shot 2022-12-06 at 14 49 03" src="https://user-images.githubusercontent.com/63646693/205916983-03d0f929-7d34-48bb-8904-e750b065c6b8.png">
