### PR TITLE
Fix [UI] Model/Artifact/Datasets Missing validation for an existing artifact name `1.2.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "final-form-arrays": "^3.0.2",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "0.0.32-1.2.1",
+    "iguazio.dashboard-react-controls": "0.0.33-1.2.1",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^3.13.1",

--- a/src/components/RegisterArtifactModal/RegisterArtifactModal.js
+++ b/src/components/RegisterArtifactModal/RegisterArtifactModal.js
@@ -178,6 +178,7 @@ const RegisterArtifactModal = ({
               formState={formState}
               initialValues={initialValues}
               messageByKind={messagesByKind[artifactKind.toLowerCase()]}
+              projectName={projectName}
               setFieldState={formState.form.mutators.setFieldState}
               showType={artifactKind === ARTIFACT_TYPE}
             />

--- a/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
+++ b/src/elements/RegisterArtifactModalForm/RegisterArtifactModalForm.js
@@ -25,15 +25,17 @@ import { FormInput, FormSelect, FormTextarea, FormChipCell } from 'igz-controls/
 import { ARTIFACT_TYPE, MLRUN_STORAGE_INPUT_PATH_SCHEME } from '../../constants'
 
 import { getValidationRules } from 'igz-controls/utils/validation.util'
+import { isArtifactNameUnique } from '../../utils/artifacts.util'
 import { getChipOptions } from '../../utils/getChipOptions'
 import { useMode } from '../../hooks/mode.hook'
 
 const RegisterArtifactModalForm = ({
   formState,
-  showType,
   initialValues,
   messageByKind,
-  setFieldState
+  projectName,
+  setFieldState,
+  showType
 }) => {
   const { isDemoMode } = useMode()
   const kindOptions = useMemo(
@@ -84,11 +86,17 @@ const RegisterArtifactModalForm = ({
       <div className="form-row">
         <div className="form-col-2">
           <FormInput
+            async
             label="Name"
             name="metadata.key"
             required
             tip="Artifact names in the same project must be unique"
-            validationRules={getValidationRules('artifact.name')}
+            validationRules={getValidationRules('artifact.name', {
+              name: 'ArtifactExists',
+              label: 'Artifact name should be unique',
+              pattern: isArtifactNameUnique(projectName),
+              async: true
+            })}
           />
         </div>
         {showType && (
@@ -143,9 +151,10 @@ RegisterArtifactModalForm.defaultProps = {
 
 RegisterArtifactModalForm.propTypes = {
   formState: PropTypes.object.isRequired,
-  showType: PropTypes.bool,
-  messageByKind: PropTypes.string,
   initialValues: PropTypes.object.isRequired,
+  messageByKind: PropTypes.string,
+  projectName: PropTypes.string.isRequired,
+  showType: PropTypes.bool,
   setFieldState: PropTypes.func.isRequired
 }
 

--- a/src/elements/RegisterModelModal/RegisterModelModal.js
+++ b/src/elements/RegisterModelModal/RegisterModelModal.js
@@ -31,6 +31,7 @@ import TargetPath from '../../common/TargetPath/TargetPath'
 
 import { getChipOptions } from '../../utils/getChipOptions'
 import { convertChipsData } from '../../utils/convertChipsData'
+import { isArtifactNameUnique } from '../../utils/artifacts.util'
 import { getValidationRules } from 'igz-controls/utils/validation.util'
 import { setFieldState } from 'igz-controls/utils/form.util'
 import { useModalBlockHistory } from '../../hooks/useModalBlockHistory.hook'
@@ -166,11 +167,17 @@ function RegisterModelModal({ actions, isOpen, onResolve, projectName, refresh }
           >
             <div className="form-row">
               <FormInput
+                async
                 label="Name"
                 name="metadata.key"
                 required
                 tip="Artifacts names in the same project must be unique."
-                validationRules={getValidationRules('artifact.name')}
+                validationRules={getValidationRules('artifact.name', {
+                  name: 'ArtifactExists',
+                  label: 'Artifact name should be unique',
+                  pattern: isArtifactNameUnique(projectName),
+                  async: true
+                })}
               />
             </div>
             <div className="form-row">

--- a/src/utils/artifacts.util.js
+++ b/src/utils/artifacts.util.js
@@ -20,6 +20,8 @@ such restriction.
 import { cloneDeep } from 'lodash'
 import { deleteTag, editTag, addTag } from '../reducers/artifactsReducer'
 
+import artifactApi from '../api/artifacts-api'
+
 export const applyTagChanges = (changes, artifactItem, projectName, dispatch, setNotification) => {
   let updateTagPromise = Promise.resolve()
   artifactItem = cloneDeep(artifactItem)
@@ -84,4 +86,14 @@ export const applyTagChanges = (changes, artifactItem, projectName, dispatch, se
   } else {
     return updateTagPromise
   }
+}
+
+export const isArtifactNameUnique = projectName => async value => {
+  if (!value) return
+
+  const {
+    data: { artifacts }
+  } = await artifactApi.getArtifact(projectName, value)
+
+  return artifacts.length === 0
 }


### PR DESCRIPTION
- **Artifacts**: Missing validation for an existing artifact name.
   Backported to `1.2.x` from #1565  
   Jira: [ML-3130](https://jira.iguazeng.com/browse/ML-3130)
   
   Before:
   <img width="651" alt="Screen Shot 2022-12-07 at 9 10 44" src="https://user-images.githubusercontent.com/63646693/206112137-2eee33d2-b058-44f7-9bf7-ced52235da48.png">
   <img width="726" alt="Screen Shot 2022-12-25 at 16 44 48" src="https://user-images.githubusercontent.com/63646693/209472453-eee68d9c-6827-43c3-a0e4-571d0708b335.png">

   After:
   <img width="653" alt="Screen Shot 2022-12-07 at 9 11 02" src="https://user-images.githubusercontent.com/63646693/206112173-796c5a99-3687-4dc4-bc2e-1247fb461922.png">
   <img width="730" alt="Screen Shot 2022-12-25 at 16 45 31" src="https://user-images.githubusercontent.com/63646693/209472470-1047a4f0-0025-4274-a0de-281802c69fd3.png">
