### PR TITLE
Fix [Feature Set] Target path for partition parquet should be taken as Folder `1.3.x`

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
@@ -274,9 +274,11 @@ const FeatureSetsPanelTargetStore = ({
 
   const handleDiscardPathChange = kind => {
     const currentStoreType = kind === ONLINE ? NOSQL : kind
-    const currentKind = featureStore.newFeatureSet.spec.targets.find(el => el.kind === currentStoreType)
+    const currentKind = featureStore.newFeatureSet.spec.targets.find(
+      el => el.kind === currentStoreType
+    )
 
-    if (currentKind .path.length > 0) {
+    if (currentKind.path.length > 0) {
       setData(state => ({
         ...state,
         [kind]: {
@@ -564,57 +566,57 @@ const FeatureSetsPanelTargetStore = ({
   }
 
   const triggerPartitionCheckbox = (id, kind) => {
-    if (kind === EXTERNAL_OFFLINE || kind === PARQUET) {
-      setData(state => {
-        let path = state[kind].path
+    setData(state => {
+      let path = state[kind].path
 
-        if (
-          kind === PARQUET &&
-          !targetsPathEditData.parquet.isEditMode &&
-          !targetsPathEditData.parquet.isModified
-        ) {
-          path = generatePath(
-            frontendSpec.feature_store_data_prefixes,
-            project,
-            data[kind].kind,
-            featureStore.newFeatureSet.metadata.name,
-            data[kind].partitioned ? PARQUET : ''
-          )
-        }
-
-        return data[kind]?.partitioned
-          ? {
-              ...state,
-              [kind]: {
-                ...dataInitialState[kind],
-                path,
-                kind: PARQUET
-              }
-            }
-          : {
-              ...state,
-              [kind]: {
-                ...state[kind],
-                path,
-                partitioned: state[kind].partitioned === id ? '' : id,
-                key_bucketing_number: '',
-                partition_cols: '',
-                time_partitioning_granularity: 'hour'
-              }
-            }
-      })
-
-      if (data[kind].partitioned) {
-        setShowAdvanced(state => ({ ...state, [kind]: false }))
-        setPartitionRadioButtonsState(state => ({
-          ...state,
-          [kind]: 'districtKeys'
-        }))
-        setSelectedPartitionKind(state => ({
-          ...state,
-          [kind]: [...selectedPartitionKindInitialState[kind]]
-        }))
+      if (
+        kind === PARQUET &&
+        !targetsPathEditData.parquet.isEditMode &&
+        !targetsPathEditData.parquet.isModified
+      ) {
+        path = generatePath(
+          frontendSpec.feature_store_data_prefixes,
+          project,
+          data[kind].kind,
+          featureStore.newFeatureSet.metadata.name,
+          data[kind].partitioned ? PARQUET : ''
+        )
+      } else if (kind === PARQUET && targetsPathEditData.parquet.isModified) {
+        path = state[kind].partitioned ? `${path}.parquet` : path.replace(/\.[^.]+$/, '')
       }
+
+      return data[kind]?.partitioned
+        ? {
+            ...state,
+            [kind]: {
+              ...dataInitialState[kind],
+              path,
+              kind: PARQUET
+            }
+          }
+        : {
+            ...state,
+            [kind]: {
+              ...state[kind],
+              path,
+              partitioned: state[kind].partitioned === id ? '' : id,
+              key_bucketing_number: '',
+              partition_cols: '',
+              time_partitioning_granularity: 'hour'
+            }
+          }
+    })
+
+    if (data[kind].partitioned) {
+      setShowAdvanced(state => ({ ...state, [kind]: false }))
+      setPartitionRadioButtonsState(state => ({
+        ...state,
+        [kind]: 'districtKeys'
+      }))
+      setSelectedPartitionKind(state => ({
+        ...state,
+        [kind]: [...selectedPartitionKindInitialState[kind]]
+      }))
     }
 
     const targets = cloneDeep(featureStore.newFeatureSet.spec.targets).map(targetKind => {

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
@@ -34,7 +34,9 @@ import {
   externalOfflineKindOptions,
   ONLINE,
   PARQUET,
-  checkboxModels
+  checkboxModels,
+  isParquetPathValid,
+  getInvalidParquetPathMessage
 } from './featureSetsPanelTargetStore.util'
 
 import { ReactComponent as Online } from 'igz-controls/images/nosql.svg'
@@ -178,14 +180,18 @@ const FeatureSetsPanelTargetStoreView = ({
                       density="normal"
                       floatingLabel
                       focused={frontendSpecIsNotEmpty}
-                      invalid={!validation.isOfflineTargetPathValid}
+                      invalid={isParquetPathValid(
+                        validation.isOfflineTargetPathValid,
+                        data.parquet
+                      )}
+                      invalidText={getInvalidParquetPathMessage(data.parquet)}
                       label="Path"
-                      onChange={path =>
+                      onChange={path => {
                         setData(state => ({
                           ...state,
                           parquet: { ...state.parquet, path }
                         }))
-                      }
+                      }}
                       placeholder={
                         'v3io:///projects/{project}/FeatureStore/{name}/{run_id}/parquet/sets/{name}.parquet'
                       }
@@ -201,7 +207,14 @@ const FeatureSetsPanelTargetStoreView = ({
                       wrapperClassName="offline-path"
                     />
                     <div className="target-store__path-actions editable">
-                      <RoundedIcon onClick={handleOfflineKindPathChange} tooltipText="Apply">
+                      <RoundedIcon
+                        disabled={isParquetPathValid(
+                          validation.isOfflineTargetPathValid,
+                          data.parquet
+                        )}
+                        onClick={handleOfflineKindPathChange}
+                        tooltipText="Apply"
+                      >
                         <Checkmark className="target-store__apply-btn" />
                       </RoundedIcon>
                       <RoundedIcon
@@ -229,6 +242,7 @@ const FeatureSetsPanelTargetStoreView = ({
                   </>
                 )}
                 <CheckBox
+                  disabled={targetsPathEditData.parquet.isEditMode}
                   item={{ id: 'partitioned', label: 'Partition' }}
                   onChange={id => triggerPartitionCheckbox(id, PARQUET)}
                   selectedId={data.parquet.partitioned}

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/featureSetsPanelTargetStore.scss
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/featureSetsPanelTargetStore.scss
@@ -82,7 +82,7 @@
 
     .partition-fields {
       width: 100%;
-      margin-bottom: 10px;
+      margin: 10px 0;
 
       &__checkbox-container {
         display: flex;

--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/featureSetsPanelTargetStore.util.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/featureSetsPanelTargetStore.util.js
@@ -218,3 +218,19 @@ export const handlePathChange = (
     }))
   }
 }
+
+export const isParquetPathValid = (validation, parquet) => {
+  return (
+    !validation ||
+    Boolean(parquet.partitioned && /\.\w*\s*$/.test(parquet.path)) ||
+    Boolean(!parquet.partitioned && !/\.parquet\s*$|\.pq\s*$/.test(parquet.path))
+  )
+}
+
+export const getInvalidParquetPathMessage = parquet => {
+  return parquet.partitioned && /\.\w*\s*$/.test(parquet.path)
+    ? 'The partitioned Parquet target for storey engine must be a directory. (The directory name must not end in .parquet/.pq.)'
+    : !parquet.partitioned && !/\.parquet\s*$|\.pq\s*$/.test(parquet.path)
+    ? 'The Parquet target for storey engine file path must have a .parquet/.pq suffix.'
+    : 'This field is invalid.'
+}


### PR DESCRIPTION
- **Feature Sets Panel:** Target path for partition parquet should be taken as Folder
   Backported to `1.3.x` from #1673 
   Jira: https://jira.iguazeng.com/browse/ML-3619

   After:
   ![226307564-363f7f38-a4c3-488b-b03f-b9db7b3f0be7](https://user-images.githubusercontent.com/58301139/227912800-9b6b6d9e-3596-4d2f-b3ac-1ba67743f037.png)
   ![226298990-6aef9a00-a77c-4b63-9a3b-3b6c1040b8cd](https://user-images.githubusercontent.com/58301139/227912812-6ffb0265-208a-49c1-8600-349d5fbe58ef.png)


