### PR TITLE
Fix [Feature Set] Tooltip icon is overlapping the input

### DIFF
--- a/src/common/DatePicker/datePicker.scss
+++ b/src/common/DatePicker/datePicker.scss
@@ -7,7 +7,6 @@
 
   .date-picker__input-wrapper {
     position: relative;
-    margin-right: 22px;
 
     .date-picker__input {
       &_empty {

--- a/src/common/TimePicker/timePicker.scss
+++ b/src/common/TimePicker/timePicker.scss
@@ -7,5 +7,11 @@
     &__label {
       text-transform: none;
     }
+
+    &__wrapper {
+      input {
+        padding: 0 16px;
+      }
+    }
   }
 }


### PR DESCRIPTION
- **Feature Set**: Tooltip icon is overlapping the input
   Jira: https://jira.iguazeng.com/browse/ML-3634

   Before:
   ![image](https://user-images.githubusercontent.com/63646693/227972471-b908eae6-86df-4083-aad6-afd5796df389.png)

   After:
   ![Screenshot from 2023-03-21 13-24-04](https://user-images.githubusercontent.com/109525572/227967264-1d43a72f-46ae-44af-9179-03297e5799e3.png)

   Added padding to the TimePicker component:
   ![Screenshot from 2023-03-21 13-20-26](https://user-images.githubusercontent.com/109525572/227967469-6a3cf147-50b9-460d-bb0a-a443d091abe3.png)
