### PR TITLE
Fix [Project Settings] long key/value in 'Project parameters' causes 'Project settings' screen distortion

### DIFF
--- a/src/common/KeyValueTable/keyValueTable.scss
+++ b/src/common/KeyValueTable/keyValueTable.scss
@@ -54,7 +54,8 @@ $actionsBlockWidth: 72px;
 
   .table-cell__inputs-wrapper {
     display: flex;
-    width: calc(100% - #{$actionsBlockWidth});
+    flex: 1;
+    width: 0;
   }
 
   .table-cell__key {


### PR DESCRIPTION
- **Project Settings**: long key/value in 'Project parameters' causes 'Project settings' screen distortion
   Jira: [ML-3257](https://jira.iguazeng.com/browse/ML-3257)
   
   Before:
   ![Screen Shot 2023-01-18 at 18 55 47](https://user-images.githubusercontent.com/63646693/213245188-347f3e1d-db3a-4b2c-8cc6-bb25f1b0b72f.png)
   
   After:
![Screen Shot 2023-01-18 at 18 56 15](https://user-images.githubusercontent.com/63646693/213245283-b13b1051-5dea-45d5-a77b-f6398e63133e.png)


   