### PR TITLE
Fix [Artifacts]  Align 'Name' column in Artifacts and ML function view

### DIFF
--- a/src/components/ConsumerGroup/consumerGroup.util.js
+++ b/src/components/ConsumerGroup/consumerGroup.util.js
@@ -24,19 +24,23 @@ export const generatePageData = () => {
     page: CONSUMER_GROUP_PAGE,
     tableHeaders: [
       {
-        header: 'Shard/Partition name',
+        headerId: 'name',
+        headerLabel: 'Shard/Partition name',
         class: 'table-cell-1'
       },
       {
-        header: 'Lag (message behind)',
+        headerId: 'lag',
+        headerLabel: 'Lag (message behind)',
         class: 'table-cell-1'
       },
       {
-        header: 'Last sequence',
+        headerId: 'sequence',
+        headerLabel: 'Last sequence',
         class: 'table-cell-1'
       },
       {
-        header: 'Committed offset',
+        headerId: 'offset',
+        headerLabel: 'Committed offset',
         class: 'table-cell-1'
       }
     ]

--- a/src/components/ConsumerGroups/consumerGroups.util.js
+++ b/src/components/ConsumerGroups/consumerGroups.util.js
@@ -24,15 +24,18 @@ export const generatePageData = () => {
     page: CONSUMER_GROUPS_PAGE,
     tableHeaders: [
       {
-        header: 'Consumer group name',
+        headerId: 'name',
+        headerLabel: 'Consumer group name',
         class: 'table-cell-1'
       },
       {
-        header: 'Stream Path',
+        headerId: 'path',
+        headerLabel: 'Stream Path',
         class: 'table-cell-1'
       },
       {
-        header: 'Real time functions',
+        headerId: 'functions',
+        headerLabel: 'Real time functions',
         class: 'table-cell-1'
       }
     ]

--- a/src/components/Details/DetailsView.js
+++ b/src/components/Details/DetailsView.js
@@ -93,7 +93,7 @@ const DetailsView = React.forwardRef(
     } = selectedItem.state || {}
 
     return (
-      <div className={detailsPanelClassNames} ref={ref}>
+      <div className={detailsPanelClassNames} ref={ref} data-testid="detailsPanel">
         {detailsStore.loading && <Loader />}
         {detailsStore.error && <ErrorMessage message={detailsStore.error.message} />}
         <div className="item-header">

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -8,6 +8,7 @@
     position: absolute;
     top: 0;
     right: 0;
+    left: 0;
     z-index: 2;
     display: flex;
     flex: 1;

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -8,7 +8,6 @@
     position: absolute;
     top: 0;
     right: 0;
-    left: 0;
     z-index: 2;
     display: flex;
     flex: 1;
@@ -22,6 +21,11 @@
 
     &_big {
       width: 100%;
+    }
+
+    &-wrapper {
+      display: flex;
+      flex-flow: column wrap;
     }
 
     .item {

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -12,7 +12,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    width: calc(100% - 240px);
+    width: calc(100% - 250px);
     height: 100%;
     overflow-y: auto;
     color: $mulledWine;

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -23,11 +23,6 @@
       width: 100%;
     }
 
-    &-wrapper {
-      display: flex;
-      flex-flow: column wrap;
-    }
-
     .item {
       &-header {
         display: flex;

--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -12,7 +12,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    width: calc(100% - 250px);
+    width: calc(100% - 240px);
     height: 100%;
     overflow-y: auto;
     color: $mulledWine;

--- a/src/components/DetailsResults/DetailsResults.js
+++ b/src/components/DetailsResults/DetailsResults.js
@@ -114,7 +114,7 @@ const DetailsResults = ({ allowSortBy, defaultSortBy, excludeSortBy, job }) => {
                           key={`${contentItemValue}${idx}`}
                           className="results-table__medal results-table__cell"
                         >
-                          {contentItemValue}
+                          <span>{contentItemValue}</span>
                           <span className="best-iteration">
                             <Tooltip template={<TextTooltipTemplate text={'Best iteration'} />}>
                               <BestIteration />

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -19,6 +19,7 @@
     &__row {
       display: flex;
       min-width: 100%;
+      min-height: 50px;
       border-bottom: $secondaryBorder;
 
       &:hover {
@@ -26,7 +27,7 @@
       }
 
       & > *:first-child {
-        margin-left: 15px;
+        margin-left: 10px;
       }
     }
 
@@ -47,10 +48,14 @@
 
       &-item {
         position: relative;
-        min-width: 150px;
+        min-width: 140px;
 
         @include tableDet;
-        @include tableHeader(8px, 15px, 8px, 30px);
+        @include tableHeader(8px, 10px, 8px, 20px);
+
+        & > * {
+          padding-left: 10px;
+        }
       }
 
       .results-table__row {
@@ -64,9 +69,14 @@
       display: flex;
       flex: 0 0 auto;
       flex-direction: column;
-      min-width: 150px;
+      justify-content: center;
+      min-width: 140px;
       margin: 0 1px;
-      padding: 19px 15px 19px 30px;
+      padding: 8px 10px 8px 20px;
+
+      & > * {
+        padding-left: 10px;
+      }
     }
 
     .table__cell-wide {
@@ -85,9 +95,6 @@
 
     &__medal {
       position: relative;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
 
       .best-iteration {
         position: absolute;
@@ -95,6 +102,7 @@
         bottom: auto;
         left: 3px;
         margin-top: 2px;
+        padding: 0;
       }
     }
   }

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -51,7 +51,7 @@
         min-width: 140px;
 
         @include tableDet;
-        @include tableHeader(8px, 10px, 8px, 20px);
+        @include tableHeader(8px, 5px, 8px, 20px);
 
         & > :first-child {
           padding-left: 10px;
@@ -72,7 +72,7 @@
       justify-content: center;
       min-width: 140px;
       margin: 0 1px;
-      padding: 8px 10px 8px 20px;
+      padding: 8px 5px 8px 20px;
 
       & > :first-child {
         padding-left: 10px;
@@ -100,7 +100,7 @@
         position: absolute;
         top: auto;
         bottom: auto;
-        left: 3px;
+        left: 0;
         margin-top: 2px;
         padding: 0;
       }

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -54,7 +54,7 @@
         @include tableHeader(8px, 5px, 8px, 20px);
 
         & > :first-child {
-          padding-left: 10px;
+          padding-left: 5px;
         }
       }
 
@@ -75,7 +75,7 @@
       padding: 8px 5px 8px 20px;
 
       & > :first-child {
-        padding-left: 10px;
+        padding-left: 5px;
       }
     }
 

--- a/src/components/DetailsResults/detailsResults.scss
+++ b/src/components/DetailsResults/detailsResults.scss
@@ -53,7 +53,7 @@
         @include tableDet;
         @include tableHeader(8px, 10px, 8px, 20px);
 
-        & > * {
+        & > :first-child {
           padding-left: 10px;
         }
       }
@@ -74,7 +74,7 @@
       margin: 0 1px;
       padding: 8px 10px 8px 20px;
 
-      & > * {
+      & > :first-child {
         padding-left: 10px;
       }
     }

--- a/src/components/Table/TableView.js
+++ b/src/components/Table/TableView.js
@@ -76,8 +76,8 @@ const TableView = ({
   return (
     <div className="table">
       <div className="table__content" ref={tableContentRef}>
-        <div className="table__item table__item_big">
-          <div className="table__item-wrapper">
+        <div className="table__wrapper">
+          <div className="table__wrapper-row">
             {pageData.tableHeaders && (
               <>
                 <div className="table-head" ref={tableHeadRef}>

--- a/src/components/Table/TableView.js
+++ b/src/components/Table/TableView.js
@@ -77,159 +77,163 @@ const TableView = ({
     <div className="table">
       <div className="table__content" ref={tableContentRef}>
         <div className="table__item table__item_big">
-          {pageData.tableHeaders && (
-            <>
-              <div className="table-head" ref={tableHeadRef}>
-                {pageData.tableHeaders?.map(
-                  (item, index) =>
-                    !item.hidden && (
-                      <div
-                        className={`table-head__item ${item.class}`}
-                        key={`${item.headerLabel}${index}`}
-                      >
-                        <Tooltip template={<TextTooltipTemplate text={item.headerLabel} />}>
-                          {item.headerLabel}
-                        </Tooltip>
-                      </div>
-                    )
-                )}
-              </div>
-              <div className="table-body">
-                {!groupFilter ||
-                isEmpty(groupedContent) ||
-                (groupFilter === GROUP_BY_NONE && isEmpty(groupLatestItem)) ? (
-                  tableContent.map((rowItem, i) => {
-                    switch (pageData.page) {
-                      case CONSUMER_GROUPS_PAGE:
-                        return <ConsumerGroupTableRow key={i} content={content} rowItem={rowItem} />
-                      case CONSUMER_GROUP_PAGE:
-                        return (
-                          <ConsumerGroupShardLagTableRow
-                            key={i}
-                            content={content}
-                            rowItem={rowItem}
-                          />
-                        )
-                      case ARTIFACTS_PAGE:
-                      case DATASETS_PAGE:
-                      case FILES_PAGE:
-                      case MODELS_PAGE:
-                        return (
-                          <ArtifactsTableRow
-                            actionsMenu={actionsMenu}
-                            content={content}
-                            handleSelectItem={handleSelectItem}
-                            key={i}
-                            rowItem={rowItem}
-                            pageData={pageData}
-                            selectedItem={selectedItem}
-                          />
-                        )
-                      case FEATURE_STORE_PAGE:
-                        return (
-                          <FeatureStoreTableRow
-                            actionsMenu={actionsMenu}
-                            content={content}
-                            handleSelectItem={handleSelectItem}
-                            key={i}
-                            rowItem={rowItem}
-                            pageData={pageData}
-                            selectedItem={selectedItem}
-                          />
-                        )
-                      case FUNCTIONS_PAGE:
-                        return (
-                          <FunctionsTableRow
-                            actionsMenu={actionsMenu}
-                            key={i}
-                            content={content}
-                            rowItem={rowItem}
-                            selectedItem={selectedItem}
-                            handleSelectItem={handleSelectItem}
-                          />
-                        )
-                      default:
-                        return null
-                    }
-                  })
-                ) : groupLatestItem.find(latestItem => !isEmpty(latestItem)) ? (
-                  tableContent.map((group, i) => {
-                    switch (pageData.page) {
-                      case ARTIFACTS_PAGE:
-                      case DATASETS_PAGE:
-                      case FILES_PAGE:
-                      case MODELS_PAGE:
-                        return params.pageTab === REAL_TIME_PIPELINES_TAB ? (
-                          <FunctionsTableRow
-                            actionsMenu={actionsMenu}
-                            key={i}
-                            content={content}
-                            handleExpandRow={handleExpandRow}
-                            handleSelectItem={handleSelectItem}
-                            rowItem={groupLatestItem[i]}
-                            selectedItem={selectedItem}
-                            tableContent={group}
-                          />
-                        ) : (
-                          <ArtifactsTableRow
-                            actionsMenu={actionsMenu}
-                            content={content}
-                            handleSelectItem={handleSelectItem}
-                            handleExpandRow={handleExpandRow}
-                            key={i}
-                            mainRowItemsCount={mainRowItemsCount}
-                            rowItem={groupLatestItem[i]}
-                            pageData={pageData}
-                            selectedItem={selectedItem}
-                            tableContent={group}
-                          />
-                        )
-                      case FUNCTIONS_PAGE:
-                        return (
-                          <FunctionsTableRow
-                            actionsMenu={actionsMenu}
-                            key={i}
-                            content={content}
-                            handleExpandRow={handleExpandRow}
-                            handleSelectItem={handleSelectItem}
-                            rowItem={groupLatestItem[i]}
-                            selectedItem={selectedItem}
-                            tableContent={group}
-                          />
-                        )
-                      default:
-                        return (
-                          <FeatureStoreTableRow
-                            actionsMenu={actionsMenu}
-                            content={content}
-                            handleSelectItem={handleSelectItem}
-                            handleExpandRow={handleExpandRow}
-                            key={i}
-                            mainRowItemsCount={mainRowItemsCount}
-                            rowItem={groupLatestItem[i]}
-                            pageData={pageData}
-                            selectedItem={selectedItem}
-                            tableContent={group}
-                          />
-                        )
-                    }
-                  })
-                ) : (
-                  <NoData />
-                )}
-              </div>
-            </>
-          )}
-          {tableHeaders?.length > 0 && (
-            <TableHead
-              content={tableHeaders}
-              mainRowItemsCount={mainRowItemsCount}
-              ref={tableHeadRef}
-              selectedItem={selectedItem}
-              sortProps={sortProps}
-            />
-          )}
-          {!pageData.tableHeaders && <div className="table-body">{children}</div>}
+          <div className="table__item-wrapper">
+            {pageData.tableHeaders && (
+              <>
+                <div className="table-head" ref={tableHeadRef}>
+                  {pageData.tableHeaders?.map(
+                    (item, index) =>
+                      !item.hidden && (
+                        <div
+                          className={`table-head__item ${item.class}`}
+                          key={`${item.headerLabel}${index}`}
+                        >
+                          <Tooltip template={<TextTooltipTemplate text={item.headerLabel} />}>
+                            {item.headerLabel}
+                          </Tooltip>
+                        </div>
+                      )
+                  )}
+                </div>
+                <div className="table-body">
+                  {!groupFilter ||
+                  isEmpty(groupedContent) ||
+                  (groupFilter === GROUP_BY_NONE && isEmpty(groupLatestItem)) ? (
+                    tableContent.map((rowItem, i) => {
+                      switch (pageData.page) {
+                        case CONSUMER_GROUPS_PAGE:
+                          return (
+                            <ConsumerGroupTableRow key={i} content={content} rowItem={rowItem} />
+                          )
+                        case CONSUMER_GROUP_PAGE:
+                          return (
+                            <ConsumerGroupShardLagTableRow
+                              key={i}
+                              content={content}
+                              rowItem={rowItem}
+                            />
+                          )
+                        case ARTIFACTS_PAGE:
+                        case DATASETS_PAGE:
+                        case FILES_PAGE:
+                        case MODELS_PAGE:
+                          return (
+                            <ArtifactsTableRow
+                              actionsMenu={actionsMenu}
+                              content={content}
+                              handleSelectItem={handleSelectItem}
+                              key={i}
+                              rowItem={rowItem}
+                              pageData={pageData}
+                              selectedItem={selectedItem}
+                            />
+                          )
+                        case FEATURE_STORE_PAGE:
+                          return (
+                            <FeatureStoreTableRow
+                              actionsMenu={actionsMenu}
+                              content={content}
+                              handleSelectItem={handleSelectItem}
+                              key={i}
+                              rowItem={rowItem}
+                              pageData={pageData}
+                              selectedItem={selectedItem}
+                            />
+                          )
+                        case FUNCTIONS_PAGE:
+                          return (
+                            <FunctionsTableRow
+                              actionsMenu={actionsMenu}
+                              key={i}
+                              content={content}
+                              rowItem={rowItem}
+                              selectedItem={selectedItem}
+                              handleSelectItem={handleSelectItem}
+                            />
+                          )
+                        default:
+                          return null
+                      }
+                    })
+                  ) : groupLatestItem.find(latestItem => !isEmpty(latestItem)) ? (
+                    tableContent.map((group, i) => {
+                      switch (pageData.page) {
+                        case ARTIFACTS_PAGE:
+                        case DATASETS_PAGE:
+                        case FILES_PAGE:
+                        case MODELS_PAGE:
+                          return params.pageTab === REAL_TIME_PIPELINES_TAB ? (
+                            <FunctionsTableRow
+                              actionsMenu={actionsMenu}
+                              key={i}
+                              content={content}
+                              handleExpandRow={handleExpandRow}
+                              handleSelectItem={handleSelectItem}
+                              rowItem={groupLatestItem[i]}
+                              selectedItem={selectedItem}
+                              tableContent={group}
+                            />
+                          ) : (
+                            <ArtifactsTableRow
+                              actionsMenu={actionsMenu}
+                              content={content}
+                              handleSelectItem={handleSelectItem}
+                              handleExpandRow={handleExpandRow}
+                              key={i}
+                              mainRowItemsCount={mainRowItemsCount}
+                              rowItem={groupLatestItem[i]}
+                              pageData={pageData}
+                              selectedItem={selectedItem}
+                              tableContent={group}
+                            />
+                          )
+                        case FUNCTIONS_PAGE:
+                          return (
+                            <FunctionsTableRow
+                              actionsMenu={actionsMenu}
+                              key={i}
+                              content={content}
+                              handleExpandRow={handleExpandRow}
+                              handleSelectItem={handleSelectItem}
+                              rowItem={groupLatestItem[i]}
+                              selectedItem={selectedItem}
+                              tableContent={group}
+                            />
+                          )
+                        default:
+                          return (
+                            <FeatureStoreTableRow
+                              actionsMenu={actionsMenu}
+                              content={content}
+                              handleSelectItem={handleSelectItem}
+                              handleExpandRow={handleExpandRow}
+                              key={i}
+                              mainRowItemsCount={mainRowItemsCount}
+                              rowItem={groupLatestItem[i]}
+                              pageData={pageData}
+                              selectedItem={selectedItem}
+                              tableContent={group}
+                            />
+                          )
+                      }
+                    })
+                  ) : (
+                    <NoData />
+                  )}
+                </div>
+              </>
+            )}
+            {tableHeaders?.length > 0 && (
+              <TableHead
+                content={tableHeaders}
+                mainRowItemsCount={mainRowItemsCount}
+                ref={tableHeadRef}
+                selectedItem={selectedItem}
+                sortProps={sortProps}
+              />
+            )}
+            {!pageData.tableHeaders && <div className="table-body">{children}</div>}
+          </div>
         </div>
       </div>
       {isTablePanelOpen && (

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -132,7 +132,7 @@
       @include tableDet;
       @include tableHeader(8px, 10px, 8px, 20px);
 
-      & > * {
+      & > :first-child {
         padding-left: 10px;
       }
 
@@ -178,7 +178,7 @@
       line-height: 18px;
       border-bottom: none;
 
-      & > * {
+      & > :first-child {
         padding-left: 10px;
       }
 

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -78,6 +78,27 @@
     }
   }
 
+  &__wrapper {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 2;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+    color: $mulledWine;
+    background-color: $white;
+    border-left: $secondaryBorder;
+
+    &-row {
+      display: flex;
+      flex-flow: column wrap;
+    }
+  }
+
   &__panel-container {
     position: sticky;
     top: 0;

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -55,8 +55,7 @@
       font-weight: 500;
     }
 
-    .artifacts,
-    .job {
+    .artifacts {
       &_medium {
         max-width: 240px;
 

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -12,46 +12,48 @@
   border-top: $secondaryBorder;
 
   & [class*='table-cell-'] {
-    flex: 0 1;
-    min-width: 90px;
-    width: 100%;
+    flex: 0 0 auto;
+    min-width: 80px;
   }
 
   .table-cell {
     &-1 {
-      flex-grow: 1;
+      flex: 1;
     }
 
     &-2 {
-      flex-grow: 2;
+      flex: 2;
     }
 
     &-3 {
-      flex-grow: 3;
+      flex: 3;
     }
 
     &-4 {
-      flex-grow: 4;
+      flex: 4;
     }
 
     &-5 {
-      flex-grow: 5;
+      flex: 5;
     }
 
     &-extra-small {
+      flex: 1;
       max-width: 85px;
-
-      @include tableColumnFlex(0, 65px);
     }
 
     &-small {
+      flex: 1;
       max-width: 150px;
-
-      @include tableColumnFlex(0, 85px);
     }
 
     &-medium {
-      @include tableColumnFlex(0, 240px);
+      flex: 1;
+      max-width: 240px;
+    }
+
+    &-name {
+      width: 240px;
     }
 
     &-icons {
@@ -59,7 +61,7 @@
       padding: 5px 10px;
       max-width: 85px;
 
-      @include tableColumnFlex(0, 65px);
+      @include tableColumnFlex(0, 70px);
     }
   }
 
@@ -73,60 +75,6 @@
 
     .text-bold {
       font-weight: 500;
-    }
-
-    .artifacts {
-      &_medium {
-        max-width: 240px;
-
-        @include tableColumnFlex(1, 240px);
-      }
-
-      &_small {
-        max-width: 150px;
-
-        @include tableColumnFlex(0.5, 50px);
-
-        a {
-          display: inline;
-        }
-      }
-
-      &_big {
-        @include tableColumnFlex(1, 80px);
-      }
-
-      &_extra-small {
-        max-width: 85px;
-
-        @include tableColumnFlex(0.3, 65px);
-      }
-
-      &__icon {
-        justify-content: center;
-      }
-
-      &__targets-icon {
-        .tooltip-wrapper {
-          margin-right: 8px;
-        }
-      }
-    }
-
-    .functions {
-      &_medium {
-        max-width: 240px;
-
-        @include tableColumnFlex(1, 240px);
-      }
-
-      &_small {
-        @include tableColumnFlex(1, 80px);
-      }
-
-      &_big {
-        @include tableColumnFlex(2, 80px);
-      }
     }
   }
 
@@ -151,7 +99,7 @@
   &-head {
     position: sticky;
     top: 0;
-    z-index: 2;
+    z-index: 3;
     display: flex;
     background-color: $white;
     border-bottom: $secondaryBorder;
@@ -279,6 +227,7 @@
       display: flex;
       flex-direction: row;
       min-height: 50px;
+
       border-bottom: $secondaryBorder;
 
       &.parent-row {

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -13,7 +13,7 @@
 
   & [class*='table-cell-'] {
     flex: 0 1;
-    min-width: 70px;
+    min-width: 90px;
     width: 100%;
   }
 
@@ -38,12 +38,28 @@
       flex-grow: 5;
     }
 
+    &-extra-small {
+      max-width: 85px;
+
+      @include tableColumnFlex(0, 65px);
+    }
+
     &-small {
       max-width: 150px;
+
+      @include tableColumnFlex(0, 85px);
     }
 
     &-medium {
       @include tableColumnFlex(0, 240px);
+    }
+
+    &-icons {
+      justify-content: center;
+      padding: 5px 10px;
+      max-width: 85px;
+
+      @include tableColumnFlex(0, 65px);
     }
   }
 
@@ -144,7 +160,7 @@
       position: relative;
 
       @include tableDet;
-      @include tableHeader(8px, 15px, 8px, 30px);
+      @include tableHeader(8px, 5px, 8px, 30px);
 
       &.buttonPopout,
       &.buttonDownload {
@@ -182,7 +198,7 @@
 
       flex-wrap: wrap;
       margin: 0 1px;
-      padding: 5px 15px 5px 30px;
+      padding: 5px 5px 5px 30px;
       font-weight: 400;
       font-size: 15px;
       line-height: 18px;

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -51,7 +51,7 @@
       width: 230px;
     }
 
-    &-icons {
+    &-icon {
       justify-content: center;
       padding: 5px;
       max-width: 85px;

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -47,11 +47,6 @@
       max-width: 150px;
     }
 
-    &-medium {
-      flex: 1;
-      max-width: 240px;
-    }
-
     &-name {
       width: 240px;
     }
@@ -62,6 +57,10 @@
       max-width: 85px;
 
       @include tableColumnFlex(0, 70px);
+
+      & > * {
+        padding: 0;
+      }
     }
   }
 
@@ -129,7 +128,11 @@
       position: relative;
 
       @include tableDet;
-      @include tableHeader(8px, 5px, 8px, 30px);
+      @include tableHeader(8px, 10px, 8px, 20px);
+
+      & > * {
+        padding-left: 10px;
+      }
 
       &.buttonPopout,
       &.buttonDownload {
@@ -147,10 +150,10 @@
   }
 
   .action_cell {
-    flex: 1 0 40px;
-    width: 40px;
-    max-width: 40px;
-    padding: 0;
+    flex: 1 0 60px;
+    width: 60px;
+    max-width: 60px;
+    padding: 0 10px;
 
     &__run-icon {
       margin-bottom: -2px;
@@ -167,11 +170,15 @@
 
       flex-wrap: wrap;
       margin: 0 1px;
-      padding: 5px 5px 5px 30px;
+      padding: 8px 10px 8px 20px;
       font-weight: 400;
       font-size: 15px;
       line-height: 18px;
       border-bottom: none;
+
+      & > * {
+        padding-left: 10px;
+      }
 
       &_hidden {
         visibility: hidden;

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -43,7 +43,7 @@
     }
 
     &-medium {
-      @include tableColumnFlex(1, 240px);
+      @include tableColumnFlex(0, 240px);
     }
   }
 

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -55,7 +55,8 @@
       font-weight: 500;
     }
 
-    .artifacts {
+    .artifacts,
+    .job {
       &_medium {
         max-width: 240px;
 

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -12,7 +12,7 @@
   border-top: $secondaryBorder;
 
   & [class*='table-cell-'] {
-    flex: 0;
+    flex: 0 1;
     min-width: 70px;
     width: 100%;
   }
@@ -40,6 +40,10 @@
 
     &-small {
       max-width: 150px;
+    }
+
+    &-medium {
+      @include tableColumnFlex(1, 240px);
     }
   }
 

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -78,19 +78,21 @@
   }
 
   &__wrapper {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 2;
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
-    overflow-y: auto;
-    color: $mulledWine;
-    background-color: $white;
-    border-left: $secondaryBorder;
+    .content & {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 2;
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      overflow-y: auto;
+      color: $mulledWine;
+      background-color: $white;
+      border-left: $secondaryBorder;
+    }
 
     &-row {
       display: flex;

--- a/src/components/Table/table.scss
+++ b/src/components/Table/table.scss
@@ -13,7 +13,7 @@
 
   & [class*='table-cell-'] {
     flex: 0 0 auto;
-    min-width: 80px;
+    min-width: 75px;
   }
 
   .table-cell {
@@ -48,17 +48,17 @@
     }
 
     &-name {
-      width: 240px;
+      width: 230px;
     }
 
     &-icons {
       justify-content: center;
-      padding: 5px 10px;
+      padding: 5px;
       max-width: 85px;
 
-      @include tableColumnFlex(0, 70px);
+      @include tableColumnFlex(0, 50px);
 
-      & > * {
+      & > :first-child {
         padding: 0;
       }
     }
@@ -130,10 +130,10 @@
       position: relative;
 
       @include tableDet;
-      @include tableHeader(8px, 10px, 8px, 20px);
+      @include tableHeader(8px, 5px, 8px, 20px);
 
       & > :first-child {
-        padding-left: 10px;
+        padding-left: 5px;
       }
 
       &.buttonPopout,
@@ -152,10 +152,14 @@
   }
 
   .action_cell {
-    flex: 1 0 60px;
-    width: 60px;
-    max-width: 60px;
-    padding: 0 10px;
+    flex: 1 0 47px;
+    width: 47px;
+    max-width: 47px;
+    padding: 0 5px;
+
+    & > :first-child {
+      padding-left: 0;
+    }
 
     &__run-icon {
       margin-bottom: -2px;
@@ -172,14 +176,14 @@
 
       flex-wrap: wrap;
       margin: 0 1px;
-      padding: 8px 10px 8px 20px;
+      padding: 8px 5px 8px 20px;
       font-weight: 400;
       font-size: 15px;
       line-height: 18px;
       border-bottom: none;
 
       & > :first-child {
-        padding-left: 10px;
+        padding-left: 5px;
       }
 
       &_hidden {

--- a/src/elements/TableLinkCell/tableLinkCell.scss
+++ b/src/elements/TableLinkCell/tableLinkCell.scss
@@ -31,6 +31,7 @@
   .date-uid-row {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     font-weight: normal;
     font-size: 12px;
     font-family: Roboto, sans-serif;

--- a/src/elements/TableLinkCell/tableLinkCell.scss
+++ b/src/elements/TableLinkCell/tableLinkCell.scss
@@ -38,7 +38,7 @@
     font-style: normal;
     line-height: 18px;
 
-    & > span:not(:last-child) {
+    & > span {
       margin-right: 10px;
     }
 

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -61,7 +61,7 @@ body {
 .content {
   position: relative;
   flex-direction: column;
-  min-width: 900px;
+  min-width: 800px;
   margin: 15px 24px;
 
   @include jobsFlex;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -215,7 +215,7 @@ main {
     position: absolute;
     top: auto;
     bottom: auto;
-    left: 5px;
+    left: 2px;
     margin: 0;
   }
 

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -35,7 +35,7 @@ import { formatDatetime } from './datetime'
 import { convertBytes } from './convertBytes'
 import { copyToClipboard } from './copyToClipboard'
 import { generateUri } from './resources'
-import { generateLinkPath, parseUri, truncateUid } from '../utils'
+import { generateLinkPath, parseUri } from '../utils'
 import { generateLinkToDetailsPanel } from './generateLinkToDetailsPanel'
 
 import { ReactComponent as SeverityOk } from 'igz-controls/images/severity-ok.svg'
@@ -129,8 +129,12 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
           ),
         expandedCellContent: {
           class: 'artifacts_medium',
-          value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`,
-          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`
+          showTag: true,
+          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
+          type: 'date',
+          value: formatDatetime(artifact.updated, 'N/A')
+
+          // value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`
         },
         rowExpanded: {
           getLink: false
@@ -248,8 +252,10 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
           ),
         expandedCellContent: {
           class: 'artifacts_medium',
-          value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`,
-          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`
+          showTag: true,
+          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
+          type: 'date',
+          value: formatDatetime(artifact.updated, 'N/A')
         },
         rowExpanded: {
           getLink: false
@@ -444,7 +450,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
 
   return {
     data: {
-      ...artifact,
+      ...artifact
     },
     content: [
       {
@@ -465,8 +471,12 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
           ),
         expandedCellContent: {
           class: 'artifacts_medium',
-          value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`,
-          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`
+          showTag: true,
+          tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
+          type: 'date',
+          value: formatDatetime(artifact.updated, 'N/A')
+
+          //  value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`,
         },
         rowExpanded: {
           getLink: false

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -73,7 +73,7 @@ const createArtifactsRowData = artifact => {
     },
     labels: {
       value: parseKeyValues(artifact.labels),
-      class: 'table-cell-medium',
+      class: 'table-cell-1',
       type: 'labels'
     },
     producer: {
@@ -146,7 +146,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-medium',
+        class: 'table-cell-1',
         type: 'labels'
       },
       {
@@ -292,7 +292,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-medium',
+        class: 'table-cell-1',
         type: 'labels'
       },
       {
@@ -433,7 +433,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.metadata?.labels),
-        class: 'table-cell-medium',
+        class: 'table-cell-1',
         type: 'labels'
       },
       {
@@ -441,14 +441,14 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'uptime',
         headerLabel: 'Uptime',
         value: formatDatetime(artifact.status?.first_request, '-'),
-        class: 'table-cell-medium'
+        class: 'table-cell-1'
       },
       {
         id: `lastRequest.${artifact.ui.identifierUnique}`,
         headerId: 'lastprediction',
         headerLabel: 'Last prediction',
         value: formatDatetime(artifact.status?.last_request, '-'),
-        class: 'table-cell-medium'
+        class: 'table-cell-1'
       },
       {
         id: `averageLatency.${artifact.ui.identifierUnique}`,
@@ -519,7 +519,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-medium',
+        class: 'table-cell-1',
         type: 'labels'
       },
       {

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -92,12 +92,12 @@ const createArtifactsRowData = artifact => {
     },
     buttonPopout: {
       value: '',
-      class: 'table-cell-icons',
+      class: 'table-cell-icon',
       type: 'buttonPopout'
     },
     buttonDownload: {
       value: '',
-      class: 'table-cell-icons',
+      class: 'table-cell-icon',
       type: 'buttonDownload'
     }
   }
@@ -213,21 +213,21 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popupt',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, MODELS_TAB))
       }
@@ -329,21 +329,21 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popout',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, ARTIFACTS))
       }
@@ -563,21 +563,21 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popout',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, DATASETS))
       }

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -69,35 +69,35 @@ const createArtifactsRowData = artifact => {
     },
     kind: {
       value: artifact.kind,
-      class: 'artifacts_extra-small'
+      class: 'table-cell-small'
     },
     labels: {
       value: parseKeyValues(artifact.labels),
-      class: 'artifacts_big',
+      class: 'table-cell-2',
       type: 'labels'
     },
     producer: {
       value: artifact.producer,
-      class: 'artifacts_small',
+      class: 'table-cell-1',
       type: 'producer'
     },
     owner: {
       value: artifact.producer?.owner,
-      class: 'artifacts_small',
+      class: 'table-cell-1',
       type: 'owner'
     },
     updated: {
       value: formatDatetime(artifact.updated, 'N/A'),
-      class: 'artifacts_small'
+      class: 'table-cell-1'
     },
     buttonPopout: {
       value: '',
-      class: 'artifacts_extra-small artifacts__icon',
+      class: 'table-cell-icons',
       type: 'buttonPopout'
     },
     buttonDownload: {
       value: '',
-      class: 'artifacts_extra-small artifacts__icon',
+      class: 'table-cell-icons',
       type: 'buttonDownload'
     }
   }
@@ -146,7 +146,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'labels'
       },
       {
@@ -154,7 +154,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'producer',
         headerLabel: 'Producer',
         value: artifact.producer,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'producer'
       },
       {
@@ -162,7 +162,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'owner',
         headerLabel: 'Owner',
         value: artifact.producer?.owner,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'owner'
       },
       {
@@ -170,14 +170,14 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'updated',
         headerLabel: 'Updated',
         value: formatDatetime(artifact.updated, 'N/A'),
-        class: 'artifacts_big'
+        class: 'table-cell-2'
       },
       {
         id: `metrics.${artifact.ui.identifierUnique}`,
         headerId: 'metrics',
         headerLabel: 'Metrics',
         value: parseKeyValues(artifact.metrics),
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'metrics'
       },
       {
@@ -200,34 +200,34 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
           ) : (
             ''
           ),
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `version.${artifact.ui.identifierUnique}`,
         headerId: 'tag',
         value: artifact.tag,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'hidden'
       },
       {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popupt',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, MODELS_TAB))
       }
@@ -277,7 +277,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         id: `version.${artifact.ui.identifierUnique}`,
         headerId: 'tag',
         value: artifact.tag,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'hidden'
       },
       {
@@ -285,14 +285,14 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'type',
         headerLabel: 'Type',
         value: artifact.kind,
-        class: 'artifacts_extra-small'
+        class: 'table-cell-small'
       },
       {
         id: `labels.${artifact.ui.identifierUnique}`,
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'artifacts_big',
+        class: 'table-cell-2',
         type: 'labels'
       },
       {
@@ -300,7 +300,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'producer',
         headerLabel: 'Producer',
         value: artifact.producer || {},
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'producer'
       },
       {
@@ -308,7 +308,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'owner',
         headerLabel: 'Owner',
         value: artifact.producer?.owner,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'owner'
       },
       {
@@ -316,34 +316,34 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'updated',
         headerLabel: 'Updated',
         value: formatDatetime(artifact.updated, 'N/A'),
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `size.${artifact.ui.identifierUnique}`,
         headerId: 'size',
         headerLabel: 'Size',
         value: artifact.size ? convertBytes(artifact.size) : 'N/A',
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popout',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, ARTIFACTS))
       }
@@ -403,7 +403,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'function',
         headerLabel: 'Function',
         value: functionName,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         link: `${generateLinkPath(functionUri)}/overview`,
         tooltip: functionUri
       },
@@ -411,7 +411,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         id: `state.${artifact.ui.identifierUnique}`,
         headerId: 'state',
         value: artifact.status?.state,
-        class: 'artifacts_extra-small',
+        class: 'table-cell-small',
         type: 'hidden'
       },
       {
@@ -419,14 +419,14 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'version',
         headerLabel: 'Version',
         value: artifact?.status?.children ? 'Router' : tag,
-        class: 'artifacts_extra-small'
+        class: 'table-cell-small'
       },
       {
         id: `modelClass.${artifact.ui.identifierUnique}`,
         headerId: 'class',
         headerLabel: 'Class',
         value: artifact.spec?.model_class,
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `labels.${artifact.ui.identifierUnique}`,
@@ -455,21 +455,21 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'averagelatency',
         headerLabel: 'Average latency',
         value: averageLatency ? `${(averageLatency / 1000).toFixed(2)}ms` : '-',
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `errorCount.${artifact.ui.identifierUnique}`,
         headerId: 'errorcount',
         headerLabel: 'Error count',
         value: artifact.status?.error_count ?? '-',
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `driftStatus.${artifact.ui.identifierUnique}`,
         headerId: 'drift',
         headerLabel: 'Drift',
         value: driftStatusIcons[artifact.status?.drift_status]?.value,
-        class: 'artifacts_extra-small',
+        class: 'table-cell-small',
         tooltip: driftStatusIcons[artifact.status?.drift_status]?.tooltip
       }
     ]
@@ -519,7 +519,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'artifacts_big',
+        class: 'table-cell-2',
         type: 'labels'
       },
       {
@@ -527,7 +527,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'producer',
         headerLabel: 'Producer',
         value: artifact.producer,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'producer'
       },
       {
@@ -535,7 +535,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'owner',
         headerLabel: 'Owner',
         value: artifact.producer?.owner,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'owner'
       },
       {
@@ -543,41 +543,41 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'updated',
         headerLabel: 'Updated',
         value: formatDatetime(artifact.updated, 'N/A'),
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `size.${artifact.ui.identifierUnique}`,
         headerId: 'size',
         headerLabel: 'Size',
         value: convertBytes(artifact.size || 0),
-        class: 'artifacts_small'
+        class: 'table-cell-1'
       },
       {
         id: `version.${artifact.ui.identifierUnique}`,
         headerId: 'tag',
         value: artifact.tag,
-        class: 'artifacts_small',
+        class: 'table-cell-1',
         type: 'hidden'
       },
       {
         id: `buttonPopout.${artifact.ui.identifierUnique}`,
         headerId: 'popout',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonPopout'
       },
       {
         id: `buttonDownload.${artifact.ui.identifierUnique}`,
         headerId: 'download',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: 'buttonDownload'
       },
       {
         id: `buttonCopy.${artifact.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'artifacts_extra-small artifacts__icon',
+        class: 'table-cell-icons',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, DATASETS))
       }

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -134,8 +134,6 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
           value: formatDatetime(artifact.updated, 'N/A')
-
-          // value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`
         },
         rowExpanded: {
           getLink: false
@@ -509,8 +507,6 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
           value: formatDatetime(artifact.updated, 'N/A')
-
-          //  value: artifact.tag ? `${artifact.tag}${iter}` : `${truncateUid(artifact.tree)}${iter}`,
         },
         rowExpanded: {
           getLink: false

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -64,7 +64,7 @@ const createArtifactsRowData = artifact => {
   return {
     key: {
       value: artifact.db_key,
-      class: 'table-cell-medium',
+      class: 'table-cell-name',
       link: 'overview'
     },
     kind: {
@@ -73,7 +73,7 @@ const createArtifactsRowData = artifact => {
     },
     labels: {
       value: parseKeyValues(artifact.labels),
-      class: 'table-cell-2',
+      class: 'table-cell-medium',
       type: 'labels'
     },
     producer: {
@@ -116,7 +116,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'table-cell-medium',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -129,7 +129,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'table-cell-medium',
+          class: 'table-cell-name',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
@@ -146,7 +146,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-1',
+        class: 'table-cell-medium',
         type: 'labels'
       },
       {
@@ -248,7 +248,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'table-cell-medium',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -261,7 +261,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'table-cell-medium',
+          class: 'table-cell-name',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
@@ -292,7 +292,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-2',
+        class: 'table-cell-medium',
         type: 'labels'
       },
       {
@@ -385,7 +385,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: name,
-        class: 'table-cell-medium',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -489,7 +489,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'table-cell-medium',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -502,7 +502,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'table-cell-medium',
+          class: 'table-cell-name',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
@@ -519,7 +519,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.labels),
-        class: 'table-cell-2',
+        class: 'table-cell-medium',
         type: 'labels'
       },
       {

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -170,7 +170,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'updated',
         headerLabel: 'Updated',
         value: formatDatetime(artifact.updated, 'N/A'),
-        class: 'table-cell-2'
+        class: 'table-cell-1'
       },
       {
         id: `metrics.${artifact.ui.identifierUnique}`,

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -64,7 +64,7 @@ const createArtifactsRowData = artifact => {
   return {
     key: {
       value: artifact.db_key,
-      class: 'artifacts_medium',
+      class: 'table-cell-medium',
       link: 'overview'
     },
     kind: {
@@ -116,7 +116,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'artifacts_medium',
+        class: 'table-cell-medium',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -129,7 +129,7 @@ export const createModelsRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'artifacts_medium',
+          class: 'table-cell-medium',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
@@ -250,7 +250,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'artifacts_medium',
+        class: 'table-cell-medium',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -263,7 +263,7 @@ export const createFilesRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'artifacts_medium',
+          class: 'table-cell-medium',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',
@@ -387,7 +387,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: name,
-        class: 'artifacts_medium',
+        class: 'table-cell-medium',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -435,7 +435,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'labels',
         headerLabel: 'Labels',
         value: parseKeyValues(artifact.metadata?.labels),
-        class: 'artifacts_medium',
+        class: 'table-cell-medium',
         type: 'labels'
       },
       {
@@ -443,14 +443,14 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'uptime',
         headerLabel: 'Uptime',
         value: formatDatetime(artifact.status?.first_request, '-'),
-        class: 'artifacts_medium'
+        class: 'table-cell-medium'
       },
       {
         id: `lastRequest.${artifact.ui.identifierUnique}`,
         headerId: 'lastprediction',
         headerLabel: 'Last prediction',
         value: formatDatetime(artifact.status?.last_request, '-'),
-        class: 'artifacts_medium'
+        class: 'table-cell-medium'
       },
       {
         id: `averageLatency.${artifact.ui.identifierUnique}`,
@@ -491,7 +491,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
         headerId: 'name',
         headerLabel: 'Name',
         value: artifact.db_key,
-        class: 'artifacts_medium',
+        class: 'table-cell-medium',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -504,7 +504,7 @@ export const createDatasetsRowData = (artifact, project, showExpandButton) => {
             artifact.iter
           ),
         expandedCellContent: {
-          class: 'artifacts_medium',
+          class: 'table-cell-medium',
           showTag: true,
           tooltip: artifact.tag ? `${artifact.tag}${iter}` : `${artifact.tree}${iter}`,
           type: 'date',

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -63,7 +63,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         headerId: 'name',
         headerLabel: 'Name',
         value: featureSet.name,
-        class: 'table-cell-medium',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -77,7 +77,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         showTag: true,
         showStatus: true,
         expandedCellContent: {
-          class: 'table-cell-medium',
+          class: 'table-cell-name',
           value: featureSet.tag || truncateUid(featureSet.uid),
           tooltip: featureSet.tag || featureSet.uid,
           showTag: true,
@@ -120,7 +120,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         id: `buttonCopy.${featureSet.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-1',
+        class: 'table-cell-icons',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => {
           copyToClipboard(generateUri(item, pageTab))
@@ -265,7 +265,7 @@ const getFeatureSetTargetCellValue = (targets, identifierUnique) => ({
     )
     .sort((icon, otherIcon) => (icon.tooltip < otherIcon.tooltip ? -1 : 1)),
   id: `targets.${identifierUnique}`,
-  class: 'table-cell-1',
+  class: 'table-cell-icons',
   type: 'icons'
 })
 
@@ -280,7 +280,7 @@ export const createFeatureVectorsRowData = (featureVector, pageTab, project, sho
         headerId: 'name',
         headerLabel: 'Name',
         value: featureVector.name,
-        class: 'table-cell-3',
+        class: 'table-cell-name',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -294,7 +294,7 @@ export const createFeatureVectorsRowData = (featureVector, pageTab, project, sho
         showTag: true,
         showStatus: true,
         expandedCellContent: {
-          class: 'table-cell-3',
+          class: 'table-cell-name',
           value: featureVector.tag || truncateUid(featureVector.uid),
           tooltip: featureVector.tag || featureVector.uid,
           showTag: true,
@@ -344,7 +344,7 @@ export const createFeatureVectorsRowData = (featureVector, pageTab, project, sho
         id: `buttonCopy.${featureVector.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-1',
+        class: 'table-cell-icons',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, pageTab))
       },

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -120,7 +120,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         id: `buttonCopy.${featureSet.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-1 artifacts__icon',
+        class: 'table-cell-1',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => {
           copyToClipboard(generateUri(item, pageTab))
@@ -265,7 +265,7 @@ const getFeatureSetTargetCellValue = (targets, identifierUnique) => ({
     )
     .sort((icon, otherIcon) => (icon.tooltip < otherIcon.tooltip ? -1 : 1)),
   id: `targets.${identifierUnique}`,
-  class: 'table-cell-2 artifacts__targets-icon',
+  class: 'table-cell-1',
   type: 'icons'
 })
 
@@ -344,7 +344,7 @@ export const createFeatureVectorsRowData = (featureVector, pageTab, project, sho
         id: `buttonCopy.${featureVector.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-1 artifacts__icon',
+        class: 'table-cell-1',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, pageTab))
       },

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -63,7 +63,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         headerId: 'name',
         headerLabel: 'Name',
         value: featureSet.name,
-        class: 'table-cell-2',
+        class: 'table-cell-medium',
         getLink: tab =>
           generateLinkToDetailsPanel(
             project,
@@ -77,7 +77,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         showTag: true,
         showStatus: true,
         expandedCellContent: {
-          class: 'table-cell-2',
+          class: 'table-cell-medium',
           value: featureSet.tag || truncateUid(featureSet.uid),
           tooltip: featureSet.tag || featureSet.uid,
           showTag: true,

--- a/src/utils/createFeatureStoreContent.js
+++ b/src/utils/createFeatureStoreContent.js
@@ -120,7 +120,7 @@ export const createFeatureSetsRowData = (featureSet, pageTab, project, showExpan
         id: `buttonCopy.${featureSet.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => {
           copyToClipboard(generateUri(item, pageTab))
@@ -265,7 +265,7 @@ const getFeatureSetTargetCellValue = (targets, identifierUnique) => ({
     )
     .sort((icon, otherIcon) => (icon.tooltip < otherIcon.tooltip ? -1 : 1)),
   id: `targets.${identifierUnique}`,
-  class: 'table-cell-icons',
+  class: 'table-cell-icon',
   type: 'icons'
 })
 
@@ -344,7 +344,7 @@ export const createFeatureVectorsRowData = (featureVector, pageTab, project, sho
         id: `buttonCopy.${featureVector.ui.identifierUnique}`,
         headerId: 'copy',
         value: '',
-        class: 'table-cell-icons',
+        class: 'table-cell-icon',
         type: BUTTON_COPY_URI_CELL_TYPE,
         actionHandler: item => copyToClipboard(generateUri(item, pageTab))
       },

--- a/src/utils/createFunctionsContent.js
+++ b/src/utils/createFunctionsContent.js
@@ -34,7 +34,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'name',
               headerLabel: 'Name',
               value: func.name,
-              class: 'table-cell-medium',
+              class: 'table-cell-name',
               getLink: hash => {
                 return `/projects/${projectName}/${MODELS_PAGE.toLowerCase()}/${REAL_TIME_PIPELINES_TAB}/pipeline/${hash}`
               },
@@ -42,7 +42,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               showStatus: true,
               expandedCellContent: {
                 value: formatDatetime(func.updated, 'N/A'),
-                class: 'table-cell-medium',
+                class: 'table-cell-name',
                 type: 'date',
                 showTag: true,
                 showStatus: true
@@ -54,7 +54,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'type',
               headerLabel: 'Type',
               value: func.graph?.kind === 'router' ? 'Router' : 'Flow',
-              class: 'table-cell-medium',
+              class: 'table-cell-small',
               type: 'type'
             },
             {
@@ -70,7 +70,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               id: `updated.${func.ui.identifierUnique}`,
               headerId: 'updated',
               value: formatDatetime(func.updated, 'N/A'),
-              class: 'table-cell-medium',
+              class: 'table-cell-2',
               type: 'date',
               showTag: true,
               showStatus: true,
@@ -88,13 +88,13 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'name',
               headerLabel: 'Name',
               value: func.name,
-              class: 'table-cell-medium',
+              class: 'table-cell-name',
               getLink: (hash, tab) => {
                 return `/projects/${projectName}/functions/${hash}${`/${tab}`}`
               },
               expandedCellContent: {
                 value: formatDatetime(func.updated, 'N/A'),
-                class: 'table-cell-medium',
+                class: 'table-cell-name',
                 type: 'date',
                 showTag: true,
                 showStatus: true
@@ -108,7 +108,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'kind',
               headerLabel: 'Kind',
               value: func.type,
-              class: 'table-cell-1',
+              class: 'table-cell-small',
               type: 'type'
             },
             {

--- a/src/utils/createFunctionsContent.js
+++ b/src/utils/createFunctionsContent.js
@@ -62,7 +62,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'function',
               headerLabel: 'Function',
               value: func.name,
-              class: 'functions_big',
+              class: 'table-cell-2',
               getLink: tab =>
                 generateLinkToDetailsPanel(func.project, FUNCTIONS_PAGE, null, func.hash, null, tab)
             },
@@ -108,7 +108,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'kind',
               headerLabel: 'Kind',
               value: func.type,
-              class: 'functions_small',
+              class: 'table-cell-1',
               type: 'type'
             },
             {
@@ -116,7 +116,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'hash',
               headerLabel: 'Hash',
               value: func.hash,
-              class: 'functions_small',
+              class: 'table-cell-1',
               type: 'hash'
             },
             {
@@ -124,7 +124,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'updated',
               headerLabel: 'Updated',
               value: formatDatetime(func.updated, 'N/A'),
-              class: 'functions_small',
+              class: 'table-cell-2',
               type: 'date',
               showTag: true,
               showStatus: true
@@ -134,21 +134,21 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'command',
               headerLabel: 'Command',
               value: func.command,
-              class: 'functions_big'
+              class: 'table-cell-1'
             },
             {
               id: `image.${func.ui.identifierUnique}`,
               headerId: 'image',
               headerLabel: 'Image',
               value: func.image,
-              class: 'functions_big'
+              class: 'table-cell-1'
             },
             {
               id: `description.${func.ui.identifierUnique}`,
               headerId: 'description',
               headerLabel: 'Description',
               value: func.description,
-              class: 'functions_small'
+              class: 'table-cell-2'
             },
             {
               id: `tag.${func.ui.identifierUnique}`,

--- a/src/utils/createFunctionsContent.js
+++ b/src/utils/createFunctionsContent.js
@@ -34,7 +34,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'name',
               headerLabel: 'Name',
               value: func.name,
-              class: 'functions_medium',
+              class: 'table-cell-medium',
               getLink: hash => {
                 return `/projects/${projectName}/${MODELS_PAGE.toLowerCase()}/${REAL_TIME_PIPELINES_TAB}/pipeline/${hash}`
               },
@@ -42,7 +42,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               showStatus: true,
               expandedCellContent: {
                 value: formatDatetime(func.updated, 'N/A'),
-                class: 'functions_medium',
+                class: 'table-cell-medium',
                 type: 'date',
                 showTag: true,
                 showStatus: true
@@ -54,7 +54,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'type',
               headerLabel: 'Type',
               value: func.graph?.kind === 'router' ? 'Router' : 'Flow',
-              class: 'functions_medium',
+              class: 'table-cell-medium',
               type: 'type'
             },
             {
@@ -70,7 +70,7 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               id: `updated.${func.ui.identifierUnique}`,
               headerId: 'updated',
               value: formatDatetime(func.updated, 'N/A'),
-              class: 'functions_medium',
+              class: 'table-cell-medium',
               type: 'date',
               showTag: true,
               showStatus: true,
@@ -88,13 +88,13 @@ const createFunctionsContent = (functions, pageTab, projectName, showExpandButto
               headerId: 'name',
               headerLabel: 'Name',
               value: func.name,
-              class: 'functions_medium',
+              class: 'table-cell-medium',
               getLink: (hash, tab) => {
                 return `/projects/${projectName}/functions/${hash}${`/${tab}`}`
               },
               expandedCellContent: {
                 value: formatDatetime(func.updated, 'N/A'),
-                class: 'functions_medium',
+                class: 'table-cell-medium',
                 type: 'date',
                 showTag: true,
                 showStatus: true

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -46,7 +46,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           headerLabel: jobName ? 'UID' : 'Name',
           id: `name.${identifierUnique}`,
           value: jobName ? job.uid || job.id : job.name,
-          class: 'table-cell-medium',
+          class: 'table-cell-name',
           type: type === 'workflow' && !isStagingMode ? 'hidden' : 'link',
           getLink: tab => {
             return jobName
@@ -164,7 +164,7 @@ export const createJobsScheduleTabContent = jobs => {
           headerLabel: 'Name',
           id: `name.${identifierUnique}`,
           value: job.name,
-          class: 'table-cell-1',
+          class: 'table-cell-name',
           showStatus: true,
           getLink: tab =>
             generateLinkToDetailsPanel(
@@ -267,7 +267,7 @@ export const createJobsWorkflowsTabContent = (
                 headerLabel: 'Name',
                 id: `name.${identifierUnique}`,
                 value: jobName,
-                class: 'table-cell-3',
+                class: 'table-cell-name',
                 type: type === 'workflow' && !isStagingMode ? 'hidden' : 'link',
                 getLink: tab => {
                   return getWorkflowDetailsLink(
@@ -371,7 +371,7 @@ export const createJobsWorkflowsTabContent = (
                 headerLabel: 'Name',
                 id: `name.${identifierUnique}`,
                 value: jobName,
-                class: 'table-cell-1',
+                class: 'table-cell-name',
                 getLink: () => {
                   return getWorkflowDetailsLink(
                     projectName,

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -46,7 +46,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           headerLabel: jobName ? 'UID' : 'Name',
           id: `name.${identifierUnique}`,
           value: jobName ? job.uid || job.id : job.name,
-          class: 'table-cell-2',
+          class: 'table-cell-medium',
           type: type === 'workflow' && !isStagingMode ? 'hidden' : 'link',
           getLink: tab => {
             return jobName

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -45,7 +45,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           header: jobName ? 'UID' : 'Name',
           id: `name.${identifierUnique}`,
           value: jobName ? job.uid || job.id : job.name,
-          class: 'table-cell-2',
+          class: 'job_medium',
           type: type === 'workflow' && !isStagingMode ? 'hidden' : 'link',
           getLink: tab => {
             return jobName

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -45,7 +45,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           header: jobName ? 'UID' : 'Name',
           id: `name.${identifierUnique}`,
           value: jobName ? job.uid || job.id : job.name,
-          class: 'job_medium',
+          class: 'table-cell-2',
           type: type === 'workflow' && !isStagingMode ? 'hidden' : 'link',
           getLink: tab => {
             return jobName

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -106,7 +106,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           headerLabel: 'Labels',
           id: `labels.${identifierUnique}`,
           value: job.labels,
-          class: 'table-cell-1 table-cell-small',
+          class: 'table-cell-1',
           type: 'labels'
         },
         {
@@ -114,7 +114,7 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           headerLabel: 'Parameters',
           id: `parameters.${identifierUnique}`,
           value: job.parametersChips,
-          class: 'table-cell-1 table-cell-small',
+          class: 'table-cell-1',
           type: 'parameters'
         },
         {


### PR DESCRIPTION
- **Artifacts**:  Align 'Name' column in Artifacts and ML function view
  -  Change the 'table__item' class name on Overview panel
  - "Consumer groups (v3io stream)" is always empty
  
   Jira: [ML-2740](https://jira.iguazeng.com/browse/ML-2740) + [ML-3332](https://jira.iguazeng.com/browse/ML-3332) + [ML-3331](https://jira.iguazeng.com/browse/ML-3331)
   
   Before:
   ![Screen Shot 2023-01-23 at 19 00 33](https://user-images.githubusercontent.com/63646693/214102084-a45d437f-a35a-4128-b4ef-488242b20e2b.png)
   ![Screen Shot 2023-01-23 at 19 00 58](https://user-images.githubusercontent.com/63646693/214102167-6caa34a3-4c33-4ed6-a19b-fbe79a59add6.png)

   After:
   ![Screen Shot 2023-01-23 at 19 02 01](https://user-images.githubusercontent.com/63646693/214102407-cfe84c1e-9176-42ff-8fe6-edf6140d9fac.png)
   ![Screen Shot 2023-01-23 at 19 02 16](https://user-images.githubusercontent.com/63646693/214102459-4f0a0da8-c274-4769-823f-fb0c34353e21.png)

