### PR TITLE
Fix [Batch inference] The model_path input only supports store paths `1.5.x`

### DIFF
--- a/src/common/TargetPath/targetPath.util.js
+++ b/src/common/TargetPath/targetPath.util.js
@@ -155,37 +155,44 @@ export const getTargetPathOptions = hiddenOptionsIds => [
   {
     className: 'path-type-v3io',
     label: 'V3IO',
-    id: V3IO_INPUT_PATH_SCHEME
+    id: V3IO_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(V3IO_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-s3',
     label: 'S3',
-    id: S3_INPUT_PATH_SCHEME
+    id: S3_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(S3_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-http',
     label: 'HTTP',
-    id: HTTP_STORAGE_INPUT_PATH_SCHEME
+    id: HTTP_STORAGE_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(HTTP_STORAGE_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-https',
     label: 'HTTPS',
-    id: HTTPS_STORAGE_INPUT_PATH_SCHEME
+    id: HTTPS_STORAGE_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(HTTPS_STORAGE_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-az',
     label: 'Azure storage',
-    id: AZURE_STORAGE_INPUT_PATH_SCHEME
+    id: AZURE_STORAGE_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(AZURE_STORAGE_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-gs',
     label: 'Google storage',
-    id: GOOGLE_STORAGE_INPUT_PATH_SCHEME
+    id: GOOGLE_STORAGE_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(GOOGLE_STORAGE_INPUT_PATH_SCHEME)
   },
   {
     className: 'path-type-dbfs',
     label: 'Databricks filesystem',
-    id: DBFS_STORAGE_INPUT_PATH_SCHEME
+    id: DBFS_STORAGE_INPUT_PATH_SCHEME,
+    hidden: hiddenOptionsIds?.includes(DBFS_STORAGE_INPUT_PATH_SCHEME)
   }
 ]
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -53,6 +53,8 @@ export const FULL_VIEW_MODE = 'full'
 
 export const REQUEST_CANCELED = 'Request canceled'
 
+export const MODEL_PATH_DATA_INPUT = 'model_path'
+
 /*=========== PAGES & TABS =============*/
 
 export const PROJECTS_PAGE = 'PROJECTS'

--- a/src/elements/FormDataInputsTable/FormDataInputsRow/FormDataInputsRow.js
+++ b/src/elements/FormDataInputsTable/FormDataInputsRow/FormDataInputsRow.js
@@ -31,6 +31,16 @@ import {
   handleStoreInputPathChange,
   targetPathInitialState
 } from '../../../common/TargetPath/targetPath.util'
+import {
+  AZURE_STORAGE_INPUT_PATH_SCHEME,
+  DBFS_STORAGE_INPUT_PATH_SCHEME,
+  GOOGLE_STORAGE_INPUT_PATH_SCHEME,
+  HTTP_STORAGE_INPUT_PATH_SCHEME,
+  HTTPS_STORAGE_INPUT_PATH_SCHEME,
+  MODEL_PATH_DATA_INPUT,
+  S3_INPUT_PATH_SCHEME,
+  V3IO_INPUT_PATH_SCHEME
+} from '../../../constants'
 
 const FormDataInputsRow = ({
   applyChanges,
@@ -86,6 +96,19 @@ const FormDataInputsRow = ({
               density="normal"
               formState={formState}
               formStateFieldInfo={`${rowPath}.data.fieldInfo`}
+              hiddenSelectOptionsIds={
+                fieldData.data.name === MODEL_PATH_DATA_INPUT && fieldData.isPredefined
+                  ? [
+                      V3IO_INPUT_PATH_SCHEME,
+                      S3_INPUT_PATH_SCHEME,
+                      HTTP_STORAGE_INPUT_PATH_SCHEME,
+                      HTTPS_STORAGE_INPUT_PATH_SCHEME,
+                      AZURE_STORAGE_INPUT_PATH_SCHEME,
+                      GOOGLE_STORAGE_INPUT_PATH_SCHEME,
+                      DBFS_STORAGE_INPUT_PATH_SCHEME
+                    ]
+                  : []
+              }
               inputDefaultValue={editingItem.data.fieldInfo?.value}
               name={`${rowPath}.data.path`}
               required


### PR DESCRIPTION
- **Batch inference**: The model_path input only supports store paths
   Backported to `1.5.x` from #2012 
   Jira: https://jira.iguazeng.com/browse/ML-4697