### PR TITLE
Fix [Job Wizard] Batch run, hubs can't select card when click near 'chips'

### DIFF
--- a/src/elements/FunctionCardTemplate/FunctionCardTemplate.js
+++ b/src/elements/FunctionCardTemplate/FunctionCardTemplate.js
@@ -63,6 +63,7 @@ const FunctionCardTemplate = ({
       {functionData.labelsName && get(formState?.values, functionData.labelsName, null) && (
         <FormChipCell
           chipOptions={getChipOptions('metrics')}
+          className="job-card-template__chips"
           formState={formState}
           initialValues={formState.initialValues}
           name={functionData.labelsName}

--- a/src/elements/FunctionCardTemplate/functionCardTemplate.scss
+++ b/src/elements/FunctionCardTemplate/functionCardTemplate.scss
@@ -74,6 +74,10 @@
     padding: 10px 0;
   }
 
+  &__chips {
+    width: fit-content;
+  }
+
   &.dense {
     min-height: 110px;
   }


### PR DESCRIPTION
- **Job Wizard**: Batch run, hubs can't select card when click near 'chips'
   Depends On: https://github.com/iguazio/dashboard-react-controls/pull/130
   **Jira**: https://jira.iguazeng.com/browse/ML-3843