### PR TITLE
Fix [UI] Put MLRun icon instead of the 'M'

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "final-form-arrays": "^3.0.2",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "0.0.27",
+    "iguazio.dashboard-react-controls": "0.0.28",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^3.13.1",

--- a/src/layout/Header/Header.js
+++ b/src/layout/Header/Header.js
@@ -20,7 +20,7 @@ such restriction.
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import logo from 'igz-controls/images/mlrun-logo-circle-small.png'
+import logo from 'igz-controls/images/mlrun-logo-small.png'
 
 import './header.scss'
 
@@ -28,8 +28,7 @@ const Header = () => {
   return (
     <header className="header">
       <Link to="/" className="header__logo">
-        <img src={logo} alt="Logo" />
-        <h1>MLRun</h1>
+        <img src={logo} alt="MLRun" />
       </Link>
 
       <a

--- a/src/layout/Header/header.scss
+++ b/src/layout/Header/header.scss
@@ -20,8 +20,7 @@
   &__logo {
     display: flex;
     align-items: center;
-    width: 43px;
-    height: 43px;
+    width: 90px;
 
     img {
       width: 100%;


### PR DESCRIPTION
- **UI** Put MLRun icon instead of the 'M'
   Backported to `1.2.x` from #1496 
   Jira: [CEML-53](https://jira.iguazeng.com/browse/CEML-53)
   
   Before:
   <img width="449" alt="Screen Shot 2022-12-06 at 17 11 33" src="https://user-images.githubusercontent.com/63646693/205950032-9ae07d1a-1955-40a5-9d72-d782aa6a0405.png">
   
   After:
   <img width="398" alt="Screen Shot 2022-12-06 at 17 11 48" src="https://user-images.githubusercontent.com/63646693/205950046-faaf5d77-dd94-4084-8c22-91d829962ae9.png">
