### PR TITLE
Fix [Real Time Pipelines] all child funcs appear in the table and clicking on any one of them opens the same graph

### DIFF
--- a/src/components/ModelsPage/RealTimePipelines/RealTimePipelines.js
+++ b/src/components/ModelsPage/RealTimePipelines/RealTimePipelines.js
@@ -63,7 +63,12 @@ const RealTimePipelines = () => {
       dispatch(fetchArtifactsFunctions({ project: params.projectName, filters }))
         .unwrap()
         .then(result => {
-          setPipelines(result)
+          setPipelines(
+            result.filter(
+              func =>
+                !Object.keys(func.labels).some(labelKey => labelKey.includes('parent-function'))
+            )
+          )
         })
     },
     [dispatch, params.projectName]


### PR DESCRIPTION
- **Real Time Pipelinesall**: child funcs appear in the table and clicking on any one of them opens the same graph
   Jira: https://jira.iguazeng.com/browse/ML-4000
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/58301139/34edcc08-da34-4b8d-9a80-ff16a531fb7b)

   After: 
   ![image](https://github.com/mlrun/ui/assets/58301139/18989ef0-e000-4cc0-b993-27c7a5f33e48)


