### PR TITLE
Fix [Details Preview] model-spec.yaml should not be shown && Extra data list should be collapsed for all screens

### DIFF
--- a/src/common/Accordion/Accordion.js
+++ b/src/common/Accordion/Accordion.js
@@ -99,6 +99,7 @@ const Accordion = ({
 Accordion.defaultProps = {
   alwaysOpened: false,
   closeOnBlur: null,
+  icon: null,
   openByDefault: false
 }
 

--- a/src/components/ArtifactsPreview/ArtifactsPreview.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreview.js
@@ -55,8 +55,8 @@ const ArtifactsPreview = ({ className, extraData, noData, preview, showExtraData
               key={index}
               preview={extraDataItem}
               setShowErrorBody={setShowErrorBody}
+              showAccordion
               showErrorBody={showErrorBody}
-              withAccordion
             />
           ))}
         </div>

--- a/src/components/ArtifactsPreview/ArtifactsPreview.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreview.js
@@ -25,11 +25,11 @@ import ArtifactsPreviewView from './ArtifactsPreviewView'
 import Loader from '../../common/Loader/Loader'
 import NoData from '../../common/NoData/NoData'
 
-const ArtifactsPreview = ({ className, extraData, noData, preview }) => {
+const ArtifactsPreview = ({ className, extraData, noData, preview, showExtraDataLoader }) => {
   const [showErrorBody, setShowErrorBody] = useState(false)
   const artifactsPreviewClasses = classnames('artifact-preview', className)
 
-  return preview.length === 0 && !noData ? (
+  return !noData && (preview.length === 0 || showExtraDataLoader) ? (
     <div className="loader-container">
       <Loader />
     </div>
@@ -56,6 +56,7 @@ const ArtifactsPreview = ({ className, extraData, noData, preview }) => {
               preview={extraDataItem}
               setShowErrorBody={setShowErrorBody}
               showErrorBody={showErrorBody}
+              withAccordion
             />
           ))}
         </div>
@@ -66,7 +67,8 @@ const ArtifactsPreview = ({ className, extraData, noData, preview }) => {
 
 ArtifactsPreview.defaultProps = {
   className: '',
-  extraData: []
+  extraData: [],
+  showExtraDataLoader: false
 }
 
 ArtifactsPreview.propTypes = {
@@ -86,7 +88,8 @@ ArtifactsPreview.propTypes = {
         content: PropTypes.any.isRequired
       })
     })
-  ).isRequired
+  ).isRequired,
+  showExtraDataLoader: PropTypes.bool
 }
 
 export default ArtifactsPreview

--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -25,6 +25,7 @@ import Accordion from '../../common/Accordion/Accordion'
 import DetailsResults from '../DetailsResults/DetailsResults'
 import PreviewError from './PreviewError/PreviewError'
 import { Tooltip, TextTooltipTemplate } from 'igz-controls/components'
+
 import { ReactComponent as Arrow } from 'igz-controls/images/arrow.svg'
 
 import { ARTIFACT_PREVIEW_TABLE_ROW_LIMIT } from '../../constants'
@@ -35,8 +36,8 @@ const ArtifactsPreviewView = ({
   className,
   preview,
   setShowErrorBody,
-  showErrorBody,
-  withAccordion
+  showAccordion,
+  showErrorBody
 }) => {
   const content = useMemo(
     () =>
@@ -49,10 +50,10 @@ const ArtifactsPreviewView = ({
   return (
     !preview?.hidden && (
       <Accordion
-        icon={withAccordion ? <Arrow /> : <></>}
+        icon={showAccordion ? <Arrow /> : null}
         iconClassName="expand-icon"
-        alwaysOpened={!withAccordion}
-        openByDefault={!withAccordion}
+        alwaysOpened={!showAccordion}
+        openByDefault={!showAccordion}
       >
         <div className="artifact-preview__wrapper">
           <div className="artifact-preview__header">
@@ -122,7 +123,7 @@ const ArtifactsPreviewView = ({
                 {preview?.type === 'html' && (
                   <iframe srcDoc={preview?.data.content} frameBorder="0" title="Preview" />
                 )}
-                {preview?.type === 'json' && !preview?.hidden && (
+                {preview?.type === 'json' && (
                   <div className="json">
                     <pre className="json-content">
                       <code
@@ -174,15 +175,15 @@ const ArtifactsPreviewView = ({
 }
 
 ArtifactsPreviewView.defaultProps = {
-  withAccordion: false
+  showAccordion: false
 }
 
 ArtifactsPreviewView.propTypes = {
   className: PropTypes.string.isRequired,
   preview: PropTypes.shape({}).isRequired,
   setShowErrorBody: PropTypes.func.isRequired,
-  showErrorBody: PropTypes.bool.isRequired,
-  withAccordion: PropTypes.bool
+  showAccordion: PropTypes.bool,
+  showErrorBody: PropTypes.bool.isRequired
 }
 
 export default ArtifactsPreviewView

--- a/src/components/ArtifactsPreview/ArtifactsPreviewView.js
+++ b/src/components/ArtifactsPreview/ArtifactsPreviewView.js
@@ -21,15 +21,23 @@ import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import Prism from 'prismjs'
 
+import Accordion from '../../common/Accordion/Accordion'
 import DetailsResults from '../DetailsResults/DetailsResults'
 import PreviewError from './PreviewError/PreviewError'
 import { Tooltip, TextTooltipTemplate } from 'igz-controls/components'
+import { ReactComponent as Arrow } from 'igz-controls/images/arrow.svg'
 
 import { ARTIFACT_PREVIEW_TABLE_ROW_LIMIT } from '../../constants'
 
 import './artifactsPreview.scss'
 
-const ArtifactsPreviewView = ({ className, preview, setShowErrorBody, showErrorBody }) => {
+const ArtifactsPreviewView = ({
+  className,
+  preview,
+  setShowErrorBody,
+  showErrorBody,
+  withAccordion
+}) => {
   const content = useMemo(
     () =>
       preview.data && preview.data.content
@@ -39,105 +47,142 @@ const ArtifactsPreviewView = ({ className, preview, setShowErrorBody, showErrorB
   )
 
   return (
-    <div className={className}>
-      {preview.header && <h2 className="artifact-preview__header">{preview.header}</h2>}
-      {preview?.type === 'error' ? (
-        <PreviewError
-          error={preview.error}
-          setShowErrorBody={setShowErrorBody}
-          showErrorBody={showErrorBody}
-        />
-      ) : (
-        <>
-          {preview?.type === 'table-results' && (
-            <div className="artifact-preview__table">
-              <DetailsResults job={preview} excludeSortBy="state" defaultDirection="desc" />
-            </div>
-          )}
-          {preview?.type === 'table' && (
-            <div className="artifact-preview__table">
-              <div className="artifact-preview__table-row artifact-preview__table-header">
-                {preview.data.headers.map((header, index) => {
-                  return (
-                    <div key={`${header}${index}`} className="artifact-preview__table-content">
-                      <Tooltip template={<TextTooltipTemplate text={header} />}>{header}</Tooltip>
-                    </div>
-                  )
-                })}
-              </div>
-              <div className="artifact-preview__table-body">
-                {content.map((contentItem, index) => (
-                  <div key={index} className="artifact-preview__table-row">
-                    {Array.isArray(contentItem) ? (
-                      contentItem.map(value => (
-                        <Tooltip
-                          className="artifact-preview__table-content"
-                          key={`${value}${Math.random()}`}
-                          template={<TextTooltipTemplate text={`${value}`} />}
-                        >
-                          {typeof value === 'object' && value !== null
-                            ? JSON.stringify(value)
-                            : String(value)}
-                        </Tooltip>
-                      ))
-                    ) : (
-                      <Tooltip
-                        className="artifact-preview__table-content"
-                        template={<TextTooltipTemplate text={contentItem} />}
-                      >
-                        {contentItem}
-                      </Tooltip>
-                    )}
+    !preview?.hidden && (
+      <Accordion
+        icon={withAccordion ? <Arrow /> : <></>}
+        iconClassName="expand-icon"
+        alwaysOpened={!withAccordion}
+        openByDefault={!withAccordion}
+      >
+        <div className="artifact-preview__wrapper">
+          <div className="artifact-preview__header">
+            <h5 className="artifact-preview__header-title">
+              {preview.header && preview.header}
+            </h5>
+          </div>
+          <div className={className}>
+            {preview?.type === 'error' ? (
+              <PreviewError
+                error={preview.error}
+                setShowErrorBody={setShowErrorBody}
+                showErrorBody={showErrorBody}
+              />
+            ) : (
+              <>
+                {preview?.type === 'table-results' && (
+                  <div className="artifact-preview__table">
+                    <DetailsResults job={preview} excludeSortBy="state" defaultDirection="desc" />
                   </div>
-                ))}
-              </div>
-            </div>
-          )}
-          {preview?.type === 'text' && <div>{preview?.data.content}</div>}
-          {preview?.type === 'html' && (
-            <iframe srcDoc={preview?.data.content} frameBorder="0" title="Preview" />
-          )}
-          {preview?.type === 'json' && !preview?.hidden && (
-            <div className="json">
-              <pre className="json-content">
-                <code
-                  dangerouslySetInnerHTML={{
-                    __html: Prism.highlight(preview?.data.content, Prism.languages.json, 'json')
-                  }}
-                />
-              </pre>
-            </div>
-          )}
-          {preview?.type === 'yaml' && (
-            <div className="json">
-              <pre className="json-content">
-                <code
-                  dangerouslySetInnerHTML={{
-                    __html: Prism.highlight(preview?.data.content, Prism.languages.yaml, 'yaml')
-                  }}
-                />
-              </pre>
-            </div>
-          )}
-          {preview?.type === 'image' && (
-            <img className="artifact-preview__image" src={preview?.data?.content} alt="preview" />
-          )}
-          {preview?.type === 'unknown' && (
-            <div className="artifact-preview__no-data">
-              {preview?.data?.content ? preview?.data.content : 'No preview'}
-            </div>
-          )}
-        </>
-      )}
-    </div>
+                )}
+                {preview?.type === 'table' && (
+                  <div className="artifact-preview__table">
+                    <div className="artifact-preview__table-row artifact-preview__table-header">
+                      {preview.data.headers.map((header, index) => {
+                        return (
+                          <div
+                            key={`${header}${index}`}
+                            className="artifact-preview__table-content"
+                          >
+                            <Tooltip template={<TextTooltipTemplate text={header} />}>
+                              {header}
+                            </Tooltip>
+                          </div>
+                        )
+                      })}
+                    </div>
+                    <div className="artifact-preview__table-body">
+                      {content.map((contentItem, index) => (
+                        <div key={index} className="artifact-preview__table-row">
+                          {Array.isArray(contentItem) ? (
+                            contentItem.map(value => (
+                              <Tooltip
+                                className="artifact-preview__table-content"
+                                key={`${value}${Math.random()}`}
+                                template={<TextTooltipTemplate text={`${value}`} />}
+                              >
+                                {typeof value === 'object' && value !== null
+                                  ? JSON.stringify(value)
+                                  : String(value)}
+                              </Tooltip>
+                            ))
+                          ) : (
+                            <Tooltip
+                              className="artifact-preview__table-content"
+                              template={<TextTooltipTemplate text={contentItem} />}
+                            >
+                              {contentItem}
+                            </Tooltip>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {preview?.type === 'text' && <div>{preview?.data.content}</div>}
+                {preview?.type === 'html' && (
+                  <iframe srcDoc={preview?.data.content} frameBorder="0" title="Preview" />
+                )}
+                {preview?.type === 'json' && !preview?.hidden && (
+                  <div className="json">
+                    <pre className="json-content">
+                      <code
+                        dangerouslySetInnerHTML={{
+                          __html: Prism.highlight(
+                            preview?.data.content,
+                            Prism.languages.json,
+                            'json'
+                          )
+                        }}
+                      />
+                    </pre>
+                  </div>
+                )}
+                {preview?.type === 'yaml' && (
+                  <div className="json">
+                    <pre className="json-content">
+                      <code
+                        dangerouslySetInnerHTML={{
+                          __html: Prism.highlight(
+                            preview?.data.content,
+                            Prism.languages.yaml,
+                            'yaml'
+                          )
+                        }}
+                      />
+                    </pre>
+                  </div>
+                )}
+                {preview?.type === 'image' && (
+                  <img
+                    className="artifact-preview__image"
+                    src={preview?.data?.content}
+                    alt="preview"
+                  />
+                )}
+                {preview?.type === 'unknown' && (
+                  <div className="artifact-preview__no-data">
+                    {preview?.data?.content ? preview?.data.content : 'No preview'}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </Accordion>
+    )
   )
+}
+
+ArtifactsPreviewView.defaultProps = {
+  withAccordion: false
 }
 
 ArtifactsPreviewView.propTypes = {
   className: PropTypes.string.isRequired,
   preview: PropTypes.shape({}).isRequired,
   setShowErrorBody: PropTypes.func.isRequired,
-  showErrorBody: PropTypes.bool.isRequired
+  showErrorBody: PropTypes.bool.isRequired,
+  withAccordion: PropTypes.bool
 }
 
 export default ArtifactsPreviewView

--- a/src/components/ArtifactsPreview/artifactsPreview.scss
+++ b/src/components/ArtifactsPreview/artifactsPreview.scss
@@ -1,10 +1,18 @@
 @import '~igz-controls/scss/colors';
 @import '~igz-controls/scss/borders';
 
+.accordion__container {
+  height: 40px;
+
+  &.open {
+    height: auto;
+  }
+}
+
 .artifact {
   &-extra-data {
     &__header {
-      margin: 15px 0;
+      margin: 15px;
     }
   }
 
@@ -19,7 +27,19 @@
     }
 
     &__header {
-      margin: 0 0 15px 0;
+      margin-bottom: 30px;
+      padding-top: 3px;
+      padding-left: 45px;
+
+      &-title {
+        display: flex;
+        align-items: center;
+        margin: 0 0 15px 0;
+        color: $topaz;
+        font-weight: 500;
+        font-size: 20px;
+        line-height: 23px;
+      }
     }
 
     .json-content {
@@ -108,6 +128,12 @@
       min-height: 560px;
     }
   }
+}
+
+.expand-icon {
+  position: absolute;
+  top: -3px;
+  left: 0;
 }
 
 .loader-container {

--- a/src/components/DetailsArtifacts/detailsArtifacts.scss
+++ b/src/components/DetailsArtifacts/detailsArtifacts.scss
@@ -48,8 +48,4 @@
     width: 100%;
     cursor: pointer;
   }
-
-  .accordion__container.open {
-    box-shadow: $previewBoxShadow;
-  }
 }

--- a/src/components/DetailsInputs/DetailsInputs.js
+++ b/src/components/DetailsInputs/DetailsInputs.js
@@ -95,7 +95,7 @@ const DetailsInputs = ({ inputs }) => {
                 key,
                 value,
                 ui: {
-                  artifactLink: generateArtifactLink(artifacts[0]),
+                  artifactLink: artifacts[0] ? generateArtifactLink(artifacts[0]) : '',
                   isPreviewable: artifacts.length > 0
                 }
               }

--- a/src/components/DetailsInputs/DetailsInputs.js
+++ b/src/components/DetailsInputs/DetailsInputs.js
@@ -64,7 +64,7 @@ const DetailsInputs = ({ inputs }) => {
         }/${TAG_FILTER_LATEST}${artifact.iter ? `/${artifact.iter}` : ''}/overview`
       }
 
-      return artifactLinks[artifact.kind ?? 'files']
+      return artifact ? artifactLinks[artifact.kind ?? 'files'] : ''
     },
     [params.projectName]
   )
@@ -95,7 +95,7 @@ const DetailsInputs = ({ inputs }) => {
                 key,
                 value,
                 ui: {
-                  artifactLink: artifacts[0] ? generateArtifactLink(artifacts[0]) : '',
+                  artifactLink: generateArtifactLink(artifacts[0]),
                   isPreviewable: artifacts.length > 0
                 }
               }

--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -97,6 +97,7 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
         extraData={extraData}
         noData={noData}
         preview={preview}
+        showExtraDataLoader={extraData.length !== (artifact.extra_data ?? []).length}
       />
     </div>
   )

--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -97,7 +97,7 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
         extraData={extraData}
         noData={noData}
         preview={preview}
-        showExtraDataLoader={extraData.length !== (artifact.extra_data ?? []).length}
+        showExtraDataLoader={artifact.extra_data && extraData.length !== artifact.extra_data.length}
       />
     </div>
   )

--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -109,7 +109,7 @@ const PreviewModal = ({ item }) => {
               extraData={extraData}
               noData={noData}
               preview={preview}
-              showExtraDataLoader={extraData.length !== (item.extra_data ?? []).length}
+              showExtraDataLoader={item.extra_data && extraData.length !== item.extra_data.length}
             />
           </div>
         </div>

--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -105,7 +105,12 @@ const PreviewModal = ({ item }) => {
             </div>
           </div>
           <div className="item-artifacts__preview">
-            <ArtifactsPreview extraData={extraData} noData={noData} preview={preview} />
+            <ArtifactsPreview
+              extraData={extraData}
+              noData={noData}
+              preview={preview}
+              showExtraDataLoader={extraData.length !== (item.extra_data ?? []).length}
+            />
           </div>
         </div>
       </div>

--- a/src/hooks/yaml.hook.js
+++ b/src/hooks/yaml.hook.js
@@ -19,7 +19,7 @@ such restriction.
 */
 import yaml from 'js-yaml'
 import { useCallback, useState } from 'react'
-import { set, cloneDeep } from 'lodash'
+import { set, cloneDeep, omit } from 'lodash'
 
 export const useYaml = initialState => {
   const [yamlContent, setYamlContent] = useState(initialState)
@@ -33,17 +33,7 @@ export const useYaml = initialState => {
 
     if (json) {
       // removes "model_spec.yaml" from "spec.extra_data"
-      set(
-        json,
-        'spec.extra_data',
-        Object.entries(json.spec?.extra_data ?? {}).reduce((result, [key, value]) => {
-          if (key !== 'model_spec.yaml') {
-            result[key] = value
-          }
-
-          return result
-        }, {})
-      )
+      set(json, 'spec.extra_data', omit(json.spec.extra_data, 'model_spec.yaml'))
     }
 
     setYamlContent(yaml.dump(json, { lineWidth: -1 }))

--- a/src/hooks/yaml.hook.js
+++ b/src/hooks/yaml.hook.js
@@ -19,6 +19,7 @@ such restriction.
 */
 import yaml from 'js-yaml'
 import { useCallback, useState } from 'react'
+import { set, cloneDeep } from 'lodash'
 
 export const useYaml = initialState => {
   const [yamlContent, setYamlContent] = useState(initialState)
@@ -28,7 +29,22 @@ export const useYaml = initialState => {
       return setYamlContent('')
     }
 
-    const json = item.ui?.originalContent ?? {}
+    const json = cloneDeep(item.ui?.originalContent) ?? {}
+
+    if (json) {
+      // removes "model_spec.yaml" from "spec.extra_data"
+      set(
+        json,
+        'spec.extra_data',
+        Object.entries(json.spec?.extra_data ?? {}).reduce((result, [key, value]) => {
+          if (key !== 'model_spec.yaml') {
+            result[key] = value
+          }
+
+          return result
+        }, {})
+      )
+    }
 
     setYamlContent(yaml.dump(json, { lineWidth: -1 }))
   }, [])

--- a/src/utils/generateArtifactPreviewData.js
+++ b/src/utils/generateArtifactPreviewData.js
@@ -21,7 +21,7 @@ export const generateArtifactPreviewData = extraData => {
   const previewItems = []
 
   Object.entries(extraData).forEach(([key, value]) => {
-    if (value.match(/html|json|yaml|png|jpg|jpeg|gif|csv/)) {
+    if (value.match(/html|json|yaml|png|jpg|jpeg|gif|csv/) && key !== 'model_spec.yaml') {
       previewItems.push({
         path: value,
         header: key


### PR DESCRIPTION
- **Details Preview**: 
   - model-spec.yaml should not be shown
   - Extra data list should be collapsed for all screens
   
   Jira: https://jira.iguazeng.com/browse/ML-3751
   Jira: https://jira.iguazeng.com/browse/ML-3752

   After:
   ![image](https://github.com/mlrun/ui/assets/78905712/4dd36fe9-c9d2-4926-ae46-f8b96e7bbebe)
