### PR TITLE
Fix [Batch run] incorrect "Add a node" button name in "Node selection" section of batch run

### DIFF
--- a/src/components/JobWizard/JobWizardSteps/JobWizardResources/JobWizardResources.js
+++ b/src/components/JobWizard/JobWizardSteps/JobWizardResources/JobWizardResources.js
@@ -67,7 +67,7 @@ const JobWizardResources = ({ formState, frontendSpec }) => {
         <FormKeyValueTable
           keyHeader="Key"
           keyLabel="Key"
-          addNewItemLabel="Add a node"
+          addNewItemLabel="Add node selector"
           fieldsPath="resources.nodeSelectorTable"
           formState={formState}
         />


### PR DESCRIPTION
- **Batch run**: incorrect "Add a node" button name in "Node selection" section of batch run
   Jira: [ML-4342](https://jira.iguazeng.com/browse/ML-4342)