### PR TITLE
Fix [Model Endpoints] function shows hash and does not provide a link `1.5.x`

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -425,7 +425,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerLabel: 'Function',
         value: functionName,
         class: 'table-cell-1',
-        link: `${generateLinkPath(functionUri)}/overview`,
+        getLink: () => `${generateLinkPath(functionUri)}/overview`,
         tooltip: functionUri
       },
       {


### PR DESCRIPTION
- **Model Endpoints**: function shows hash and does not provide a link
   Backported to `1.5.x` from  #1947 
   Jira: https://jira.iguazeng.com/browse/ML-4572

   ![image](https://github.com/mlrun/ui/assets/58301139/4dd51d38-977d-4e21-9aaf-dca4b03fb81d)


