### PR TITLE
Fix [Workflow] Use `run_type` value instead of `type` in the table

### DIFF
--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -354,10 +354,10 @@ export const createJobsWorkflowContent = (
           showStatus: true
         },
         {
-          headerId: 'type',
-          headerLabel: 'Type',
-          id: `type.${identifierUnique}`,
-          value: job.type,
+          headerId: 'kind',
+          headerLabel: 'Kind',
+          id: `kind.${identifierUnique}`,
+          value: job.run_type,
           class: 'table-cell-1',
           type: 'type',
           hidden: isSelectedItem


### PR DESCRIPTION
- **Workflow**: Use run_type value instead of type in the table
   Jira: https://jira.iguazeng.com/browse/ML-3399
   
   After:
   ![image](https://user-images.githubusercontent.com/25711177/220956685-a8c42175-de9e-4e21-825d-b0d22eed686f.png)
