### PR TITLE
Fix [Batch run] Remove the '$' from Batch Inference version presentation `1.5.x`

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -97,7 +97,7 @@ export const generateJobWizardData = (
   selectedFunctionData,
   defaultData,
   currentProjectName,
-  isEditMode,
+  isEditMode
 ) => {
   const functions = selectedFunctionData.functions
   const functionInfo = getFunctionInfo(selectedFunctionData)
@@ -339,20 +339,20 @@ const getVersionOptions = selectedFunctions => {
   const versionOptions = unionBy(
     selectedFunctions.map(func => {
       return {
-        label: (func.metadata.tag === TAG_LATEST ? '$' : '') + (func.metadata.tag || '$latest'),
+        label: func.metadata.tag || TAG_LATEST,
         id: func.metadata.tag || TAG_LATEST
       }
     }),
     'id'
   )
 
-  return versionOptions.length ? versionOptions : [{ label: '$latest', id: 'latest' }]
+  return versionOptions.length ? versionOptions : [{ label: 'latest', id: TAG_LATEST }]
 }
 
 const getDefaultMethod = (methodOptions, selectedFunctions) => {
   let method = ''
 
-  const latestFunction = selectedFunctions.find(item => item.metadata.tag === 'latest')
+  const latestFunction = selectedFunctions.find(item => item.metadata.tag === TAG_LATEST)
 
   if (methodOptions.length) {
     method = methodOptions[0]?.id
@@ -367,7 +367,7 @@ const getDefaultMethod = (methodOptions, selectedFunctions) => {
 
 const getDefaultMethodAndVersion = (versionOptions, methodOptions, selectedFunctions) => {
   const defaultVersion =
-    versionOptions.find(version => version.id === 'latest')?.id || versionOptions[0].id || ''
+    versionOptions.find(version => version.id === TAG_LATEST)?.id || versionOptions[0].id || ''
 
   const defaultMethod = getDefaultMethod(methodOptions, selectedFunctions)
 

--- a/src/components/JobsPanel/jobsPanel.util.js
+++ b/src/components/JobsPanel/jobsPanel.util.js
@@ -213,24 +213,24 @@ export const getVersionOptions = selectedFunctions => {
   const versionOptions = unionBy(
     selectedFunctions.map(func => {
       return {
-        label: (func.metadata.tag === TAG_LATEST ? '$' : '') + (func.metadata.tag || '$latest'),
+        label: func.metadata.tag || TAG_LATEST,
         id: func.metadata.tag || TAG_LATEST
       }
     }),
     'id'
   )
 
-  return versionOptions.length ? versionOptions : [{ label: '$latest', id: 'latest' }]
+  return versionOptions.length ? versionOptions : [{ label: 'latest', id: TAG_LATEST }]
 }
 
 export const getDefaultMethodAndVersion = (versionOptions, selectedFunctions) => {
-  const defaultMethod = selectedFunctions.find(item => item.metadata.tag === 'latest')?.spec
+  const defaultMethod = selectedFunctions.find(item => item.metadata.tag === TAG_LATEST)?.spec
     .default_handler
 
   const defaultVersion =
     versionOptions.length === 1
       ? versionOptions[0].id
-      : versionOptions.find(version => version.id === 'latest').id
+      : versionOptions.find(version => version.id === TAG_LATEST).id
 
   return {
     defaultMethod,


### PR DESCRIPTION
- **Batch run**Ж Remove the '$' from Batch Inference version presentation
   Backported to `1.5.x` from #1949 
   Jira: https://jira.iguazeng.com/browse/ML-4591

   ![image](https://github.com/mlrun/ui/assets/58301139/a840f7e2-31a0-4ed4-b5d7-43b511b16f33)
