### PR TITLE
Fix [Project Monitoring] Display old layout not in demo mode

### DIFF
--- a/src/components/Project/ProjectMonitorView.js
+++ b/src/components/Project/ProjectMonitorView.js
@@ -36,6 +36,7 @@ import { ConfirmDialog, RoundedIcon } from 'igz-controls/components'
 
 import { PANEL_CREATE_MODE } from '../../constants'
 import { launchIDEOptions } from './project.utils'
+import { formatDatetime } from '../../utils'
 
 import { ReactComponent as RefreshIcon } from 'igz-controls/images/refresh.svg'
 
@@ -100,24 +101,52 @@ const ProjectMonitorView = ({
               <ProjectDetailsHeader projectData={project.data} projectName={params.projectName} />
             )}
             <div className="main-info__toolbar">
-              <Select
-                className="main-info__toolbar-menu launch-menu"
-                density="dense"
-                hideSelectedOption
-                label="Launch IDE"
-                onClick={handleLaunchIDE}
-                options={launchIDEOptions}
-              />
-              <Select
-                className="main-info__toolbar-menu create-new-menu"
-                density="dense"
-                hideSelectedOption
-                label="Create new"
-                options={createNewOptions}
-              />
-              <RoundedIcon onClick={refresh} id="refresh" tooltipText="Refresh" className="refresh">
-                <RefreshIcon />
-              </RoundedIcon>
+              {/* TODO: remove HTML in 1.4 */}
+              {!isDemoMode && (
+                <div>
+                  {project.data.status.state && (
+                    <div className="general-info__row status-row">
+                      <div className="row-value">
+                        <span className="row-label">Status:</span>
+                        <span className="row-name">{project.data.status.state}</span>
+                      </div>
+                    </div>
+                  )}
+                  <div className="general-info__row created-at-row">
+                    <div className="row-value">
+                      <span className="row-label">Created at:</span>
+                      <span className="row-name">
+                        {formatDatetime(project.data.metadata.created, '-')}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+              <div className="main-info__toolbar-actions">
+                <Select
+                  className="main-info__toolbar-menu launch-menu"
+                  density="dense"
+                  hideSelectedOption
+                  label="Launch IDE"
+                  onClick={handleLaunchIDE}
+                  options={launchIDEOptions}
+                />
+                <Select
+                  className="main-info__toolbar-menu create-new-menu"
+                  density="dense"
+                  hideSelectedOption
+                  label="Create new"
+                  options={createNewOptions}
+                />
+                <RoundedIcon
+                  onClick={refresh}
+                  id="refresh"
+                  tooltipText="Refresh"
+                  className="refresh"
+                >
+                  <RefreshIcon />
+                </RoundedIcon>
+              </div>
             </div>
             <div className="main-info__statistics-section">
               <ProjectSummaryCard

--- a/src/components/Project/project.scss
+++ b/src/components/Project/project.scss
@@ -78,7 +78,7 @@
 
       &__toolbar {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         align-items: center;
         margin-bottom: 15px;
 
@@ -118,6 +118,13 @@
               }
             }
           }
+        }
+
+        &-actions {
+          display: flex;
+          flex: 1;
+          align-items: center;
+          justify-content: flex-end;
         }
 
         .refresh {


### PR DESCRIPTION
- **Project Monitoring**: Display old layout not in demo mode
   Jira: [ML-3253](https://jira.iguazeng.com/browse/ML-3253)
   
   `Demo mode`:
    <img width="1533" alt="Screen Shot 2023-01-19 at 11 59 31" src="https://user-images.githubusercontent.com/63646693/213412697-39d79579-b9db-4ae9-bc36-4c4dba0a92f9.png">

   
   `Production`:
    <img width="1541" alt="Screen Shot 2023-01-19 at 11 59 18" src="https://user-images.githubusercontent.com/63646693/213412653-e315ce68-4d78-4b03-9ba7-f296891daa68.png">

   