### PR TITLE
Fix [Batch Run] The Container and Resource Path fields for V3IO volume should not be mandatory

### DIFF
--- a/src/elements/FormVolumesTable/formVolumesTable.util.js
+++ b/src/elements/FormVolumesTable/formVolumesTable.util.js
@@ -122,7 +122,6 @@ export const generateVolumeInputsData = (selectedItem, fields, editingItem) => {
           inputHidden: selectedType !== V3IO_VOLUME_TYPE,
           label: 'Container',
           tip: 'The name of the data container that contains the data',
-          required: true,
           textHidden: true,
           type: 'input'
         }
@@ -142,7 +141,6 @@ export const generateVolumeInputsData = (selectedItem, fields, editingItem) => {
           inputHidden: selectedType !== V3IO_VOLUME_TYPE,
           label: 'Resource Path',
           tip: 'A relative directory path within the data container',
-          required: true,
           textHidden: true,
           type: 'input'
         }


### PR DESCRIPTION
- **Batch Run**: The Container and Resource Path fields for V3IO volume should not be mandatory
   Jira: [ML-4355](https://jira.iguazeng.com/browse/ML-4355)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/c115505c-d6f0-4dec-b890-7d025ce822f3)

   After:
   <img width="1221" alt="Screenshot 2023-08-09 at 10 42 12" src="https://github.com/mlrun/ui/assets/63646693/833be42e-0545-4540-b142-e7ccde605cbc">
