### PR TITLE
Fix [Jobs] UI does not show boolean result in "Monitor Jobs" -> "Results"

### DIFF
--- a/src/components/DetailsResults/DetailsResults.js
+++ b/src/components/DetailsResults/DetailsResults.js
@@ -168,7 +168,7 @@ const DetailsResults = ({ allowSortBy, defaultSortBy, defaultDirection, excludeS
                       className="data-ellipsis"
                       template={<TextTooltipTemplate text={resultValue} />}
                     >
-                      {resultValue.toString()}
+                      {String(resultValue ?? '')}
                     </Tooltip>
                   </td>
                 </tr>

--- a/src/components/DetailsResults/DetailsResults.js
+++ b/src/components/DetailsResults/DetailsResults.js
@@ -168,7 +168,7 @@ const DetailsResults = ({ allowSortBy, defaultSortBy, defaultDirection, excludeS
                       className="data-ellipsis"
                       template={<TextTooltipTemplate text={resultValue} />}
                     >
-                      {resultValue}
+                      {resultValue.toString()}
                     </Tooltip>
                   </td>
                 </tr>


### PR DESCRIPTION
- **Jobs**: UI does not show boolean result in "Monitor Jobs" -> "Results"
   Jira: [ML-4365](https://jira.iguazeng.com/browse/ML-4365)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/2254eea5-b8b4-41d0-aadd-e31778784043)

   After:
   <img width="1400" alt="Screenshot 2023-08-10 at 12 35 07" src="https://github.com/mlrun/ui/assets/63646693/b997f1be-eaec-4ba9-b069-0d476877a10e">

   