### PR TITLE
Fix [Batch run] Hide 'Build image' option, add message for 'Image name' `1.5`

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -40,7 +40,6 @@ import {
   JOB_DEFAULT_OUTPUT_PATH,
   LIST_TUNING_STRATEGY,
   MAX_SELECTOR_CRITERIA,
-  NEW_IMAGE_SOURCE,
   PANEL_DEFAULT_ACCESS_KEY,
   PARAMETERS_FROM_FILE_VALUE,
   PARAMETERS_FROM_UI_VALUE,
@@ -505,7 +504,9 @@ const parseImageData = (selectedFunction, frontendSpec, currentProjectName) => {
   }
 
   return {
-    imageSource: selectedFunction.spec?.image ? EXISTING_IMAGE_SOURCE : NEW_IMAGE_SOURCE,
+    // todo: Uncomment when BE implements "Building a new image"
+    // imageSource: selectedFunction.spec?.image ? EXISTING_IMAGE_SOURCE : NEW_IMAGE_SOURCE,
+    imageSource: EXISTING_IMAGE_SOURCE,
     imageName:
       selectedFunction.spec?.image ||
       frontendSpec?.default_function_image_by_kind?.[selectedFunction.kind] ||

--- a/src/components/JobWizard/JobWizardSteps/JobWizardRunDetails/JobWizardRunDetails.js
+++ b/src/components/JobWizard/JobWizardSteps/JobWizardRunDetails/JobWizardRunDetails.js
@@ -27,12 +27,11 @@ import {
   FormCheckBox,
   FormChipCell,
   FormInput,
-  FormRadio,
   FormSelect,
   FormTextarea
 } from 'igz-controls/components'
 
-import { EXISTING_IMAGE_SOURCE, NEW_IMAGE_SOURCE } from '../../../../constants'
+import { EXISTING_IMAGE_SOURCE } from '../../../../constants'
 import { SECONDARY_BUTTON, TERTIARY_BUTTON } from 'igz-controls/constants'
 import { areFormValuesChanged } from 'igz-controls/utils/form.util'
 import { getChipOptions } from '../../../../utils/getChipOptions'
@@ -62,6 +61,10 @@ const JobWizardRunDetails = ({
   const methodPath = 'runDetails.method'
   const imageSourcePath = 'runDetails.image.imageSource'
   const [spyOnMethodChange, setSpyOnMethodChange] = useState(true)
+  const commonImageWarningMsg = 'The image must include all the software packages that are required to run the function. ' +
+    'For example, for an XGBoost model, ensure that the image includes the correct XGboost package and version'
+  const batchInferenceWarningMsg = 'The image must include all the software packages that are required to run the model. ' +
+    'For example, for an XGBoost model, ensure that the image includes the correct XGboost package and version'
 
   const selectedImageSource = useMemo(
     () => get(formState.values, imageSourcePath, EXISTING_IMAGE_SOURCE),
@@ -241,15 +244,15 @@ const JobWizardRunDetails = ({
           />
         </div>
 
-        <div className="form-row"></div>
-        <div className="form-row">
-          <FormRadio
-            name={imageSourcePath}
-            value={EXISTING_IMAGE_SOURCE}
-            label="Use an existing image"
-          />
-          <FormRadio name={imageSourcePath} value={NEW_IMAGE_SOURCE} label="Build a new image" />
-        </div>
+        {/*todo: Uncomment when BE implements "Building a new image"*/}
+        {/*<div className="form-row">*/}
+        {/*  <FormRadio*/}
+        {/*    name={imageSourcePath}*/}
+        {/*    value={EXISTING_IMAGE_SOURCE}*/}
+        {/*    label="Use an existing image"*/}
+        {/*  />*/}
+        {/*  <FormRadio name={imageSourcePath} value={NEW_IMAGE_SOURCE} label="Build a new image" />*/}
+        {/*</div>*/}
         {selectedImageSource === EXISTING_IMAGE_SOURCE ? (
           <div className="form-row">
             <FormInput
@@ -258,6 +261,9 @@ const JobWizardRunDetails = ({
               required
               tip="The name of the function's container image"
             />
+            <div className="warning-text">
+              {isBatchInference ? batchInferenceWarningMsg : commonImageWarningMsg}
+            </div>
           </div>
         ) : (
           <>

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -673,6 +673,7 @@ iframe {
   &-row {
     display: flex;
     margin-bottom: 20px;
+    flex-wrap: wrap;
 
     &.align-stretch {
       align-items: stretch;


### PR DESCRIPTION
- **Batch run**: Hide 'Build image' option, add message for 'Image name'
   1. Hide 'Build a new image' option for 'Batch inference' and 'Batch run'
   2. Add an explanation message for 'Image name' input
   
   Depends On: hhttps://github.com/iguazio/dashboard-react-controls/pull/178
   Backported to `1.5.x` from #1927 

   Jira: [ML-4606](https://jira.iguazeng.com/browse/ML-4606)