### PR TITLE
Fix [Schedule] Scheduled jobs are not shown

### DIFF
--- a/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
+++ b/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
@@ -109,7 +109,8 @@ const ScheduledJobs = ({
               status: error?.response?.status || 400,
               id: Math.random(),
               message: 'Failed to fetch jobs',
-              retry: () => refreshJobs(filters)
+              retry: () => refreshJobs(filters),
+              error
             })
           )
         })
@@ -144,7 +145,8 @@ const ScheduledJobs = ({
               message:
                 error.response.status === FORBIDDEN_ERROR_STATUS_CODE
                   ? 'You are not permitted to run new job.'
-                  : 'Job failed to start.'
+                  : 'Job failed to start.',
+              error
             })
           )
         })
@@ -241,13 +243,14 @@ const ScheduledJobs = ({
             setJobWizardMode(PANEL_EDIT_MODE)
           }
         })
-        .catch(() => {
+        .catch(error => {
           dispatch(
             setNotification({
               status: 400,
               id: Math.random(),
               retry: () => handleEditScheduleJob(editableItem),
-              message: 'Failed to fetch job access key'
+              message: 'Failed to fetch job access key',
+              error
             })
           )
         })

--- a/src/reducers/notificationReducer.js
+++ b/src/reducers/notificationReducer.js
@@ -28,6 +28,10 @@ const notificationSlice = createSlice({
   initialState,
   reducers: {
     setNotification(state, { payload }) {
+      if (payload.error) {
+        console.error(payload.error)
+      }
+
       state.notification.push(payload)
     },
     removeNotification(state, { payload }) {

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -213,7 +213,7 @@ export const createJobsScheduleTabContent = jobs => {
           headerId: 'lastrun',
           headerLabel: 'Last run (Local TZ)',
           id: `lastRun.${identifierUnique}`,
-          value: formatDatetime(job.start_time),
+          value: formatDatetime(job.startTime),
           class: 'table-cell-1',
           getLink: lastRunLink
         },

--- a/src/utils/getState.js
+++ b/src/utils/getState.js
@@ -30,7 +30,7 @@ const getState = (state, page, kind) => {
     return {
       value: state ?? null,
       label: state ? commonStateLabels[state] : '',
-      className: `state-${state ?? ''}${kind ? '-' + kind : ''}`
+      className: `state${state ? '-' + state : ''}${kind ? '-' + kind : ''}`
     }
   }
 }

--- a/src/utils/parseJob.js
+++ b/src/utils/parseJob.js
@@ -34,8 +34,8 @@ export const parseJob = (job, tab) => {
       lastRunUri: job.last_run_uri,
       project: job.project,
       scheduled_object: job.scheduled_object,
-      start_time: new Date(job.last_run?.status.start_time),
-      state: getState(job.last_run?.status.state, JOBS_PAGE, 'job'),
+      startTime: new Date(job.last_run?.status?.start_time),
+      state: getState(job.last_run?.status?.state, JOBS_PAGE, 'job'),
       type: job.kind === 'pipeline' ? 'workflow' : job.kind,
       ui: {
         originalContent: job
@@ -45,7 +45,7 @@ export const parseJob = (job, tab) => {
     jobItem = {
       artifacts: job.status.artifacts || [],
       error: job.status.error ?? '',
-      function: job?.spec?.function ?? '',
+      function: job.spec?.function ?? '',
       handler: job.spec?.handler ?? '',
       hyperparams: job.spec?.hyperparams || {},
       inputs: job.spec?.inputs || {},
@@ -63,13 +63,13 @@ export const parseJob = (job, tab) => {
         ...parseKeyValues(job.spec?.hyperparams || {})
       ],
       project: job.metadata.project,
-      results: job.status.results || {},
-      resultsChips: parseKeyValues(job.status.results || {}),
-      startTime: new Date(job.status.start_time),
-      state: getState(job.status.state, JOBS_PAGE, 'job'),
-      ui_run: job.status.ui_url,
+      results: job.status?.results || {},
+      resultsChips: parseKeyValues(job.status?.results || {}),
+      startTime: new Date(job.status?.start_time),
+      state: getState(job.status?.state, JOBS_PAGE, 'job'),
+      ui_run: job.status?.ui_url,
       uid: job.metadata.uid,
-      updated: new Date(job.status.last_update),
+      updated: new Date(job.status?.last_update),
       ui: {}
     }
   }


### PR DESCRIPTION
- **Schedule**: Scheduled jobs are not shown
   Happened if job's `last_run` property was an empty object (`last_run: {}`)
   Jira: https://jira.iguazeng.com/browse/ML-3528
   