### PR TITLE
Fix [Batch run] inputs issues `1.5.x`

### DIFF
--- a/src/components/DetailsInputs/DetailsInputs.js
+++ b/src/components/DetailsInputs/DetailsInputs.js
@@ -101,6 +101,17 @@ const DetailsInputs = ({ inputs }) => {
                   }
                 }
               ])
+            } else {
+              setContent(state => [
+                ...state,
+                {
+                  key,
+                  value,
+                  ui: {
+                    isPreviewable: false
+                  }
+                }
+              ])
             }
           })
       } else {

--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -97,7 +97,7 @@ export const generateJobWizardData = (
   selectedFunctionData,
   defaultData,
   currentProjectName,
-  isEditMode,
+  isEditMode
 ) => {
   const functions = selectedFunctionData.functions
   const functionInfo = getFunctionInfo(selectedFunctionData)
@@ -864,8 +864,11 @@ const generateDataInputs = dataInputsTableData => {
   const dataInputs = {}
 
   dataInputsTableData.forEach(dataInput => {
-    dataInputs[dataInput.data.name] =
-      dataInput.data.fieldInfo.pathType + dataInput.data.fieldInfo.value
+    const dataInputValue = dataInput.data.fieldInfo.pathType + dataInput.data.fieldInfo.value
+
+    if (dataInputValue.length > 0) {
+      dataInputs[dataInput.data.name] = dataInputValue
+    }
   })
 
   return dataInputs
@@ -946,7 +949,7 @@ const generateResources = resources => {
   }
 }
 
-const generateFunctionBuild = (imageData) => {
+const generateFunctionBuild = imageData => {
   if (imageData.imageSource === EXISTING_IMAGE_SOURCE) return {}
 
   return {
@@ -1005,7 +1008,10 @@ export const generateJobRequestData = (
         }
       },
       spec: {
-        image: formData.runDetails.image?.imageSource === EXISTING_IMAGE_SOURCE ? formData.runDetails.image.imageName : '',
+        image:
+          formData.runDetails.image?.imageSource === EXISTING_IMAGE_SOURCE
+            ? formData.runDetails.image.imageName
+            : '',
         build: generateFunctionBuild(formData.runDetails.image),
         env: generateEnvironmentVariables(formData.advanced.environmentVariablesTable),
         node_selector: generateObjectFromKeyValue(formData.resources.nodeSelectorTable),


### PR DESCRIPTION
- **Batch run**:  inputs issues 
  1. when using batch run wizard on a stored function with an empty input, the UI pass the empty input with a value similar to the key
  2. Inputs are not displayed in the inputs job tab if there has been an error with a previous input store path
  
  Backported to `1.5.x` from #1961 

   Jira: https://jira.iguazeng.com/browse/ML-4659, https://jira.iguazeng.com/browse/ML-4658, https://jira.iguazeng.com/browse/ML-4657