### PR TITLE
Fix [Functions] Details Pane Header Too Short for Tab Content Width

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -242,6 +242,8 @@
 
       pre {
         padding: 8px 16px;
+        white-space: pre-wrap;
+        word-break: break-word;
       }
     }
 


### PR DESCRIPTION
- **Functions**: Details Pane Header Too Short for Tab Content Width
   Jira: https://jira.iguazeng.com/browse/ML-3464

   Before: 
   ![Screenshot from 2023-02-23 13-36-16](https://user-images.githubusercontent.com/58301139/221110311-9b4cdf62-eccd-4304-8492-fca9a187e36a.png)

   After: 
   ![Screenshot from 2023-02-24 08-43-49](https://user-images.githubusercontent.com/58301139/221110412-6d54bc3e-0989-4fc5-997c-9c0302311e5f.png)


