### PR TITLE
Fix [Monitor Jobs] 'No data to show' for dask job in 'Pods' tab

### DIFF
--- a/src/components/Details/DetailsTabsContent/DetailsTabsContent.js
+++ b/src/components/Details/DetailsTabsContent/DetailsTabsContent.js
@@ -39,6 +39,8 @@ import NoData from '../../../common/NoData/NoData'
 import DetailsStatistics from '../../DetailsStatistics/DetailsStatistics'
 import DetailsRequestedFeatures from '../../DetailsRequestedFeatures/DetailsRequestedFeatures'
 
+import {isJobKindDask, JOB_STEADY_STATES} from '../../Jobs/jobs.util'
+
 import {
   DETAILS_ANALYSIS_TAB,
   DETAILS_ARTIFACTS_TAB,
@@ -92,7 +94,21 @@ const DetailsTabsContent = ({
     case DETAILS_DRIFT_ANALYSIS_TAB:
       return <DetailsDriftAnalysis />
     case DETAILS_PODS_TAB:
-      return <DetailsPods />
+      return (
+        !isJobKindDask(selectedItem?.labels) && (
+          <DetailsPods
+            noDataMessage={
+              selectedItem.reason
+                ? selectedItem.reason
+                : `Pods not found, it is likely because Kubernetes removed these pods listing ${
+                    JOB_STEADY_STATES.includes(selectedItem.state.value)
+                      ? 'after their completion'
+                      : ''
+                  }`
+            }
+          />
+        )
+      )
     case DETAILS_FEATURES_ANALYSIS_TAB:
       return <DetailsFeatureAnalysis />
     case DETAILS_PREVIEW_TAB:

--- a/src/components/DetailsPods/DetailsPods.js
+++ b/src/components/DetailsPods/DetailsPods.js
@@ -18,6 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Prism from 'prismjs'
 import classnames from 'classnames'
@@ -30,7 +31,7 @@ import { generatePods } from './detailsPods.util'
 
 import './detailsPods.scss'
 
-const DetailsPods = ({ detailsStore }) => {
+const DetailsPods = ({ detailsStore, noDataMessage }) => {
   const [selectedPod, setSelectedPod] = useState(null)
   const [table, setTable] = useState([])
   const params = useParams()
@@ -105,10 +106,18 @@ const DetailsPods = ({ detailsStore }) => {
           </div>
         </>
       ) : (
-        <NoData />
+        <NoData message={noDataMessage} />
       )}
     </div>
   )
+}
+
+DetailsPods.defaultProps = {
+  noDataMessage: ''
+}
+
+DetailsPods.propTypes = {
+  noDataMessage: PropTypes.string
 }
 
 export default connect(({ detailsStore }) => ({

--- a/src/components/Jobs/MonitorJobs/monitorJobs.util.js
+++ b/src/components/Jobs/MonitorJobs/monitorJobs.util.js
@@ -30,10 +30,11 @@ import {
 } from '../../../constants'
 import {
   JOB_STEADY_STATES,
-  detailsMenu,
   getInfoHeaders,
   isJobAbortable,
-  limitedFunctionKinds
+  limitedFunctionKinds,
+  getJobsDetailsMenu,
+  isJobKindDask
 } from '../jobs.util'
 import jobsActions from '../../../actions/jobs'
 import detailsActions from '../../../actions/details'
@@ -54,7 +55,7 @@ export const generatePageData = (handleFetchJobLogs, selectedJob) => {
   return {
     page: JOBS_PAGE,
     details: {
-      menu: detailsMenu,
+      menu: getJobsDetailsMenu(selectedJob?.labels),
       type: JOBS_PAGE,
       infoHeaders: getInfoHeaders(!isNil(selectedJob.ui_run)),
       refreshLogs: handleFetchJobLogs,
@@ -85,10 +86,10 @@ export const generateActionsMenu = (
           label: 'Monitoring',
           tooltip: !jobs_dashboard_url
             ? 'Grafana service unavailable'
-            : job?.labels?.includes('kind: dask')
+            : isJobKindDask(job?.labels)
             ? 'Unavailable for Dask jobs'
             : '',
-          disabled: !jobs_dashboard_url || job?.labels?.includes('kind: dask'),
+          disabled: !jobs_dashboard_url || isJobKindDask(job?.labels),
           onClick: handleMonitoring
         },
         {

--- a/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
+++ b/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
@@ -162,9 +162,10 @@ const MonitorWorkflows = ({
         selectedFunction,
         handleFetchFunctionLogs,
         handleFetchJobLogs,
-        handleRemoveFunctionLogs
+        handleRemoveFunctionLogs,
+        selectedJob?.labels
       ),
-    [handleFetchJobLogs, handleFetchFunctionLogs, handleRemoveFunctionLogs, selectedFunction]
+    [handleFetchJobLogs, handleFetchFunctionLogs, handleRemoveFunctionLogs, selectedFunction, selectedJob]
   )
 
   const refreshJobs = useCallback(() => {

--- a/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
+++ b/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
@@ -27,7 +27,13 @@ import {
   PERIOD_FILTER,
   STATUS_FILTER
 } from '../../../constants'
-import { detailsMenu, getInfoHeaders, isJobAbortable, JOB_STEADY_STATES } from '../jobs.util'
+import {
+  getJobsDetailsMenu,
+  getInfoHeaders,
+  isJobAbortable,
+  JOB_STEADY_STATES,
+  isJobKindDask
+} from '../jobs.util'
 import jobsActions from '../../../actions/jobs'
 import functionsActions from '../../../actions/functions'
 import workflowsActions from '../../../actions/workflow'
@@ -58,13 +64,16 @@ export const generatePageData = (
   selectedFunction,
   handleFetchFunctionLogs,
   handleFetchJobLogs,
-  handleRemoveFunctionLogs
+  handleRemoveFunctionLogs,
+  selectedJobLabels
 ) => {
   return {
     page: JOBS_PAGE,
     details: {
       type: !isEveryObjectValueEmpty(selectedFunction) ? FUNCTIONS_PAGE : JOBS_PAGE,
-      menu: !isEveryObjectValueEmpty(selectedFunction) ? functionsDetailsMenu : detailsMenu,
+      menu: !isEveryObjectValueEmpty(selectedFunction)
+        ? functionsDetailsMenu
+        : getJobsDetailsMenu(selectedJobLabels),
       infoHeaders: !isEveryObjectValueEmpty(selectedFunction)
         ? functionsInfoHeaders
         : getInfoHeaders(false),
@@ -98,10 +107,10 @@ export const generateActionsMenu = (
           label: 'Monitoring',
           tooltip: !jobs_dashboard_url
             ? 'Grafana service unavailable'
-            : job?.labels?.includes('kind: dask')
+            : isJobKindDask(job?.labels)
             ? 'Unavailable for Dask jobs'
             : '',
-          disabled: !jobs_dashboard_url || job?.labels?.includes('kind: dask'),
+          disabled: !jobs_dashboard_url || isJobKindDask(job?.labels),
           onClick: handleMonitoring
         },
         {

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -63,32 +63,35 @@ export const actionsMenuHeader = 'Batch run'
 
 export const JOB_STEADY_STATES = ['completed', 'error', 'aborted']
 
-export const detailsMenu = [
-  {
-    label: 'overview',
-    id: 'overview'
-  },
-  {
-    label: 'inputs',
-    id: 'inputs'
-  },
-  {
-    label: 'artifacts',
-    id: 'artifacts'
-  },
-  {
-    label: 'results',
-    id: 'results'
-  },
-  {
-    label: 'logs',
-    id: 'logs'
-  },
-  {
-    label: 'pods',
-    id: 'pods'
-  }
-]
+export const getJobsDetailsMenu = (jobLabels = []) => {
+  return [
+    {
+      label: 'overview',
+      id: 'overview'
+    },
+    {
+      label: 'inputs',
+      id: 'inputs'
+    },
+    {
+      label: 'artifacts',
+      id: 'artifacts'
+    },
+    {
+      label: 'results',
+      id: 'results'
+    },
+    {
+      label: 'logs',
+      id: 'logs'
+    },
+    {
+      label: 'pods',
+      id: 'pods',
+      hidden: isJobKindDask(jobLabels)
+    }
+  ]
+}
 
 export const tabs = [
   { id: MONITOR_JOBS_TAB, label: 'Monitor Jobs' },
@@ -100,6 +103,11 @@ export const isJobAbortable = (job, abortableFunctionKinds) =>
   (abortableFunctionKinds ?? [])
     .map(kind => `kind: ${kind}`)
     .some(kindLabel => job?.labels?.includes(kindLabel))
+
+
+export const isJobKindDask = (jobLabels = []) => {
+  return jobLabels?.includes('kind: dask')
+}
 
 export const actionCreator = {
   fetchJobFunction: jobsActions.fetchJobFunction

--- a/src/elements/TableProducerCell/TableProducerCell.js
+++ b/src/elements/TableProducerCell/TableProducerCell.js
@@ -24,13 +24,14 @@ import PropTypes from 'prop-types'
 import ProducerTooltipTemplate from '../TooltipTemplate/ProducerTooltipTemplate'
 import { Tooltip } from 'igz-controls/components'
 
-import { DETAILS_OVERVIEW_TAB, MONITOR_JOBS_TAB } from '../../constants'
-import { detailsMenu } from '../../components/Jobs/jobs.util'
+import { getJobsDetailsMenu } from '../../components/Jobs/jobs.util'
 
-const TableProducerCell = ({ className, data }) => {
+import { DETAILS_OVERVIEW_TAB, MONITOR_JOBS_TAB } from '../../constants'
+
+const TableProducerCell = ({ data }) => {
   const [project, uid] = data.value.uri?.split('/') || []
   const { name } = data.value
-  const overviewTab = detailsMenu.find(tab => tab.id === DETAILS_OVERVIEW_TAB) || {}
+  const overviewTab = getJobsDetailsMenu().find(tab => tab.id === DETAILS_OVERVIEW_TAB) || {}
 
   return (
     <div className={`table-body__cell ${data.class}`}>
@@ -57,12 +58,7 @@ const TableProducerCell = ({ className, data }) => {
   )
 }
 
-TableProducerCell.defaultProps = {
-  className: ''
-}
-
 TableProducerCell.propTypes = {
-  className: PropTypes.string,
   data: PropTypes.shape({}).isRequired
 }
 

--- a/src/utils/parseJob.js
+++ b/src/utils/parseJob.js
@@ -63,6 +63,7 @@ export const parseJob = (job, tab) => {
         ...parseKeyValues(job.spec?.hyperparams || {})
       ],
       project: job.metadata.project,
+      reason: job.status?.reason ?? '',
       results: job.status?.results || {},
       resultsChips: parseKeyValues(job.status?.results || {}),
       startTime: new Date(job.status?.start_time),


### PR DESCRIPTION
- **Monitor Jobs**: 'No data to show' for dask job in 'Pods' tab
   - After job runs and then node goes down, the pod logs are gone - need clear error message

   Jira: https://jira.iguazeng.com/browse/ML-3078
   Jira: https://jira.iguazeng.com/browse/ML-3561

   After:
   ![image](https://user-images.githubusercontent.com/78905712/224053257-dd6df4b8-1f14-4825-be67-adaabfeba961.png)
   ![image](https://user-images.githubusercontent.com/78905712/224053276-127a2612-71e5-47b3-9abe-a7f4dd5782e7.png)
