### PR TITLE
Fix [API] browser caching `1.5.x`

### DIFF
--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -20,10 +20,14 @@ such restriction.
 import axios from 'axios'
 import qs from 'qs'
 
+const headers = {
+  'Cache-Control': 'no-cache'
+}
 export const mainBaseUrl = `${process.env.PUBLIC_URL}/api/v1`
 
 export const mainHttpClient = axios.create({
   baseURL: mainBaseUrl,
+  headers,
 
   // serialize a param with an array value as a repeated param, for example:
   // { label: ['host', 'owner=admin'] } => 'label=host&label=owner%3Dadmin'
@@ -31,13 +35,16 @@ export const mainHttpClient = axios.create({
 })
 
 export const functionTemplatesHttpClient = axios.create({
-  baseURL: `${process.env.PUBLIC_URL}/function-catalog`
+  baseURL: `${process.env.PUBLIC_URL}/function-catalog`,
+  headers
 })
 
 export const nuclioHttpClient = axios.create({
-  baseURL: `${process.env.PUBLIC_URL}/nuclio/api`
+  baseURL: `${process.env.PUBLIC_URL}/nuclio/api`,
+  headers
 })
 
 export const iguazioHttpClient = axios.create({
-  baseURL: process.env.NODE_ENV === 'production' ? '/api' : '/iguazio/api'
+  baseURL: process.env.NODE_ENV === 'production' ? '/api' : '/iguazio/api',
+  headers
 })


### PR DESCRIPTION
- **API**: browser caching
   Backported to `1.5.x` from #2070 
   Jira: [ML-4960](https://jira.iguazeng.com/browse/ML-4960)