### PR TITLE
Fix [Models Endpoints] Histogram bars are not in place in the feature analysis tab

### DIFF
--- a/src/components/DetailsFeaturesAnalysis/detailsFeaturesAnalysis.scss
+++ b/src/components/DetailsFeaturesAnalysis/detailsFeaturesAnalysis.scss
@@ -40,7 +40,7 @@
       min-width: 50px;
       padding: 0 5px;
 
-      &-chart {
+      &__chart {
         height: 54px;
       }
 

--- a/src/components/DetailsFeaturesAnalysis/detailsFeaturesAnalysis.util.js
+++ b/src/components/DetailsFeaturesAnalysis/detailsFeaturesAnalysis.util.js
@@ -185,13 +185,13 @@ export const generateFeaturesAnalysis = (modelEndpoint = {}) => {
             value: value?.hist ?? [[], []],
             type: 'chart',
             className:
-              'features-analysis__table-cell_medium features-analysis__table-cell-chart'
+              'features-analysis__table-cell_medium features-analysis__table-cell__chart'
           },
           {
             value: currentStats[key]?.hist ?? [[], []],
             type: 'chart',
             className:
-              'features-analysis__table-cell_medium features-analysis__table-cell-chart'
+              'features-analysis__table-cell_medium features-analysis__table-cell__chart'
           }
         ]
       }


### PR DESCRIPTION
- **Models Endpoints**: Histogram bars are not in place in the feature analysis tab
   Jira: https://jira.iguazeng.com/browse/ML-3510

   After:
   ![image](https://user-images.githubusercontent.com/78905712/223118432-7375745d-b67b-4e41-9a81-7ce7c1e54f0f.png)
