### PR TITLE
Fix [Models-endpoint] Uptime/Last prediction are cropped in "Model Endpoints" screen

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -401,20 +401,20 @@ export const createModelEndpointsRowData = (artifact, project) => {
         id: `labels.${artifact.ui.identifierUnique}`,
         header: 'Labels',
         value: parseKeyValues(artifact.metadata?.labels),
-        class: 'artifacts_big',
+        class: 'artifacts_medium',
         type: 'labels'
       },
       {
         id: `firstRequest.${artifact.ui.identifierUnique}`,
         header: 'Uptime',
         value: formatDatetime(artifact.status?.first_request, '-'),
-        class: 'artifacts_small'
+        class: 'artifacts_medium'
       },
       {
         id: `lastRequest.${artifact.ui.identifierUnique}`,
         header: 'Last prediction',
         value: formatDatetime(artifact.status?.last_request, '-'),
-        class: 'artifacts_small'
+        class: 'artifacts_medium'
       },
       {
         id: `averageLatency.${artifact.ui.identifierUnique}`,


### PR DESCRIPTION
- **Models-endpoint** Uptime/Last prediction are cropped in "Model Endpoints" screen
   Backported to `1.2.1` from #1547 
   Jira: https://jira.iguazeng.com/browse/ML-3077

   ![image](https://user-images.githubusercontent.com/78905712/208619685-05e6c593-1947-41ff-80fb-93e97cb7a6be.png)
