### PR TITLE
Fix [UI CE] MLRun CE UI doesn't show its version

### DIFF
--- a/src/layout/Header/Header.js
+++ b/src/layout/Header/Header.js
@@ -18,6 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import { ReactComponent as Logo } from 'igz-controls/images/mlrun-blue-logo.svg'
@@ -27,6 +28,8 @@ import { ReactComponent as SlackIcon } from 'igz-controls/images/slack-icon.svg'
 import './header.scss'
 
 const Header = () => {
+  const frontendSpec = useSelector(store => store.appStore.frontendSpec)
+
   return (
     <header className="header">
       <div className="header__brand">
@@ -74,6 +77,9 @@ const Header = () => {
         >
           <GithubIcon />
         </a>
+        {frontendSpec.ce?.version && (
+          <span className="ml-app-version">Version: {frontendSpec.ce.version}</span>
+        )}
       </div>
     </header>
   )

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -52,6 +52,10 @@ body {
 .ml-app {
   display: flex;
   width: 100%;
+
+  &-version {
+    font-size: 0.75rem;
+  }
 }
 
 .content {


### PR DESCRIPTION
- **CE**: MLRun CE UI doesn't show its version
   Jira: [CEML-64](https://jira.iguazeng.com/browse/CEML-64)
   
   Before:
   <img width="1792" alt="Screen Shot 2023-01-09 at 17 49 19" src="https://user-images.githubusercontent.com/63646693/211349515-390dce12-a235-4c97-b185-ebdb64155136.png">

   After:
   <img width="1792" alt="Screen Shot 2023-01-09 at 17 49 33" src="https://user-images.githubusercontent.com/63646693/211349565-03321d2c-2dec-43f4-97d4-d9356b750bb2.png">
