### PR TITLE
Fix [Jobs] Missing scroll bar in jobs UI logs `1.5.x`

### DIFF
--- a/src/components/Details/details.scss
+++ b/src/components/Details/details.scss
@@ -174,7 +174,14 @@
       &__content {
         width: 100%;
         height: 100%;
+        padding: 0 15px 0 0;
         overflow-y: scroll;
+
+        /* Define the thumb style */
+        &::-webkit-scrollbar-thumb {
+          background: $doveGray;
+          border-radius: 5px;
+        }
       }
 
       .logs_refresh {


### PR DESCRIPTION
- **Jobs**: Missing scroll bar in jobs UI logs
   Backported to `1.5.x` from #1965 
   Jira: [ML-4689](https://jira.iguazeng.com/browse/ML-4689)