### PR TITLE
Fix [Scheduled workflow] Workflow (and not job) should have different icon and minimal editing `1.5.x`

### DIFF
--- a/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
+++ b/src/components/Jobs/ScheduledJobs/ScheduledJobs.js
@@ -41,6 +41,7 @@ import { DANGER_BUTTON, FORBIDDEN_ERROR_STATUS_CODE } from 'igz-controls/constan
 import { JobsContext } from '../Jobs'
 import { createJobsScheduleTabContent } from '../../../utils/createJobsContent'
 import { getJobFunctionData } from '../jobs.util'
+import { generateContentActionsMenu } from '../../../layout/Content/content.util'
 import { getNoDataMessage } from '../../../utils/getNoDataMessage'
 import { openPopUp } from 'igz-controls/utils/common.util'
 import { parseJob } from '../../../utils/parseJob'
@@ -190,46 +191,49 @@ const ScheduledJobs = ({
         dispatch,
         fetchFunctionTemplate,
         fetchJobFunctionSuccess
-      )
-        .then(functionData => {
-          setEditableItem({
-            ...editableItem,
-            scheduled_object: {
-              ...editableItem.scheduled_object,
-              function: functionData
-            }
-          })
-
-          setJobWizardMode(PANEL_EDIT_MODE)
+      ).then(functionData => {
+        setEditableItem({
+          ...editableItem,
+          scheduled_object: {
+            ...editableItem.scheduled_object,
+            function: functionData
+          }
         })
+
+        setJobWizardMode(PANEL_EDIT_MODE)
+      })
     },
     [fetchJobFunction, dispatch, fetchFunctionTemplate, fetchJobFunctionSuccess, setJobWizardMode]
   )
 
   const actionsMenu = useMemo(() => {
-    return [
-      {
-        label: 'Run now',
-        icon: <Run className="action_cell__run-icon" />,
-        onClick: handleRunJob
-      },
-      {
-        label: 'Edit',
-        icon: <Edit />,
-        onClick: handleEditScheduleJob
-      },
-      {
-        label: 'Delete',
-        icon: <Delete />,
-        className: 'danger',
-        onClick: onRemoveScheduledJob
-      },
-      {
-        label: 'View YAML',
-        icon: <Yaml />,
-        onClick: toggleConvertedYaml
-      }
-    ]
+    return generateContentActionsMenu(
+      job => [
+        {
+          label: 'Run now',
+          icon: <Run className="action_cell__run-icon" />,
+          onClick: handleRunJob
+        },
+        {
+          label: 'Edit',
+          icon: <Edit />,
+          onClick: handleEditScheduleJob,
+          hidden: job?.type === 'workflow'
+        },
+        {
+          label: 'Delete',
+          icon: <Delete />,
+          className: 'danger',
+          onClick: onRemoveScheduledJob
+        },
+        {
+          label: 'View YAML',
+          icon: <Yaml />,
+          onClick: toggleConvertedYaml
+        }
+      ],
+      []
+    )
   }, [handleEditScheduleJob, handleRunJob, onRemoveScheduledJob, toggleConvertedYaml])
 
   useEffect(() => {

--- a/src/utils/parseJob.js
+++ b/src/utils/parseJob.js
@@ -26,6 +26,9 @@ export const parseJob = (job, tab) => {
   let jobItem = null
 
   if (tab === SCHEDULE_TAB) {
+    const isTypeWorkflow =
+      job.labels && 'job-type' in job.labels && job.labels['job-type'] === 'workflow-runner'
+
     jobItem = {
       createdTime: new Date(job.creation_time),
       func: job.scheduled_object.task.spec.function,
@@ -36,7 +39,7 @@ export const parseJob = (job, tab) => {
       scheduled_object: job.scheduled_object,
       startTime: new Date(job.last_run?.status?.start_time),
       state: getState(job.last_run?.status?.state, JOBS_PAGE, 'job'),
-      type: job.kind === 'pipeline' ? 'workflow' : job.kind,
+      type: job.kind === 'pipeline' || isTypeWorkflow ? 'workflow' : job.kind,
       ui: {
         originalContent: job
       }


### PR DESCRIPTION
- **Scheduled workflow**: Workflow (and not job) should have different icon and minimal editing
   Backported to `1.5.x` from #1935 
   Jira: [ML-4628](https://jira.iguazeng.com/browse/ML-4628)
   
   Before:
   <img width="1120" alt="Screenshot 2023-09-20 at 23 09 54" src="https://github.com/mlrun/ui/assets/63646693/09e77940-5b41-4a02-8013-cdfa718a8b1f">

   After:
   <img width="1132" alt="Screenshot 2023-09-20 at 23 10 31" src="https://github.com/mlrun/ui/assets/63646693/12428c52-3e6d-4677-97b7-5151962953ad">

   