### PR TITLE
Fix [UI] text overlaps in job Results tab

### DIFF
--- a/src/components/DetailsResults/DetailsResults.js
+++ b/src/components/DetailsResults/DetailsResults.js
@@ -42,9 +42,7 @@ const DetailsResults = ({ job }) => {
               <div className="results-table__row">
                 {result.headers.map((item, i) => (
                   <div className="results-table__header-item" key={i}>
-                    <Tooltip template={<TextTooltipTemplate text={item} />}>
-                      {item}
-                    </Tooltip>
+                    <Tooltip template={<TextTooltipTemplate text={item} />}>{item}</Tooltip>
                   </div>
                 ))}
               </div>
@@ -58,10 +56,7 @@ const DetailsResults = ({ job }) => {
                       contentItemValue.match(/completed|running|error/gi)
                     ) {
                       return (
-                        <div
-                          className="results-table__cell"
-                          key={`${contentItemValue}${idx}`}
-                        >
+                        <div className="results-table__cell" key={`${contentItemValue}${idx}`}>
                           <Tooltip
                             template={
                               <TextTooltipTemplate
@@ -86,28 +81,17 @@ const DetailsResults = ({ job }) => {
                           className="results-table__medal results-table__cell"
                         >
                           {contentItemValue}
-                          <Tooltip
-                            template={
-                              <TextTooltipTemplate text={'Best iteration'} />
-                            }
-                          >
+                          <Tooltip template={<TextTooltipTemplate text={'Best iteration'} />}>
                             <BestIteration />
                           </Tooltip>
                         </div>
                       )
                     } else {
                       return (
-                        <div
-                          className="results-table__cell"
-                          key={`${contentItemValue}${idx}`}
-                        >
+                        <div className="results-table__cell" key={`${contentItemValue}${idx}`}>
                           <Tooltip
                             className="data-ellipsis"
-                            template={
-                              <TextTooltipTemplate
-                                text={contentItemValue.toString()}
-                              />
-                            }
+                            template={<TextTooltipTemplate text={contentItemValue.toString()} />}
                           >
                             {roundFloats(contentItemValue)}
                           </Tooltip>
@@ -119,13 +103,20 @@ const DetailsResults = ({ job }) => {
               ))}
             </div>
           </>
-        ) : job.iterations?.length === 0 &&
-          Object.keys(job.results ?? {}).length !== 0 ? (
+        ) : job.iterations?.length === 0 && Object.keys(job.results ?? {}).length !== 0 ? (
           Object.keys(job.results).map(key => {
             return (
               <div key={key} className="results-table__row">
-                <div className="results-table__cell">{key}</div>
-                <div className="results-table__cell">{job.results[key]}</div>
+                  <div className="results-table__cell table__cell-wide">
+                      <Tooltip className="data-ellipsis" template={<TextTooltipTemplate text={key} />}>
+                          {key}
+                      </Tooltip>
+                  </div>
+                  <div className="results-table__cell table__cell-wide">
+                      <Tooltip className="data-ellipsis" template={<TextTooltipTemplate text={job.results[key]} />}>
+                          {job.results[key]}
+                      </Tooltip>
+                  </div>
               </div>
             )
           })

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -69,6 +69,11 @@
       padding: 19px 15px 19px 25px;
     }
 
+    .table__cell-wide {
+      flex: 0 0 250px;
+      width: 250px;
+    }
+
     i {
       margin: 0 15px;
     }


### PR DESCRIPTION
- **Jobs**: text overlaps in job Results tab
   Backported to `1.2.1` from #1578 
   Jira: https://jira.iguazeng.com/browse/ML-3148

   After:
   ![image](https://user-images.githubusercontent.com/78905712/209953890-7e11642a-e6ba-4cf3-abb8-2bab4890589f.png)
