### PR TITLE
Fix [Batch Run] The "handler"/"method" option is missing in UI in case the function has not "entry_points"

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -85,7 +85,7 @@ const volumeTypesMap = {
 const volumeTypeNamesMap = {
   [CONFIG_MAP_VOLUME_TYPE]: 'name',
   [PVC_VOLUME_TYPE]: 'claimName',
-  [SECRET_VOLUME_TYPE]: 'secretName',
+  [SECRET_VOLUME_TYPE]: 'secretName'
 }
 
 export const generateJobWizardData = (
@@ -340,13 +340,27 @@ const getVersionOptions = selectedFunctions => {
   return versionOptions.length ? versionOptions : [{ label: '$latest', id: 'latest' }]
 }
 
+const getDefaultMethod = (methodOptions, selectedFunctions) => {
+  let method = ''
+
+  const latestFunction = selectedFunctions.find(item => item.metadata.tag === 'latest')
+
+  if (methodOptions.length) {
+    method = methodOptions[0]?.id
+  } else if (latestFunction) {
+    method = latestFunction.spec.default_handler || 'handler'
+  } else {
+    method = selectedFunctions[0]?.spec.default_handler || 'handler'
+  }
+
+  return method
+}
+
 const getDefaultMethodAndVersion = (versionOptions, methodOptions, selectedFunctions) => {
   const defaultVersion =
     versionOptions.find(version => version.id === 'latest')?.id || versionOptions[0].id || ''
-  const defaultMethod =
-    selectedFunctions.find(item => item.metadata.tag === 'latest')?.spec?.default_handler ||
-    methodOptions[0]?.id ||
-    ''
+
+  const defaultMethod = getDefaultMethod(methodOptions, selectedFunctions)
 
   return {
     defaultVersion,

--- a/src/components/JobWizard/JobWizardSteps/JobWizardRunDetails/JobWizardRunDetails.js
+++ b/src/components/JobWizard/JobWizardSteps/JobWizardRunDetails/JobWizardRunDetails.js
@@ -182,16 +182,22 @@ const JobWizardRunDetails = ({
               />
             </div>
           )}
-          {jobAdditionalData.methodOptions?.length !== 0 && !isBatchInference && (
-            <div className="form-col-1">
-              <FormSelect
-                name={methodPath}
-                label="Method"
-                options={jobAdditionalData.methodOptions || []}
-                scrollToView={false}
-              />
-            </div>
-          )}
+          {!isBatchInference ? (
+            jobAdditionalData.methodOptions?.length !== 0 ? (
+              <div className="form-col-1">
+                <FormSelect
+                  label="Method"
+                  name={methodPath}
+                  options={jobAdditionalData.methodOptions || []}
+                  scrollToView={false}
+                />
+              </div>
+            ) : (
+              <div className="form-col-1">
+                <FormInput label="Method" name={methodPath} disabled={isEditMode} />
+              </div>
+            )
+          ) : null}
         </div>
         <div className="form-row">
           <FormChipCell

--- a/src/elements/FunctionsPanelCode/FunctionsPanelCode.js
+++ b/src/elements/FunctionsPanelCode/FunctionsPanelCode.js
@@ -84,6 +84,12 @@ const FunctionsPanelCode = ({
   ])
 
   useEffect(() => {
+    if (!functionsStore.newFunction.spec.default_handler) {
+      setNewFunctionHandler('handler')
+    }
+  }, [functionsStore.newFunction.spec.default_handler, setNewFunctionHandler])
+
+  useEffect(() => {
     if (mode === PANEL_CREATE_MODE && imageType.length === 0) {
       if (appStore.frontendSpec.default_function_image_by_kind?.[functionsStore.newFunction.kind]) {
         setNewFunctionImage(
@@ -224,7 +230,8 @@ const FunctionsPanelCode = ({
           ...state,
           commands: state.commands || '',
           requirements:
-            state.requirements || (appStore.frontendSpec?.function_deployment_mlrun_requirement ?? ''),
+            state.requirements ||
+            (appStore.frontendSpec?.function_deployment_mlrun_requirement ?? ''),
           base_image:
             state.base_image ||
             appStore.frontendSpec?.default_function_image_by_kind?.[


### PR DESCRIPTION
- **Batch Run**: The "handler"/"method" option is missing in UI in case the function has not "entry_points"
   Fixed:
   - In "Create new Function": `default_handler`  = "handler" by default if no other value is supplied on **Submit**.
   - In "Batch run": show by default **list** of `entry_points`, if non exist show a **text field** of function `default_handler` or "handler" if non exists.

   Jira: [ML-4446](https://jira.iguazeng.com/browse/ML-4446)
   
   Before:
   <img width="1392" alt="Screenshot 2023-08-24 at 16 41 33" src="https://github.com/mlrun/ui/assets/63646693/ba2158fb-0755-47e3-8e05-cb2551f3881e">

   
   After:
   <img width="1372" alt="Screenshot 2023-08-24 at 16 39 35" src="https://github.com/mlrun/ui/assets/63646693/61d473e6-95c0-49bb-a40e-740ace5e38f1">
