### PR TITLE
Fix [Batch run] Mandatory parameters should be selected v2 `1.5.x`

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -617,7 +617,7 @@ export const parsePredefinedParameters = funcParams => {
           name: parameter.name ?? '',
           type: parameter.type ?? '',
           value: parsedValue,
-          isChecked: !parsedValue,
+          isChecked: !has(parameter, 'default'),
           isHyper: false
         },
         doc: parameter.doc,
@@ -652,7 +652,7 @@ export const parseDefaultParameters = (funcParams = {}, runParams = {}, runHyper
               )
             : parameter.type ?? '',
           value: parsedValue,
-          isChecked: parsedValue && predefinedParameterIsModified,
+          isChecked: (parsedValue && predefinedParameterIsModified) || !has(parameter, 'default'),
           isHyper: parameter.name in runHyperParams
         },
         doc: parameter.doc ?? '',


### PR DESCRIPTION
- **Batch run**: Mandatory parameters should be selected v2
   Backported to `1.5.x` from #1968 
   Jira: [ML-4661](https://jira.iguazeng.com/browse/ML-4661)