### PR TITLE
Fix [Jobs] missing error reason when job abort fails

### DIFF
--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -32,6 +32,7 @@ import {
   SCHEDULE_TAB,
   JOB_KIND_SPARK
 } from '../../constants'
+import { CONFLICT_ERROR_STATUS_CODE } from 'igz-controls/constants'
 import jobsActions from '../../actions/jobs'
 import { generateKeyValues } from '../../utils'
 import { setNotification } from '../../reducers/notificationReducer'
@@ -259,10 +260,10 @@ export const handleAbortJob = (
         })
       )
     })
-    .catch(() => {
+    .catch(error => {
       dispatch(
         setNotification({
-          status: 400,
+          status: error.response?.status || 400,
           id: Math.random(),
           retry: () =>
             handleAbortJob(
@@ -275,7 +276,10 @@ export const handleAbortJob = (
               setConfirmData,
               dispatch
             ),
-          message: 'Aborting job failed'
+          message:
+            error.response?.status === CONFLICT_ERROR_STATUS_CODE && error.response?.data?.detail
+              ? error.response.data.detail
+              : 'Aborting job failed'
         })
       )
     })

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -276,10 +276,7 @@ export const handleAbortJob = (
               setConfirmData,
               dispatch
             ),
-          message:
-            error.response?.status === CONFLICT_ERROR_STATUS_CODE && error.response?.data?.detail
-              ? error.response.data.detail
-              : 'Aborting job failed'
+          message: error.response?.data?.detail || 'Aborting job failed'
         })
       )
     })


### PR DESCRIPTION
- **Jobs**: missing error reason when job abort fails
   Jira: [ML-4732](https://jira.iguazeng.com/browse/ML-4732)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/5bd53d2b-d98f-4d34-96e6-761eae018808)

   After:
   <img width="689" alt="Screenshot 2023-10-05 at 10 36 28" src="https://github.com/mlrun/ui/assets/63646693/6c045eb2-8360-4d72-9fa6-1b378058fc4c">
