### PR TITLE
Fix [UI] models/datasets - preview icon tooltip says "Artifact Preview"

### DIFF
--- a/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
+++ b/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
@@ -26,6 +26,7 @@ import { createForm } from 'final-form'
 
 import { Button, FormInput, Modal } from 'igz-controls/components'
 
+import { DATASET_TYPE, MODEL_TYPE } from '../../constants'
 import { setNotification } from '../../reducers/notificationReducer'
 import { SECONDARY_BUTTON, TERTIARY_BUTTON } from 'igz-controls/constants'
 import { getValidationRules } from 'igz-controls/utils/validation.util'
@@ -147,7 +148,13 @@ const AddArtifactTagPopUp = ({
                 <div className="form-col-1">
                   <FormInput
                     name="artifactTag"
-                    label="Artifact tag"
+                    label={`${
+                      artifact.kind === MODEL_TYPE
+                        ? 'Model'
+                        : artifact.kind === DATASET_TYPE
+                        ? 'Dataset'
+                        : 'Artifact'
+                    } tag`}
                     focused
                     required
                     validationRules={getValidationRules('common.name', [

--- a/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
+++ b/src/elements/AddArtifactTagPopUp/AddArtifactTagPopUp.js
@@ -150,11 +150,11 @@ const AddArtifactTagPopUp = ({
                     name="artifactTag"
                     label={`${
                       artifact.kind === MODEL_TYPE
-                        ? 'Model'
+                        ? 'Model tag'
                         : artifact.kind === DATASET_TYPE
-                        ? 'Dataset'
-                        : 'Artifact'
-                    } tag`}
+                        ? 'Dataset tag'
+                        : 'Artifact tag'
+                    }`}
                     focused
                     required
                     validationRules={getValidationRules('common.name', [

--- a/src/elements/TableCell/TableCell.js
+++ b/src/elements/TableCell/TableCell.js
@@ -29,7 +29,7 @@ import TableProducerCell from '../TableProducerCell/TableProducerCell'
 import TableTypeCell from '../TableTypeCell/TableTypeCell'
 import { Tooltip, TextTooltipTemplate, RoundedIcon } from 'igz-controls/components'
 
-import { BUTTON_COPY_URI_CELL_TYPE } from '../../constants'
+import { BUTTON_COPY_URI_CELL_TYPE, DATASET_TYPE, MODEL_TYPE } from '../../constants'
 import { getChipOptions } from '../../utils/getChipOptions'
 import { showArtifactsPreview } from '../../reducers/artifactsReducer'
 import { truncateUid } from '../../utils'
@@ -116,7 +116,15 @@ const TableCell = ({
     return (
       <td className={`table-body__cell ${data.class} ${className}`}>
         <RoundedIcon
-          tooltipText={data.disabled ? '' : 'Artifact Preview'}
+          tooltipText={
+            data.disabled
+              ? ''
+              : item.kind === MODEL_TYPE
+              ? 'Model Preview'
+              : item.kind === DATASET_TYPE
+              ? 'Dataset Preview'
+              : 'Artifact Preview'
+          }
           disabled={data.disabled}
           onClick={() => {
             dispatch(


### PR DESCRIPTION
- **UI**: models/datasets - preview icon tooltip says "Artifact Preview"
   Related to #1834 
  Jira: [ML-4305](https://jira.iguazeng.com/browse/ML-4305)
  
  After:
  <img width="243" alt="Screenshot 2023-08-01 at 16 07 59" src="https://github.com/mlrun/ui/assets/63646693/45da6b1d-4b72-477f-8b18-74e693491669">
   <img width="519" alt="Screenshot 2023-08-01 at 16 08 17" src="https://github.com/mlrun/ui/assets/63646693/6d62f256-f621-43e4-84be-d77f6638fa3f">

  