### PR TITLE
Fix [Filters] "Version tag" shows only "All" and "latest" tags

### DIFF
--- a/src/common/FormTagFilter/FormTagFilter.js
+++ b/src/common/FormTagFilter/FormTagFilter.js
@@ -188,7 +188,7 @@ const FormTagFilter = ({ label, name }) => {
               ref={dropdownRef}
               style={{ width: `${dropdownWidth}px` }}
             >
-              {tagFilterOptions.map(tag => {
+              {tagOptions.map(tag => {
                 const dropdownItemClassName = classnames(
                   'form-tag-filter__dropdown-item',
                   tagFilter.length !== 0 &&


### PR DESCRIPTION
- **Filters**: "Version tag" shows only "All" and "latest" tags
   Jira: [ML-4385](https://jira.iguazeng.com/browse/ML-4385)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/74bed7e5-0099-468b-b71b-8faedb8d29dd)

   After:
   <img width="1458" alt="Screenshot 2023-08-13 at 17 15 10" src="https://github.com/mlrun/ui/assets/63646693/a5e16326-4582-4022-ae98-afc1edc34340">
