### PR TITLE
Fix [Jobs] Monitor job pods view use too broad api call `1.5.x`

### DIFF
--- a/src/actions/details.js
+++ b/src/actions/details.js
@@ -94,11 +94,11 @@ const detailsActions = {
     type: FETCH_MODEL_FEATURE_VECTOR_SUCCESS,
     payload: featureSets
   }),
-  fetchJobPods: (project, uid) => dispatch => {
+  fetchJobPods: (project, uid, kind) => dispatch => {
     dispatch(detailsActions.fetchPodsBegin())
 
     return detailsApi
-      .getJobPods(project)
+      .getJobPods(project, uid, kind)
       .then(({ data }) => {
         let podsData = generatePods(project, uid, data)
 

--- a/src/api/details-api.js
+++ b/src/api/details-api.js
@@ -20,16 +20,19 @@ such restriction.
 import { mainHttpClient } from '../httpClient'
 
 const detailsApi = {
-  getJobPods: project =>
-    mainHttpClient.get(`/projects/${project}/runtime-resources?group-by=job`),
+  getJobPods: (project, uid, kind) => {
+    const params = {
+      'group-by': 'job',
+      kind,
+      'label-selector': `mlrun/uid=${uid}`
+    }
+
+    return mainHttpClient.get(`/projects/${project}/runtime-resources`, { params })
+  },
   getModelEndpoint: (project, uid) =>
-    mainHttpClient.get(
-      `/projects/${project}/model-endpoints/${uid}?feature_analysis=true`
-    ),
+    mainHttpClient.get(`/projects/${project}/model-endpoints/${uid}?feature_analysis=true`),
   getModelFeatureVector: (project, name, reference) =>
-    mainHttpClient.get(
-      `/projects/${project}/feature-vectors/${name}/references/${reference}`
-    )
+    mainHttpClient.get(`/projects/${project}/feature-vectors/${name}/references/${reference}`)
 }
 
 export default detailsApi

--- a/src/hooks/usePods.hook.js
+++ b/src/hooks/usePods.hook.js
@@ -18,7 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import { useEffect } from 'react'
-import { isEmpty } from 'lodash'
+import { isEmpty, get } from 'lodash'
 import { useParams } from 'react-router-dom'
 
 export const usePods = (fetchJobPods, removePods, selectedJob) => {
@@ -26,7 +26,11 @@ export const usePods = (fetchJobPods, removePods, selectedJob) => {
 
   useEffect(() => {
     if (!isEmpty(selectedJob)) {
-      fetchJobPods(params.projectName, selectedJob.uid)
+      fetchJobPods(
+        params.projectName,
+        selectedJob.uid,
+        get(selectedJob, 'ui.originalContent.metadata.labels.kind', 'job')
+      )
 
       const interval = setInterval(() => {
         fetchJobPods(params.projectName, selectedJob.uid)


### PR DESCRIPTION
- **Jobs**: Monitor job pods view use too broad api call
   Backported to `1.5.x` from #1976 
   Jira: https://jira.iguazeng.com/browse/ML-4693