### PR TITLE
Fix [UI] expand button is visible when change project on the Datasets, Artifacts and Models pages

### DIFF
--- a/src/components/Datasets/Datasets.js
+++ b/src/components/Datasets/Datasets.js
@@ -253,7 +253,7 @@ const Datasets = () => {
 
   useEffect(() => {
     dispatch(setFilters({ groupBy: GROUP_BY_NONE }))
-  }, [dispatch])
+  }, [dispatch, params.projectName])
 
   useEffect(() => {
     checkForSelectedDataset(

--- a/src/components/Files/Files.js
+++ b/src/components/Files/Files.js
@@ -246,7 +246,7 @@ const Files = () => {
 
   useEffect(() => {
     dispatch(setFilters({ groupBy: GROUP_BY_NONE }))
-  }, [dispatch])
+  }, [dispatch, params.projectName])
 
   useEffect(() => {
     checkForSelectedFile(

--- a/src/components/ModelsPage/Models/Models.js
+++ b/src/components/ModelsPage/Models/Models.js
@@ -261,7 +261,7 @@ const Models = ({ fetchModelFeatureVector }) => {
 
   useEffect(() => {
     dispatch(setFilters({ groupBy: GROUP_BY_NONE }))
-  }, [dispatch])
+  }, [dispatch, params.projectName])
 
   useEffect(() => {
     checkForSelectedModel(


### PR DESCRIPTION
- **UI** expand button is visible when change project on the Datasets, Artifacts and Models pages
   Jira: https://jira.iguazeng.com/browse/ML-4121

   After:
   ![Screenshot from 2023-08-10 16-55-04](https://github.com/mlrun/ui/assets/109525572/99b02bd4-3708-4ab2-a42a-4f2e69b7970e)
