### PR TITLE
Fix [Project Monitor] mlrun long run - GET to mlrun/api/v1/runs?.. fails with 504

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -322,7 +322,7 @@ const projectsAction = {
     type: FETCH_PROJECT_FUNCTIONS_SUCCESS,
     payload: functions
   }),
-  fetchProjectJobs: project => dispatch => {
+  fetchProjectJobs: (project, startTimeFrom) => dispatch => {
     dispatch(projectsAction.fetchProjectJobsBegin())
 
     const params = {
@@ -331,7 +331,8 @@ const projectsAction = {
       'partition-sort-by': 'updated',
       'rows-per-partition': '5',
       'max-partitions': '5',
-      iter: 'false'
+      iter: 'false',
+      start_time_from: startTimeFrom
     }
 
     return projectsApi

--- a/src/elements/ProjectDataCard/ProjectDataCard.js
+++ b/src/elements/ProjectDataCard/ProjectDataCard.js
@@ -56,7 +56,9 @@ const ProjectDataCard = ({ content, href, link, params, statistics, table, title
         <NoData />
       ) : (
         <>
-          <div className="project-data-card__recent-text">{!href ? 'Recent' : ''}</div>
+          <div className="project-data-card__recent-text">
+            {!href ? 'Recent - "Last 48 hours"' : ''}
+          </div>
           <ProjectTable params={params} table={table} />
           {href ? (
             <a href={href} target="_top" className="link project-data-card__see-all-link">

--- a/src/elements/ProjectJobs/ProjectJobs.js
+++ b/src/elements/ProjectJobs/ProjectJobs.js
@@ -20,16 +20,12 @@ such restriction.
 import React, { useEffect, useMemo, useState } from 'react'
 import { connect } from 'react-redux'
 import { useParams } from 'react-router-dom'
+import moment from 'moment'
 
 import ProjectDataCard from '../ProjectDataCard/ProjectDataCard'
 
 import { MONITOR_JOBS_TAB } from '../../constants'
-import {
-  getJobsStatistics,
-  getJobsTableData,
-  groupByName,
-  sortByDate
-} from './projectJobs.utils'
+import { getJobsStatistics, getJobsTableData, groupByName, sortByDate } from './projectJobs.utils'
 import projectsAction from '../../actions/projects'
 
 const ProjectJobs = ({ fetchProjectJobs, projectStore }) => {
@@ -38,14 +34,14 @@ const ProjectJobs = ({ fetchProjectJobs, projectStore }) => {
 
   useEffect(() => {
     if (projectStore.project.jobs.data) {
-      setGroupedLatestItem(
-        sortByDate(groupByName(projectStore.project.jobs.data))
-      )
+      setGroupedLatestItem(sortByDate(groupByName(projectStore.project.jobs.data)))
     }
   }, [projectStore.project.jobs.data])
 
   useEffect(() => {
-    fetchProjectJobs(params.projectName)
+    const startTimeFrom = moment().add(-2, 'days').toISOString()
+
+    fetchProjectJobs(params.projectName, startTimeFrom)
   }, [fetchProjectJobs, params.projectName])
 
   const jobsData = useMemo(() => {


### PR DESCRIPTION
- **Project Monitor**: mlrun long run - GET to mlrun/api/v1/runs?.. fails with 504
   - Filter results by setting `start_time_from` 2 days ago
   
    Jira: [ML-4756](https://jira.iguazeng.com/browse/ML-4756)
    
    Before:
    <img width="709" alt="Screenshot 2023-10-15 at 22 24 16" src="https://github.com/mlrun/ui/assets/63646693/c91a3b7d-8601-40d8-8a4b-6cb7c9317dba">

    
   After:
   <img width="705" alt="Screenshot 2023-10-16 at 21 27 25" src="https://github.com/mlrun/ui/assets/63646693/3b8f3316-3a7d-4281-a7f2-e1d9f956bf5a">

   
