### PR TITLE
Fix [Workflow report] The job 'Result' field length too short

### DIFF
--- a/src/components/DetailsResults/DetailsResults.js
+++ b/src/components/DetailsResults/DetailsResults.js
@@ -112,11 +112,14 @@ const DetailsResults = ({ job }) => {
                     {key}
                   </Tooltip>
                 </div>
-                  <div className="results-table__cell table__cell-wide">
-                      <Tooltip className="data-ellipsis" template={<TextTooltipTemplate text={job.results[key]} />}>
-                          {job.results[key]}
-                      </Tooltip>
-                  </div>
+                <div className="results-table__cell table__cell-full">
+                  <Tooltip
+                    className="data-ellipsis"
+                    template={<TextTooltipTemplate text={job.results[key]} />}
+                  >
+                    {job.results[key]}
+                  </Tooltip>
+                </div>
               </div>
             )
           })

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -74,6 +74,11 @@
       width: 250px;
     }
 
+    .table__cell-full {
+      flex: 1 0 auto;
+      width: auto;
+    }
+
     i {
       margin: 0 15px;
     }


### PR DESCRIPTION
- **Workflow report**: The job 'Result' field length too short
   Jira: [ML-3285](https://jira.iguazeng.com/browse/ML-3285)
   
   Before:
   ![Screen Shot 2023-01-23 at 15 28 08](https://user-images.githubusercontent.com/63646693/214051346-d878c2c6-ebc8-49b1-9746-2c4fa7f58731.png)

   After:
   ![Screen Shot 2023-01-23 at 15 28 33](https://user-images.githubusercontent.com/63646693/214051442-570b043d-9930-4506-9093-ca593aedb45c.png)
