### PR TITLE
Fix [UI] Scheduled Jobs are triggered at +1 day

### DIFF
--- a/src/components/ScheduleCron/ScheduleCron.js
+++ b/src/components/ScheduleCron/ScheduleCron.js
@@ -19,14 +19,16 @@ such restriction.
 */
 import React from 'react'
 import PropTypes from 'prop-types'
-import cronstrue from 'cronstrue'
 
 import Input from '../../common/Input/Input'
 
 const ScheduleCron = ({ cron, setCron }) => {
   return (
     <>
-      <p>Note: all times are interpreted in UTC timezone</p>
+      <p>
+        Note: all times are interpreted in UTC timezone. <br />
+        The first weekday (0) is always <b>Monday</b>.
+      </p>
       <Input
         placeholder="10 * * * *"
         value={cron}
@@ -34,11 +36,6 @@ const ScheduleCron = ({ cron, setCron }) => {
         onChange={setCron}
         type="text"
       />
-      <p>
-        {cronstrue.toString(cron, {
-          throwExceptionOnParseError: false
-        })}
-      </p>
       <div>
         You can use{' '}
         <a

--- a/src/components/SheduleWizard/ScheduleWizard.js
+++ b/src/components/SheduleWizard/ScheduleWizard.js
@@ -131,7 +131,10 @@ const ScheduleWizard = ({
             {activeTab === tabs[0].id ? 'Simple ' : 'Advanced '}
             Schedule
           </h3>
-          <p>Note: all times are interpreted in UTC timezone</p>
+          <p>
+            Note: all times are interpreted in UTC timezone. <br />
+            The first weekday (0) is always <b>Monday</b>.
+          </p>
 
           {activeTab === tabs[0].id && (
             <ScheduleWizardSimple
@@ -141,7 +144,7 @@ const ScheduleWizard = ({
             />
           )}
 
-          {activeTab === tabs[1].id && <ScheduleWizardCronstring scheduleData={scheduleData} />}
+          {activeTab === tabs[1].id && <ScheduleWizardCronstring />}
         </div>
         <div className="modal__footer-actions">
           <Button label="Cancel" onClick={() => setShowSchedule(false)} variant={TERTIARY_BUTTON} />

--- a/src/components/SheduleWizard/ScheduleWizardCronstring.js
+++ b/src/components/SheduleWizard/ScheduleWizardCronstring.js
@@ -18,21 +18,14 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import React from 'react'
-import cronstrue from 'cronstrue'
 
 import { FormInput } from 'igz-controls/components'
-import { SCHEDULE_DATA } from '../../types'
 
-const ScheduleWizardCronstring = ({ scheduleData }) => {
+const ScheduleWizardCronstring = () => {
   return (
     <>
       <FormInput label="Expression" name="scheduleData.cron" placeholder="10 * * * *" />
-      <p className="cron-text">
-        {cronstrue.toString(scheduleData.cron, {
-          throwExceptionOnParseError: false
-        })}
-      </p>
-      <div>
+      <div className="cronstring-note">
         You can use{' '}
         <a
           className="link cron-link"
@@ -46,10 +39,6 @@ const ScheduleWizardCronstring = ({ scheduleData }) => {
       </div>
     </>
   )
-}
-
-ScheduleWizardCronstring.propTypes = {
-  scheduleData: SCHEDULE_DATA.isRequired
 }
 
 export default ScheduleWizardCronstring

--- a/src/components/SheduleWizard/scheduleWizard.scss
+++ b/src/components/SheduleWizard/scheduleWizard.scss
@@ -35,7 +35,7 @@
         text-transform: uppercase;
       }
 
-      .cron-text {
+      .cronstring-note {
         max-width: 600px;
         margin: 8px 0;
       }

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { isEmpty } from 'lodash'
 
-import { Tooltip, TextTooltipTemplate } from 'igz-controls/components'
+import { Tip, Tooltip, TextTooltipTemplate } from 'igz-controls/components'
 
 const TableHead = React.forwardRef(({ content, mainRowItemsCount, selectedItem }, ref) => {
   return (
@@ -39,6 +39,7 @@ const TableHead = React.forwardRef(({ content, mainRowItemsCount, selectedItem }
             <Tooltip template={<TextTooltipTemplate text={tableItem.header} />}>
               {tableItem.header}
             </Tooltip>
+            {tableItem.tip && <Tip text={tableItem.tip} />}
           </div>
         ) : null
       })}

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -151,6 +151,10 @@
       &.align-right {
         justify-content: flex-end;
       }
+
+      .tip-container {
+        margin-left: 2px;
+      }
     }
   }
 

--- a/src/elements/ScheduleRecurring/ScheduleRecurring.js
+++ b/src/elements/ScheduleRecurring/ScheduleRecurring.js
@@ -61,7 +61,10 @@ const ScheduleRecurring = ({
 
   return (
     <div className="recurring-container">
-      <p>Note: all times are interpreted in UTC timezone</p>
+        <p>
+            Note: all times are interpreted in UTC timezone. <br />
+            The first weekday (0) is always <b>Monday</b>.
+        </p>
       <div className="repeat_container">
         <Select
           density="chunky"

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -17,8 +17,6 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import cronstrue from 'cronstrue'
-
 import { FUNCTIONS_PAGE, JOBS_PAGE, MONITOR_JOBS_TAB, MONITOR_WORKFLOWS_TAB } from '../constants'
 import { formatDatetime } from './datetime'
 import measureTime from './measureTime'
@@ -185,8 +183,9 @@ export const createJobsScheduleTabContent = jobs => {
         {
           header: 'Schedule (UTC)',
           id: `schedule.${identifierUnique}`,
-          value: job.scheduled_object?.schedule ? cronstrue.toString(job.scheduled_object?.schedule) : null,
-          class: 'table-cell-1'
+          value: job.scheduled_object?.schedule || null,
+          class: 'table-cell-1',
+          tip: 'The first weekday (0) is always Monday.'
         },
         {
           header: 'Labels',


### PR DESCRIPTION
- **Jobs**: Scheduled Jobs are triggered at +1 day

   - Hide the generated cron string, i.e "At 12:00 AM, only on Sunday, Monday, Tuesday, Wednesday, and Thursday"
   - Add a message under the Note and above the Input "The first weekday (0) is always Monday."
   - Jobs => Schedule tab => Add tooltip to "Schedule (UTC)" Column title. Saying: "The first weekday (0) is always Monday."
   
    Jira: https://jira.iguazeng.com/browse/ML-2878

   ![image](https://user-images.githubusercontent.com/78905712/208898803-104381b2-2fec-42e7-aa19-5f4ea5ca4d64.png)
   ![image](https://user-images.githubusercontent.com/78905712/208899139-e127315c-b7bc-49a3-900f-fb4fb17acee9.png)
