### PR TITLE
Fix [UI] Bytes Artifact fails to show in "Preview" tab `1.2.1`

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -122,7 +122,11 @@ const ArtifactsPreviewView = ({ className, preview, setShowErrorBody, showErrorB
           {preview?.type === 'image' && (
             <img className="artifact-preview__image" src={preview?.data?.content} alt="preview" />
           )}
-          {preview?.type === 'unknown' && <div>No preview</div>}
+          {preview?.type === 'unknown' && (
+              <div className="artifact-preview__no-data">
+                {preview?.data?.content ? preview?.data.content : 'No preview'}
+              </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/ArtifactsPreview/artifactsPreview.scss
+++ b/src/components/ArtifactsPreview/artifactsPreview.scss
@@ -41,6 +41,13 @@
       }
     }
 
+    &__no-data {
+      margin-top: 10px;
+      font-weight: 500;
+      font-size: 16px;
+      line-height: 20px;
+    }
+
     &__table {
       display: flex;
       flex-direction: column;

--- a/src/utils/createArtifactPreviewContent.js
+++ b/src/utils/createArtifactPreviewContent.js
@@ -17,22 +17,25 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import { has } from 'lodash'
+import { has, isString } from 'lodash'
 
-export const createArtifactPreviewContent = (res, fileFormat) => {
+export const createArtifactPreviewContent = (res, fileFormat, path, artifactName) => {
   const artifact = {}
 
-  if (res.headers['content-type'].includes('text/csv')) {
+  if (res.headers['content-type'].includes('text/csv') && isString(res.data)) {
     const data = res.data.split('\n')
+
     if (data[0].includes('state')) {
       const headers = data[0].split(',')
       let content = data.slice(1)
+
       content.pop()
       content = content.map(item => item.split(','))
       artifact.type = 'table-results'
       artifact.iterationStats = [headers].concat(content)
     } else {
       let content = data.slice(1)
+
       content = content.map(item => item.split(','))
       content.pop()
       artifact.type = 'table'
@@ -69,6 +72,13 @@ export const createArtifactPreviewContent = (res, fileFormat) => {
     }
   } else {
     artifact.type = 'unknown'
+
+    if (path && artifactName) {
+      artifact.data = {
+        content: `Preview is not available for this artifact type. Go to ${path} to retrieve the data, or use mlrun api/sdk project.get_artifact(‘${artifactName}’).show()`
+      }
+    }
   }
+
   return artifact
 }

--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -64,6 +64,7 @@ export const fetchArtifactPreviewFromExtraData = (
       previewItem.path,
       previewItem.path.startsWith('/User') && (artifact.user || artifact.producer.owner),
       previewItem.path.replace(/.*\./g, ''),
+      artifact.db_key,
       cancelToken
     )
       .then(content => {
@@ -93,7 +94,8 @@ export const fetchArtifactPreviewFromTargetPath = (artifact, noData, setNoData, 
   fetchArtifactPreview(
     artifact.target_path,
     artifact.target_path.startsWith('/User') && (artifact.user || artifact.producer?.owner),
-    artifact.target_path.replace(/.*\./g, '')
+    artifact.target_path.replace(/.*\./g, ''),
+    artifact.db_key
   )
     .then(content => {
       setPreview([content])
@@ -116,9 +118,9 @@ export const fetchArtifactPreviewFromTargetPath = (artifact, noData, setNoData, 
     })
 }
 
-export const fetchArtifactPreview = (path, user, fileFormat, cancelToken) => {
+export const fetchArtifactPreview = (path, user, fileFormat, artifactName, cancelToken) => {
   return api.getArtifactPreview(path, user, fileFormat, cancelToken).then(res => {
-    return createArtifactPreviewContent(res, fileFormat)
+    return createArtifactPreviewContent(res, fileFormat, path, artifactName)
   })
 }
 


### PR DESCRIPTION
- **Artifacts**: Bytes Artifact fails to show in "Preview" tab
   Backported to `1.2.1` from #1567 
   Jira: [ML-3106](https://jira.iguazeng.com/browse/ML-3106)

   After:
   ![image](https://user-images.githubusercontent.com/78905712/209649661-4a5eadb3-87da-4922-a1c2-1cdbbe39454a.png)
