### PR TITLE
Fix [Datasets] upon log_dataset with extra_data UI "Preview" tab does not show actual data but extra_data

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreview.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreview.js
@@ -19,13 +19,13 @@ such restriction.
 */
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 
 import ArtifactsPreviewView from './ArtifactsPreviewView'
 import Loader from '../../common/Loader/Loader'
 import NoData from '../../common/NoData/NoData'
-import classnames from 'classnames'
 
-const ArtifactsPreview = ({ className, noData, preview }) => {
+const ArtifactsPreview = ({ className, extraData, noData, preview }) => {
   const [showErrorBody, setShowErrorBody] = useState(false)
   const artifactsPreviewClasses = classnames('artifact-preview', className)
 
@@ -36,24 +36,42 @@ const ArtifactsPreview = ({ className, noData, preview }) => {
   ) : noData ? (
     <NoData />
   ) : (
-    preview.map((previewItem, index) => (
-      <ArtifactsPreviewView
-        className={artifactsPreviewClasses}
-        key={index}
-        preview={previewItem}
-        setShowErrorBody={setShowErrorBody}
-        showErrorBody={showErrorBody}
-      />
-    ))
+    <>
+      {preview.map((previewItem, index) => (
+        <ArtifactsPreviewView
+          className={artifactsPreviewClasses}
+          key={index}
+          preview={previewItem}
+          setShowErrorBody={setShowErrorBody}
+          showErrorBody={showErrorBody}
+        />
+      ))}
+      {extraData.length > 0 && (
+        <div className="artifact-extra-data">
+          <h1 className="artifact-extra-data__header">Extra Data</h1>
+          {extraData.map((extraDataItem, index) => (
+            <ArtifactsPreviewView
+              className={artifactsPreviewClasses}
+              key={index}
+              preview={extraDataItem}
+              setShowErrorBody={setShowErrorBody}
+              showErrorBody={showErrorBody}
+            />
+          ))}
+        </div>
+      )}
+    </>
   )
 }
 
 ArtifactsPreview.defaultProps = {
-  className: ''
+  className: '',
+  extraData: []
 }
 
 ArtifactsPreview.propTypes = {
   className: PropTypes.string,
+  extraData: PropTypes.array,
   noData: PropTypes.bool.isRequired,
   preview: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/ArtifactsPreview/artifactsPreview.scss
+++ b/src/components/ArtifactsPreview/artifactsPreview.scss
@@ -1,99 +1,108 @@
 @import '~igz-controls/scss/colors';
 @import '~igz-controls/scss/borders';
 
-.artifact-preview {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  overflow-x: auto;
-
-  &__with-popout {
-    margin-right: 33px;
+.artifact {
+  &-extra-data {
+    &__header {
+      margin: 45px 0 0;
+    }
   }
 
-  &__header {
-    margin: 30px 0;
-  }
-
-  .json-content {
-    white-space: pre-wrap;
-  }
-
-  &__error {
+  &-preview {
     display: flex;
+    flex: 1;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding-top: 50px;
+    overflow-x: auto;
 
-    .json-content {
-      width: 100%;
-    }
-  }
-
-  &__table {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
-    color: $mulledWine;
-
-    &-header {
-      position: sticky;
-      top: 0;
-      z-index: 2;
-      font-weight: 500;
-      background-color: $white;
-    }
-
-    &-body {
-      display: flex;
-      flex-direction: column;
-      min-width: 100%;
-      max-height: 340px;
-    }
-
-    &-row {
-      display: flex;
-      min-width: 100%;
-      padding: 10px;
-      border-bottom: $secondaryBorder;
-
-      &:last-child {
-        border-bottom: none;
-      }
-
-      &:not(.table-header) {
-        &:hover {
-          background-color: $alabaster;
-        }
-      }
+    &__with-popout {
+      margin-right: 33px;
     }
 
     &__header {
-      flex: 1;
-      width: 50px;
-      padding: 0 5px;
+      margin: 30px 0;
     }
 
-    &-content {
-      flex: 1;
-      width: 150px;
-      padding: 0 5px;
+    .json-content {
+      white-space: pre-wrap;
     }
-  }
 
-  &__image {
-    width: 100%;
-  }
+    &__error {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding-top: 50px;
 
-  iframe {
-    min-height: 560px;
-  }
+      .json-content {
+        width: 100%;
+      }
+    }
+
+    &__table {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+      color: $mulledWine;
+
+      &-header {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+        font-weight: 500;
+        background-color: $white;
+      }
+
+      &-body {
+        display: flex;
+        flex-direction: column;
+        min-width: 100%;
+        max-height: 340px;
+      }
+
+      &-row {
+        display: flex;
+        min-width: 100%;
+        padding: 10px;
+        border-bottom: $secondaryBorder;
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        &:not(.table-header) {
+          &:hover {
+            background-color: $alabaster;
+          }
+        }
+      }
+
+      &__header {
+        flex: 1;
+        width: 50px;
+        padding: 0 5px;
+      }
+
+      &-content {
+        flex: 1;
+        width: 150px;
+        padding: 0 5px;
+      }
+    }
+
+    &__image {
+      width: 100%;
+    }
+
+    iframe {
+      min-height: 560px;
+    }
 }
+}
+
 
 .loader-container {
   position: relative;

--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -26,19 +26,34 @@ import { Tooltip, TextTooltipTemplate } from 'igz-controls/components'
 
 import { ReactComponent as Popout } from 'igz-controls/images/popout.svg'
 
-import { getArtifactPreview } from '../../utils/getArtifactPreview'
+import {
+  fetchArtifactPreviewFromExtraData,
+  getArtifactPreview
+} from '../../utils/getArtifactPreview'
 
 const DetailsPreview = ({ artifact, handlePreview }) => {
   const [preview, setPreview] = useState([])
+  const [extraData, setExtraData] = useState([])
   const [noData, setNoData] = useState(false)
 
   useEffect(() => {
     getArtifactPreview(artifact, noData, setNoData, setPreview)
+  }, [artifact, noData])
 
+  useEffect(() => {
+    if (artifact.extra_data && extraData.length === 0) {
+      fetchArtifactPreviewFromExtraData(artifact, noData, setNoData, previewContent =>
+        setExtraData(state => [...state, previewContent])
+      )
+    }
+  }, [artifact, extraData.length, noData])
+
+  useEffect(() => {
     return () => {
       setPreview([])
+      setExtraData([])
     }
-  }, [artifact, noData])
+  }, [])
 
   const artifactsPreviewClassNames = classnames(
     artifact.target_path && 'artifact-preview__with-popout'
@@ -55,6 +70,7 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
       )}
       <ArtifactsPreview
         className={artifactsPreviewClassNames}
+        extraData={extraData}
         noData={noData}
         preview={preview}
       />

--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -27,13 +27,17 @@ import Download from '../../common/Download/Download'
 import { Tooltip, TextTooltipTemplate, PopUpDialog } from 'igz-controls/components'
 
 import { formatDatetime } from '../../utils'
-import { getArtifactPreview } from '../../utils/getArtifactPreview'
+import {
+  fetchArtifactPreviewFromExtraData,
+  getArtifactPreview
+} from '../../utils/getArtifactPreview'
 import { closeArtifactsPreview } from '../../reducers/artifactsReducer'
 
 import './previewModal.scss'
 
 const PreviewModal = ({ item }) => {
   const [preview, setPreview] = useState([])
+  const [extraData, setExtraData] = useState([])
   const [noData, setNoData] = useState(false)
   const dispatch = useDispatch()
 
@@ -42,6 +46,21 @@ const PreviewModal = ({ item }) => {
       getArtifactPreview(item, noData, setNoData, setPreview)
     }
   }, [item, noData, preview.length])
+
+  useEffect(() => {
+    if (item.extra_data && extraData.length === 0) {
+      fetchArtifactPreviewFromExtraData(item, noData, setNoData, previewContent =>
+        setExtraData(state => [...state, previewContent])
+      )
+    }
+  }, [item, extraData.length, noData])
+
+  useEffect(() => {
+    return () => {
+      setPreview([])
+      setExtraData([])
+    }
+  }, [])
 
   return (
     <PopUpDialog
@@ -82,7 +101,7 @@ const PreviewModal = ({ item }) => {
             </div>
           </div>
           <div className="item-artifacts__preview">
-            <ArtifactsPreview noData={noData} preview={preview} />
+            <ArtifactsPreview extraData={extraData} noData={noData} preview={preview} />
           </div>
         </div>
       </div>

--- a/src/utils/generateArtifacts.js
+++ b/src/utils/generateArtifacts.js
@@ -45,9 +45,9 @@ export const generateArtifacts = (artifacts, tab, originalContent) => {
             if (generatedArtifact.extra_data) {
               const generatedPreviewData = generateArtifactPreviewData(generatedArtifact.extra_data)
 
-              item.preview = generatedPreviewData.preview
+              item.extra_data = generatedPreviewData.preview
             } else {
-              item.preview ??= []
+              item.extra_data ??= []
             }
 
             if (!generatedArtifact.ui) {

--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -20,12 +20,7 @@ such restriction.
 import api from '../api/artifacts-api'
 import { createArtifactPreviewContent } from './createArtifactPreviewContent'
 
-export const setArtifactPreviewFromSchema = (
-  artifact,
-  noData,
-  setNoData,
-  setPreview
-) => {
+export const setArtifactPreviewFromSchema = (artifact, noData, setNoData, setPreview) => {
   if (noData) {
     setNoData(false)
   }
@@ -41,12 +36,7 @@ export const setArtifactPreviewFromSchema = (
   ])
 }
 
-export const setArtifactPreviewFromPreviewData = (
-  artifact,
-  noData,
-  setNoData,
-  setPreview
-) => {
+export const setArtifactPreviewFromPreviewData = (artifact, noData, setNoData, setPreview) => {
   if (noData) {
     setNoData(false)
   }
@@ -62,17 +52,11 @@ export const setArtifactPreviewFromPreviewData = (
   ])
 }
 
-export const fetchArtifactPreviewFromPreviewData = (
-  artifact,
-  noData,
-  setNoData,
-  setPreview
-) => {
-  artifact.preview.forEach(previewItem => {
+export const fetchArtifactPreviewFromExtraData = (artifact, noData, setNoData, setPreview) => {
+  artifact.extra_data.forEach(previewItem => {
     fetchArtifactPreview(
       previewItem.path,
-      previewItem.path.startsWith('/User') &&
-        (artifact.user || artifact.producer.owner),
+      previewItem.path.startsWith('/User') && (artifact.user || artifact.producer.owner),
       previewItem.path.replace(/.*\./g, '')
     )
       .then(content => {
@@ -96,16 +80,10 @@ export const fetchArtifactPreviewFromPreviewData = (
   })
 }
 
-export const fetchArtifactPreviewFromTargetPath = (
-  artifact,
-  noData,
-  setNoData,
-  setPreview
-) => {
+export const fetchArtifactPreviewFromTargetPath = (artifact, noData, setNoData, setPreview) => {
   fetchArtifactPreview(
     artifact.target_path,
-    artifact.target_path.startsWith('/User') &&
-      (artifact.user || artifact.producer?.owner),
+    artifact.target_path.startsWith('/User') && (artifact.user || artifact.producer?.owner),
     artifact.target_path.replace(/.*\./g, '')
   )
     .then(content => {
@@ -135,11 +113,7 @@ export const fetchArtifactPreview = (path, user, fileFormat) => {
   })
 }
 
-const handleSetArtifactPreviewObject = (
-  previewContent,
-  artifactIndex,
-  setPreview
-) => {
+const handleSetArtifactPreviewObject = (previewContent, artifactIndex, setPreview) => {
   setPreview(state => {
     if (state[artifactIndex]) {
       return {
@@ -149,9 +123,7 @@ const handleSetArtifactPreviewObject = (
     } else {
       return {
         ...state,
-        [artifactIndex]: Array.isArray(previewContent)
-          ? previewContent
-          : [previewContent]
+        [artifactIndex]: Array.isArray(previewContent) ? previewContent : [previewContent]
       }
     }
   })
@@ -165,60 +137,23 @@ export const getArtifactPreview = (
   previewIsObject = false,
   artifactIndex = null
 ) => {
-  if (artifact.schema && !artifact.extra_data) {
+  if (artifact.schema) {
     setArtifactPreviewFromSchema(artifact, noData, setNoData, previewContent =>
       previewIsObject
-        ? handleSetArtifactPreviewObject(
-            previewContent,
-            artifactIndex,
-            setPreview
-          )
+        ? handleSetArtifactPreviewObject(previewContent, artifactIndex, setPreview)
         : setPreview(previewContent)
     )
   } else if (artifact.preview?.length > 0 && !artifact.target_path) {
-    setArtifactPreviewFromPreviewData(
-      artifact,
-      noData,
-      setNoData,
-      previewContent =>
-        previewIsObject
-          ? handleSetArtifactPreviewObject(
-              previewContent,
-              artifactIndex,
-              setPreview
-            )
-          : setPreview(previewContent)
+    setArtifactPreviewFromPreviewData(artifact, noData, setNoData, previewContent =>
+      previewIsObject
+        ? handleSetArtifactPreviewObject(previewContent, artifactIndex, setPreview)
+        : setPreview(previewContent)
     )
-  } else if (artifact.preview?.length > 0) {
-    fetchArtifactPreviewFromPreviewData(
-      artifact,
-      noData,
-      setNoData,
-      previewContent =>
-        previewIsObject
-          ? handleSetArtifactPreviewObject(
-              previewContent,
-              artifactIndex,
-              setPreview
-            )
-          : setPreview(state => [...state, previewContent])
-    )
-  } else if (
-    (artifact.preview?.length === 0 || !artifact.preview) &&
-    artifact.target_path
-  ) {
-    fetchArtifactPreviewFromTargetPath(
-      artifact,
-      noData,
-      setNoData,
-      previewContent =>
-        previewIsObject
-          ? handleSetArtifactPreviewObject(
-              previewContent,
-              artifactIndex,
-              setPreview
-            )
-          : setPreview(previewContent)
+  } else if ((artifact.preview?.length === 0 || !artifact.preview) && artifact.target_path) {
+    fetchArtifactPreviewFromTargetPath(artifact, noData, setNoData, previewContent =>
+      previewIsObject
+        ? handleSetArtifactPreviewObject(previewContent, artifactIndex, setPreview)
+        : setPreview(previewContent)
     )
   } else {
     setNoData(true)


### PR DESCRIPTION
- **Datasets**: upon log_dataset with extra_data UI "Preview" tab does not show actual data but extra_data
   Backported to `1.2.x` from #1503 
   Jira: https://jira.iguazeng.com/browse/ML-2910

   ![Screenshot from 2022-12-07 15-36-29](https://user-images.githubusercontent.com/58301139/206194605-6818ca03-5cce-445c-ab13-60011519363d.png)
   ![Screenshot from 2022-12-07 15-37-11](https://user-images.githubusercontent.com/58301139/206194611-088728c7-6178-4fae-9881-42ed1b50120a.png)
