### PR TITLE
Fix [Jobs] make default sort by 'Iter' in 'Results' tab

### DIFF
--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -51,7 +51,7 @@ const ArtifactsPreviewView = ({ className, preview, setShowErrorBody, showErrorB
         <>
           {preview?.type === 'table-results' && (
             <div className="artifact-preview__table">
-              <DetailsResults job={preview} defaultSortBy="accuracy" excludeSortBy="state" />
+              <DetailsResults job={preview} excludeSortBy="state" />
             </div>
           )}
           {preview?.type === 'table' && (

--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -326,7 +326,7 @@ export const renderContent = (
         />
       )
     case DETAILS_RESULTS_TAB:
-      return <DetailsResults job={selectedItem} defaultSortBy="accuracy" excludeSortBy="state" />
+      return <DetailsResults job={selectedItem} excludeSortBy="state" />
     case DETAILS_LOGS_TAB:
     case DETAILS_BUILD_LOG_TAB:
       return (


### PR DESCRIPTION
- **Jobs**: make default sort by 'Iter' in 'Results' tab
   Jira: [ML-3322](https://jira.iguazeng.com/browse/ML-3322)