### PR TITLE
Fix [Feature Store] inaccurate validation message for redis

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStoreView.js
@@ -133,7 +133,7 @@ const FeatureSetsPanelTargetStoreView = ({
                       invalid={!validation.isOnlineTargetPathValid}
                       invalidText={
                         data.online.kind === REDISNOSQL && /[{}]/g.test(data.online.path)
-                          ? 'Invalid Redis URL, change the URL to a valid URL in the form of <redis|rediss>:///<host>[:port]'
+                          ? 'Invalid Redis URL, change the URL to a valid URL in the form of <redis|rediss>://<host>[:port]'
                           : ''
                       }
                       label="Path"


### PR DESCRIPTION
- **Feature Store**: inaccurate validation message for redis
   Jira: [ML-4868](https://jira.iguazeng.com/browse/ML-4868)
   
   After:
   <img width="533" alt="Screenshot 2023-11-02 at 13 09 09" src="https://github.com/mlrun/ui/assets/63646693/3b520b50-e513-4149-9855-1ba8409b6e16">

   