### PR TITLE
Fix [UI] The old Version tag should not be deleted after click on 'Edit' button

### DIFF
--- a/src/components/ModelsPage/Models/ModelsView.js
+++ b/src/components/ModelsPage/Models/ModelsView.js
@@ -122,7 +122,9 @@ const ModelsView = React.forwardRef(
             {viewMode === FULL_VIEW_MODE && (
               <Details
                 actionsMenu={actionsMenu}
+                applyDetailsChanges={applyDetailsChanges}
                 detailsMenu={pageData.details.menu}
+                formInitialValues={detailsFormInitialValues}
                 handleRefresh={handleRefresh}
                 isDetailsScreen
                 pageData={pageData}


### PR DESCRIPTION
- **UI**: The old Version tag should not be deleted after click on 'Edit' button
   Jira: https://jira.iguazeng.com/browse/ML-4004