### PR TITLE
Fix [Jobs] Creating a job using a function from a different project gets 404 - uses wrong function URI

### DIFF
--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -527,7 +527,7 @@ export const generateRequestData = (
   const func = isFunctionTemplate
     ? `hub://${selectedFunction.metadata.name.replace(/-/g, '_')}`
     : defaultFunc ??
-      `${params.projectName}/${selectedFunction.metadata.name}@${selectedFunction.metadata.hash}`
+      `${project}/${selectedFunction.metadata.name}@${selectedFunction.metadata.hash}`
   const resources = {
     limits: {},
     requests: {}


### PR DESCRIPTION
- **Jobs**: Creating a job using a function from a different project gets 404 - uses wrong function URI
   Backported to `1.2.x` from #1505 
   Jira: https://jira.iguazeng.com/browse/ML-2961