### PR TITLE
Fix [Datasets and Models] Filter by tag isn't performed when version tag was edited `1.5.x`

### DIFF
--- a/src/components/Datasets/Datasets.js
+++ b/src/components/Datasets/Datasets.js
@@ -186,7 +186,7 @@ const Datasets = () => {
       }
     }
 
-    handleRefresh(filtersStore)
+    handleRefresh(datasetsFilters)
   }
 
   const handleRequestOnExpand = useCallback(
@@ -247,9 +247,9 @@ const Datasets = () => {
 
   useEffect(() => {
     if (isNil(filtersStore.tagOptions) && urlTagOption) {
-      fetchData({ ...filtersStore, tag: urlTagOption })
+      fetchData({ ...datasetsFilters, tag: urlTagOption })
     }
-  }, [fetchData, filtersStore, urlTagOption])
+  }, [datasetsFilters, fetchData, filtersStore, urlTagOption])
 
   useEffect(() => {
     dispatch(setFilters({ groupBy: GROUP_BY_NONE }))

--- a/src/components/ModelsPage/Models/Models.js
+++ b/src/components/ModelsPage/Models/Models.js
@@ -234,7 +234,7 @@ const Models = ({ fetchModelFeatureVector }) => {
       }
     }
 
-    handleRefresh(filtersStore)
+    handleRefresh(modelsFilters)
   }
 
   useEffect(() => {
@@ -245,9 +245,9 @@ const Models = ({ fetchModelFeatureVector }) => {
 
   useEffect(() => {
     if (isNil(filtersStore.tagOptions) && urlTagOption) {
-      fetchData({ ...filtersStore, tag: urlTagOption })
+      fetchData({ ...modelsFilters, tag: urlTagOption })
     }
-  }, [fetchData, filtersStore, urlTagOption])
+  }, [fetchData, filtersStore, modelsFilters, urlTagOption])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- **Datasets, Models** :Filter by tag isn't performed when version tag was edited
   Backported to 1.5.x from #1963 
   Jira: https://jira.iguazeng.com/browse/ML-4158
