### PR TITLE
Fix [Feature store] "Partition" checkbox is missing for parquet "Exte…

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
@@ -353,6 +353,13 @@ const FeatureSetsPanelTargetStoreView = ({
                   handleUrlOnFocus={handleExternalOfflineKindPathOnFocus}
                   handleUrlSelectOnChange={handleUrlSelectOnChange}
                 />
+                {data.externalOffline.kind === PARQUET && (
+                  <CheckBox
+                    item={{ id: 'partitioned', label: 'Partition' }}
+                    onChange={id => triggerPartitionCheckbox(id, EXTERNAL_OFFLINE)}
+                    selectedId={data.externalOffline.partitioned}
+                  />
+                )}
               </div>
               {data.externalOffline.partitioned && (
                 <div className="partition-fields">


### PR DESCRIPTION
- **Feature store**: "Partition" checkbox is missing for parquet "External offline" in "Create Feature Set" wizard
   Jira: [ML-3967](https://jira.iguazeng.com/browse/ML-3967)