### PR TITLE
Fix [Jobs and Workflows] Job Wizard fields aren't populated on `re-run`

### DIFF
--- a/src/components/Jobs/MonitorJobs/MonitorJobs.js
+++ b/src/components/Jobs/MonitorJobs/MonitorJobs.js
@@ -337,6 +337,7 @@ const MonitorJobs = ({
       openPopUp(JobWizard, {
         params,
         onWizardClose: () => {
+          setEditableItem(null)
           setJobWizardMode(null)
           setJobWizardIsOpened(false)
         },
@@ -355,6 +356,7 @@ const MonitorJobs = ({
     jobWizardMode,
     params,
     refreshJobs,
+    setEditableItem,
     setJobWizardIsOpened,
     setJobWizardMode
   ])

--- a/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
+++ b/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
@@ -84,6 +84,7 @@ const MonitorWorkflows = ({
   const [jobs, setJobs] = useState([])
   const [selectedJob, setSelectedJob] = useState({})
   const [convertedYaml, toggleConvertedYaml] = useYaml('')
+  const { isDemoMode } = useMode()
   const appStore = useSelector(store => store.appStore)
   const workflowsStore = useSelector(state => state.workflowsStore)
   const filtersStore = useSelector(state => state.filtersStore)
@@ -450,10 +451,16 @@ const MonitorWorkflows = ({
   }, [params.projectName, params.workflowId])
 
   useEffect(() => {
-    if (jobWizardMode && !jobWizardIsOpened) {
+    if (
+      jobWizardMode &&
+      !jobWizardIsOpened &&
+      ((jobWizardMode === PANEL_RERUN_MODE && editableItem?.rerun_object) ||
+        jobWizardMode !== PANEL_RERUN_MODE)
+    ) {
       openPopUp(JobWizard, {
         params,
         onWizardClose: () => {
+          setEditableItem(null)
           setJobWizardMode(null)
           setJobWizardIsOpened(false)
         },
@@ -471,6 +478,7 @@ const MonitorWorkflows = ({
     jobWizardMode,
     params,
     refreshJobs,
+    setEditableItem,
     setJobWizardIsOpened,
     setJobWizardMode
   ])
@@ -539,7 +547,7 @@ const MonitorWorkflows = ({
       {convertedYaml.length > 0 && (
         <YamlModal convertedYaml={convertedYaml} toggleConvertToYaml={toggleConvertedYaml} />
       )}
-      {editableItem && (
+      {editableItem && !isDemoMode && (
         // todo: delete when the job wizard is out of the demo mode
         <JobsPanel
           closePanel={() => {

--- a/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
+++ b/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
@@ -319,6 +319,7 @@ const ScheduledJobs = ({
       openPopUp(JobWizard, {
         params,
         onWizardClose: () => {
+          setEditableItem(null)
           setJobWizardMode(null)
           setJobWizardIsOpened(false)
         },
@@ -337,6 +338,7 @@ const ScheduledJobs = ({
     jobWizardMode,
     params,
     refreshJobs,
+    setEditableItem,
     setJobWizardIsOpened,
     setJobWizardMode
   ])


### PR DESCRIPTION
- **Jobs and Workflows**: Job Wizard fields aren't populated on `re-run`
   Jira: https://jira.iguazeng.com/browse/ML-3112

   Before:
   ![image-2022-12-22-18-19-56-344](https://user-images.githubusercontent.com/25711177/209341463-a4c6e96d-faa4-412c-87f1-8f2be6635c06.png)

   After:
   ![image](https://user-images.githubusercontent.com/25711177/209341289-69920418-6c5e-46b9-958b-4f436d81959f.png)
