### PR TITLE
Fix [UI] Bytes Artifact fails to show in "Preview" tab

### DIFF
--- a/src/utils/createArtifactPreviewContent.js
+++ b/src/utils/createArtifactPreviewContent.js
@@ -75,7 +75,7 @@ export const createArtifactPreviewContent = (res, fileFormat, path, artifactName
 
     if (path && artifactName) {
       artifact.data = {
-        content: `Preview is not available for this artifact type. Go to ${path} to retrieve the data, or use mlrun api/sdk project.get_artifact(‘${artifactName}’).show()`
+        content: `Preview is not available for this artifact type. Go to ${path} to retrieve the data, or use mlrun api/sdk project.get_artifact('${artifactName}').to_dataitem().get()`
       }
     }
   }


### PR DESCRIPTION
- **Artifacts**: Bytes Artifact fails to show in "Preview" tab
   Backported to `1.2.1` from #1573 
   Jira: [ML-3106](https://jira.iguazeng.com/browse/ML-3106)

   After:
   ![image](https://user-images.githubusercontent.com/78905712/209921608-93f8e133-1930-46b0-ac7b-d432cf70a3b7.png)
