### PR TITLE
Fix [Jobs] Schedule change tooltip in UTC `1.2.1`

### DIFF
--- a/src/components/ScheduleCron/ScheduleCron.js
+++ b/src/components/ScheduleCron/ScheduleCron.js
@@ -27,7 +27,7 @@ const ScheduleCron = ({ cron, setCron }) => {
     <>
       <p>
         Note: all times are interpreted in UTC timezone. <br />
-        The first weekday (0) is always <b>Monday</b>.
+        The first day of the week (0) is <b>Monday</b>, and not Sunday.
       </p>
       <Input
         placeholder="10 * * * *"

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -12,7 +12,7 @@
   border-top: $secondaryBorder;
 
   & [class*='table-cell-'] {
-    flex: 1 0 0%;
+    flex: 0;
     min-width: 70px;
     width: 100%;
   }
@@ -40,10 +40,6 @@
 
     &-small {
       max-width: 150px;
-    }
-
-    &-medium {
-      max-width: 250px;
     }
   }
 

--- a/src/elements/ScheduleRecurring/ScheduleRecurring.js
+++ b/src/elements/ScheduleRecurring/ScheduleRecurring.js
@@ -30,19 +30,10 @@ import { selectOptions } from './scheduleRecurring.util'
 
 import './scheduleRecurring.scss'
 
-const ScheduleRecurring = ({
-  daysOfWeek,
-  handleDaysOfWeek,
-  recurringDispatch,
-  recurringState
-}) => {
+const ScheduleRecurring = ({ daysOfWeek, handleDaysOfWeek, recurringDispatch, recurringState }) => {
   const {
     scheduleRepeat: { activeOption: scheduleRepeatActiveOption, week },
-    scheduleRepeatEnd: {
-      activeOption: scheduleRepeatEndActiveOption,
-      occurrences,
-      date
-    }
+    scheduleRepeatEnd: { activeOption: scheduleRepeatEndActiveOption, occurrences, date }
   } = recurringState
 
   const handleScheduleRepeatChange = (value, activeOption) => {
@@ -63,7 +54,7 @@ const ScheduleRecurring = ({
     <div className="recurring-container">
       <p>
         Note: all times are interpreted in UTC timezone. <br />
-        The first weekday (0) is always <b>Monday</b>.
+        The first day of the week (0) is <b>Monday</b>, and not Sunday.
       </p>
       <div className="repeat_container">
         <Select
@@ -81,9 +72,7 @@ const ScheduleRecurring = ({
           <div className="schedule-repeat schedule-repeat-week">
             {daysOfWeek.map(day => (
               <span
-                className={`schedule-repeat-week_day ${week.days.includes(
-                  day.id
-                ) && 'active'}`}
+                className={`schedule-repeat-week_day ${week.days.includes(day.id) && 'active'}`}
                 key={day.id}
                 onClick={() => handleDaysOfWeek(day.id)}
               >
@@ -104,9 +93,7 @@ const ScheduleRecurring = ({
                 selectOptions[scheduleRepeatActiveOption].find(
                   option =>
                     option.id ===
-                    recurringState.scheduleRepeat[
-                      scheduleRepeatActiveOption
-                    ].toString()
+                    recurringState.scheduleRepeat[scheduleRepeatActiveOption].toString()
                 )?.id
               }
             />
@@ -124,9 +111,7 @@ const ScheduleRecurring = ({
         {['day', 'month', 'week'].includes(scheduleRepeatActiveOption) && (
           <TimePicker
             hideLabel
-            value={
-              recurringState.scheduleRepeat[scheduleRepeatActiveOption].time
-            }
+            value={recurringState.scheduleRepeat[scheduleRepeatActiveOption].time}
             onChange={value => {
               recurringDispatch({
                 type:

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -17,7 +17,7 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import cronstrue from 'cronstrue'
+
 import { FUNCTIONS_PAGE, JOBS_PAGE, MONITOR_JOBS_TAB, MONITOR_WORKFLOWS_TAB } from '../constants'
 import { formatDatetime } from './datetime'
 import measureTime from './measureTime'
@@ -184,9 +184,9 @@ export const createJobsScheduleTabContent = jobs => {
         {
           header: 'Schedule (UTC)',
           id: `schedule.${identifierUnique}`,
-          value: job.scheduled_object ? cronstrue.toString(job.scheduled_object?.schedule) : null,
+          value: job.scheduled_object?.schedule || null,
           class: 'table-cell-1',
-          tip: 'The first weekday (0) is always Monday.'
+          tip: 'The first day of the week (0) is Monday, and not Sunday.'
         },
         {
           header: 'Labels',

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -17,6 +17,7 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
+import cronstrue from 'cronstrue'
 import { FUNCTIONS_PAGE, JOBS_PAGE, MONITOR_JOBS_TAB, MONITOR_WORKFLOWS_TAB } from '../constants'
 import { formatDatetime } from './datetime'
 import measureTime from './measureTime'
@@ -170,7 +171,7 @@ export const createJobsScheduleTabContent = jobs => {
           header: 'Type',
           id: `type.${identifierUnique}`,
           value: job.type,
-          class: 'table-cell-1',
+          class: 'table-cell-small',
           type: 'type'
         },
         {
@@ -183,7 +184,7 @@ export const createJobsScheduleTabContent = jobs => {
         {
           header: 'Schedule (UTC)',
           id: `schedule.${identifierUnique}`,
-          value: job.scheduled_object?.schedule || null,
+          value: job.scheduled_object ? cronstrue.toString(job.scheduled_object?.schedule) : null,
           class: 'table-cell-1',
           tip: 'The first weekday (0) is always Monday.'
         },


### PR DESCRIPTION
- **Jobs**: Schedule change tooltip in UTC
   - Change tooltip and schedule message to: "The first day of the week (0) is Monday, and not Sunday."

   Backported to `1.2.1` from #1570 
   Jira: [ML-2878](https://jira.iguazeng.com/browse/ML-2878)
