### PR TITLE
Impl [Models] Adjust the Average Latency calculation in model endpoints tab `1.3.x`

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -374,7 +374,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
     ? `store://functions/${artifact.spec.function_uri}`
     : ''
   const { key: functionName } = parseUri(functionUri)
-  const averageLatency = artifact.status?.metrics?.latency_avg_1h?.values?.[0]?.[1]
+  const averageLatency = artifact.status?.metrics?.real_time?.latency_avg_1h?.[0]?.[1]
 
   return {
     data: {


### PR DESCRIPTION
- **Models**: Adjust the Average Latency calculation in model endpoints tab
   Backported to `1.3.x` from #1689 
   Jira: [ML-3278](https://jira.iguazeng.com/browse/ML-3278)
   
   Before:
   <img width="1496" alt="Screen Shot 2023-01-19 at 15 10 48" src="https://user-images.githubusercontent.com/63646693/213451292-ba458312-1d3f-4f3b-a904-1957661ec973.png">

   After:
   <img width="1499" alt="Screen Shot 2023-01-19 at 15 10 31" src="https://user-images.githubusercontent.com/63646693/213451239-1824747b-8980-4aa6-afcf-364e14e48989.png">

   