### PR TITLE
Fix [Batch run] Batch run labels are incorrect `1.5`

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -127,7 +127,7 @@ export const generateJobWizardData = (
       name: functionInfo.name,
       version: functionInfo.version,
       method: functionInfo.method,
-      labels: functionInfo.labels,
+      labels: [],
       image: parseImageData(functionInfo.function, frontendSpec, currentProjectName)
     },
     parameters: {
@@ -299,7 +299,6 @@ const getFunctionInfo = selectedFunctionData => {
       functions.find(func => func.metadata.tag === currentFunctionVersion) ?? functions[0]
 
     return {
-      labels: parseChipsData(currentFunction?.metadata.labels),
       name: selectedFunctionData.name,
       method: defaultMethod,
       version: currentFunctionVersion,


### PR DESCRIPTION
- **Batch run**: Batch run labels are incorrect `1.5.x`
   Backported to `1.5.x` from #1952 
   Jira: [ML-4663](https://jira.iguazeng.com/browse/ML-4663)