### PR TITLE
Fix [Jobs] Missing scroll bar in jobs UI logs

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -174,7 +174,14 @@
       &__content {
         width: 100%;
         height: 100%;
+        padding: 0 15px 0 0;
         overflow-y: scroll;
+
+        /* Define the thumb style */
+        &::-webkit-scrollbar-thumb {
+          background: $doveGray;
+          border-radius: 5px;
+        }
       }
 
       .logs_refresh {


### PR DESCRIPTION
- **Jobs**: Missing scroll bar in jobs UI logs
   Jira: [ML-4689](https://jira.iguazeng.com/browse/ML-4689)
   
   After:
   <img width="1285" alt="Screenshot 2023-09-28 at 19 42 38" src="https://github.com/mlrun/ui/assets/63646693/8b5a1344-a48f-4078-a1e1-4067e647260b">

   