### PR TITLE
Fix [Batch run] No validation for a negative CPU value during setting the resources in Batch Run

### DIFF
--- a/src/elements/FormResourcesUnits/FormResourcesUnits.js
+++ b/src/elements/FormResourcesUnits/FormResourcesUnits.js
@@ -168,8 +168,8 @@ const FormResourcesUnits = ({ formState }) => {
                 name="resources.currentRequest.cpu"
                 label="Request"
                 type="number"
-                min={selectedRequestUnit?.minValue}
-                step={selectedRequestUnit?.step}
+                min={selectedRequestUnit?.minValue ?? 1}
+                step={selectedRequestUnit?.step ?? 1}
                 validator={validateCpu}
                 required
                 invalidText={`Request must be less than or equal to Limit and not be less than ${selectedRequestUnit?.minValue}`}
@@ -186,8 +186,8 @@ const FormResourcesUnits = ({ formState }) => {
                 name="resources.currentLimits.cpu"
                 label="Limit"
                 type="number"
-                min={selectedLimitUnit?.minValue}
-                step={selectedLimitUnit?.step}
+                min={selectedLimitUnit?.minValue ?? 1}
+                step={selectedLimitUnit?.step ?? 1}
                 validator={validateCpu}
                 required
                 invalidText={`Limit must be bigger than or equal to Request and not be less than ${selectedLimitUnit?.minValue}`}


### PR DESCRIPTION
- **Batch run**: No validation for a negative CPU value during setting the resources in Batch Run
   Depends on: https://github.com/iguazio/dashboard-react-controls/pull/151
   Jira: [ML-4308](https://jira.iguazeng.com/browse/ML-4308)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/3a0f57b6-06de-4f1f-b65d-9d27d0b26ba6)
   
   After:
   <img width="412" alt="Screenshot 2023-08-06 at 11 39 01" src="https://github.com/mlrun/ui/assets/63646693/97c575d7-3977-48a7-b98b-9a75464eb95f">
