### PR TITLE
Fix [Jobs] The 'Refresh' button covers/hides the logs of the job

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -143,7 +143,7 @@
       position: relative;
       width: 100%;
       min-height: 400px;
-      padding: 0 5px;
+      padding: 10px 80px 10px 20px;
       color: $white;
       font-family: 'Source Code Pro', 'Courier New', monospace;
       white-space: pre-wrap;
@@ -156,28 +156,13 @@
 
       .logs_refresh {
         position: absolute;
-        top: 30px;
-        right: 30px;
-        display: flex;
-        align-items: center;
-        padding: 8px 12px;
-        color: $cornflowerBlue;
-        background-color: $white;
-        border: 1px solid $cornflowerBlue;
-        border-radius: 16px;
-        box-shadow: $previewBoxShadow;
-        cursor: pointer;
+        top: 20px;
+        right: 20px;
 
-        svg {
-          path {
-            fill: $cornflowerBlue;
-          }
-        }
-
-        &:active,
-        &:focus {
-          outline: none;
-          box-shadow: none;
+        .btn {
+          min-width: 40px;
+          padding: 0;
+          border-radius: 50%;
         }
       }
     }

--- a/src/components/DetailsLogs/DetailsLogs.js
+++ b/src/components/DetailsLogs/DetailsLogs.js
@@ -24,8 +24,9 @@ import { useParams } from 'react-router-dom'
 
 import NoData from '../../common/NoData/NoData'
 import Loader from '../../common/Loader/Loader'
+import { Button } from 'igz-controls/components'
 
-import { ReactComponent as Refresh } from 'igz-controls/images/refresh.svg'
+import { ReactComponent as RefreshIcon } from 'igz-controls/images/refresh.svg'
 
 const DetailsLogs = ({
   item,
@@ -76,10 +77,14 @@ const DetailsLogs = ({
         <NoData />
       )}
       {withLogsRefreshBtn && (
-        <button onClick={() => refreshLogs(item.uid, params.projectName)} className="logs_refresh">
-          <Refresh />
-          Refresh
-        </button>
+        <div className="logs_refresh">
+          <Button
+            icon={<RefreshIcon />}
+            label=""
+            tooltip="Refresh"
+            onClick={() => refreshLogs(item.uid, params.projectName)}
+          />
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
- **Jobs**: The 'Refresh' button covers/hides the logs of the job
   Jira: [ML-3096](https://jira.iguazeng.com/browse/ML-3096) + [ML-3097](https://jira.iguazeng.com/browse/ML-3097)
   
   Before:
   <img width="897" alt="Screen Shot 2022-12-22 at 1 16 32" src="https://user-images.githubusercontent.com/63646693/209021406-846826e6-d3a0-4ba5-8f07-caaadd8df08d.png">

   After:
   <img width="981" alt="Screen Shot 2022-12-22 at 1 16 59" src="https://user-images.githubusercontent.com/63646693/209021448-03d0ab9c-781e-4757-84e1-d85020c1eec5.png">
