### PR TITLE
Fix [Artifacts] unable to set empty "Version tag"

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "final-form-arrays": "^3.0.2",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "0.0.36",
+    "iguazio.dashboard-react-controls": "0.0.37",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^3.13.1",

--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -17,7 +17,7 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import { isEmpty, isEqual, cloneDeep, isNil } from 'lodash'
+import { get, isEmpty, isEqual, cloneDeep, isNil } from 'lodash'
 
 import {
   DATASETS_PAGE,
@@ -341,14 +341,15 @@ export const handleFinishEdit = (
   })
 
   const changesData = cloneDeep(changes.data)
+  const currentFieldValue = get(formState, ['values', currentField], '')
 
   if (!isNil(formState?.initialValues[currentField])) {
-    if (isEqual(formState.initialValues[currentField], formState.values[currentField])) {
+    if (isEqual(formState.initialValues[currentField], currentFieldValue)) {
       delete changesData[currentField]
     } else {
       changesData[currentField] = {
         initialFieldValue: formState.initialValues[currentField],
-        currentFieldValue: formState.values[currentField]
+        currentFieldValue: currentFieldValue
       }
     }
   } else {

--- a/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
+++ b/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
@@ -150,7 +150,7 @@ const AddArtifactTagPopUp = ({
                     label="Artifact tag"
                     focused
                     required
-                    validationRules={getValidationRules('common.tag', [
+                    validationRules={getValidationRules('common.name', [
                       {
                         name: 'uniqueness',
                         label: 'Tag name must be unique',


### PR DESCRIPTION
- **Artifacts**: Unable to set empty "Version tag"
   Depends on: DRC version [v0.0.37](https://github.com/iguazio/dashboard-react-controls/releases/tag/v0.0.37)
   Jira: https://jira.iguazeng.com/browse/ML-3529

   After:
   ![image](https://user-images.githubusercontent.com/78905712/223452476-b8f51b75-2c8f-4984-b9bf-8eb8e96c7cf9.png)
   ![image](https://user-images.githubusercontent.com/78905712/223446171-9ba13c98-4ec3-40c0-b789-eb4051cac926.png)

  

