### PR TITLE
Fix [UI] Edit a an artifact tag from the overview tab does not have exit option `1.2.1`

### DIFF
--- a/src/components/DetailsInfo/DetailsInfo.js
+++ b/src/components/DetailsInfo/DetailsInfo.js
@@ -67,6 +67,20 @@ const DetailsInfo = React.forwardRef(
       }
     }, [onApplyChanges])
 
+    const handleDiscardChanges = field => {
+      detailsInfoDispatch({
+        type: detailsInfoActions.RESET_EDIT_MODE
+      })
+
+      setChangesData({
+        ...detailsStore.changes.data,
+        [field]: {
+          ...detailsStore.changes.data[field],
+          currentFieldValue: detailsStore.changes.data[field]?.initialFieldValue
+        }
+      })
+    }
+
     const handleInfoItemClick = (field, fieldType, info) => {
       if (isEveryObjectValueEmpty(detailsInfoState.editMode)) {
         detailsInfoDispatch({
@@ -112,6 +126,7 @@ const DetailsInfo = React.forwardRef(
         detailsInfoDispatch={detailsInfoDispatch}
         detailsInfoState={detailsInfoState}
         detailsStore={detailsStore}
+        handleDiscardChanges={handleDiscardChanges}
         handleFinishEdit={() =>
           handleFinishEdit(
             Object.keys(detailsStore.changes.data),

--- a/src/components/DetailsInfo/DetailsInfo.js
+++ b/src/components/DetailsInfo/DetailsInfo.js
@@ -76,7 +76,7 @@ const DetailsInfo = React.forwardRef(
         ...detailsStore.changes.data,
         [field]: {
           ...detailsStore.changes.data[field],
-          currentFieldValue: detailsStore.changes.data[field]?.initialFieldValue
+          currentFieldValue: detailsStore.changes.data[field]?.previousFieldValue
         }
       })
     }

--- a/src/components/DetailsInfo/DetailsInfoView.js
+++ b/src/components/DetailsInfo/DetailsInfoView.js
@@ -47,6 +47,7 @@ const DetailsInfoView = React.forwardRef(
       detailsInfoDispatch,
       detailsInfoState,
       detailsStore,
+      handleDiscardChanges,
       handleFinishEdit,
       handleInfoItemClick,
       pageData,
@@ -156,6 +157,7 @@ const DetailsInfoView = React.forwardRef(
                         detailsInfoDispatch={detailsInfoDispatch}
                         editableFieldType={detailsInfoState.editMode.fieldType}
                         func={func}
+                        handleDiscardChanges={handleDiscardChanges}
                         handleFinishEdit={handleFinishEdit}
                         info={info}
                         isFieldInEditMode={detailsInfoState.editMode.field === header.id}

--- a/src/elements/DetailsInfoItem/DetailsInfoItem.js
+++ b/src/elements/DetailsInfoItem/DetailsInfoItem.js
@@ -48,6 +48,7 @@ const DetailsInfoItem = React.forwardRef(
       detailsInfoDispatch,
       editableFieldType,
       func,
+      handleDiscardChanges,
       handleFinishEdit,
       info,
       isFieldInEditMode,
@@ -95,16 +96,13 @@ const DetailsInfoItem = React.forwardRef(
             {editableFieldType === 'textarea' && (
               <TextArea focused maxLength={500} onChange={item.onChange} type="text" value={info} />
             )}
-            {inputIsValid && (
-              <RoundedIcon onClick={handleFinishEdit} tooltipText="Apply">
-                <Checkmark />
-              </RoundedIcon>
-            )}
+
+            <RoundedIcon disabled={!inputIsValid} onClick={handleFinishEdit} tooltipText="Apply">
+              <Checkmark />
+            </RoundedIcon>
 
             <RoundedIcon
-              onClick={() => {
-                console.log(currentField, item?.editModeType, info, item)
-              }}
+              onClick={() => handleDiscardChanges(currentField)}
               tooltipText="Discard changes"
             >
               <Close />

--- a/src/elements/DetailsInfoItem/DetailsInfoItem.js
+++ b/src/elements/DetailsInfoItem/DetailsInfoItem.js
@@ -32,7 +32,8 @@ import { Tooltip, TextTooltipTemplate, RoundedIcon } from 'igz-controls/componen
 import { CHIP_OPTIONS } from '../../types'
 import { copyToClipboard } from '../../utils/copyToClipboard'
 
-import { ReactComponent as Checkmark } from 'igz-controls/images/checkmark.svg'
+import { ReactComponent as Checkmark } from 'igz-controls/images/checkmark2.svg'
+import { ReactComponent as Close } from 'igz-controls/images/close.svg'
 import { ReactComponent as Copy } from 'igz-controls/images/ic_copy-to-clipboard.svg'
 import { ReactComponent as Edit } from 'igz-controls/images/edit.svg'
 
@@ -95,12 +96,19 @@ const DetailsInfoItem = React.forwardRef(
               <TextArea focused maxLength={500} onChange={item.onChange} type="text" value={info} />
             )}
             {inputIsValid && (
-              <Tooltip template={<TextTooltipTemplate text="Apply" />}>
-                <RoundedIcon onClick={handleFinishEdit} tooltipText="Apply">
-                  <Checkmark className="details-item__apply-btn" />
-                </RoundedIcon>
-              </Tooltip>
+              <RoundedIcon onClick={handleFinishEdit} tooltipText="Apply">
+                <Checkmark />
+              </RoundedIcon>
             )}
+
+            <RoundedIcon
+              onClick={() => {
+                console.log(currentField, item?.editModeType, info, item)
+              }}
+              tooltipText="Discard changes"
+            >
+              <Close />
+            </RoundedIcon>
           </div>
         )
       }


### PR DESCRIPTION
- **UI**: Edit a an artifact tag from the overview tab does not have exit option `1.2.1`
   Backported to `1.2.1` from #1555 
   Jira: [ML-3061](https://jira.iguazeng.com/browse/ML-3061)
   
   Before:
   <img width="1228" alt="Screen Shot 2022-12-20 at 15 30 08" src="https://user-images.githubusercontent.com/63646693/208678517-a61dbb8e-fb7d-44db-a362-53990cbd232c.png">

   After:
   <img width="1264" alt="Screen Shot 2022-12-20 at 15 29 35" src="https://user-images.githubusercontent.com/63646693/208678405-39ebe7fd-d82a-417f-914a-be7231638fbf.png">
