### PR TITLE
Fix [UI] create feature set - schema entities tool tip is not red

### DIFF
--- a/src/common/Input/input.scss
+++ b/src/common/Input/input.scss
@@ -134,8 +134,14 @@
     background-color: transparent;
     pointer-events: none;
 
+    label {
+      display: flex;
+      align-items: center;
+    }
+
     &-mandatory {
       color: $amaranth;
+      margin-left: 2px;
 
       &_disabled {
         color: $spunPearl;
@@ -143,15 +149,16 @@
     }
 
     &.active-label {
-      top: 9px;
+      top: 8px;
       height: auto;
       font-weight: 700;
       font-size: 10px;
       line-height: 12px;
       pointer-events: auto;
 
-      .input__label-mandatory:not(.input__label-mandatory_disabled) {
-        color: $topaz;
+      .input__label-mandatory,
+      .input__label-mandatory_disabled {
+        font-size: 13px;
       }
     }
 


### PR DESCRIPTION
- **UI**: Create feature set - schema entities tool tip is not red
   Jira: [ML-4972](https://jira.iguazeng.com/browse/ML-4972)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/a51005f6-d9b7-4168-917a-a47bfb5a6e1c)
 
   After: 
   ![image](https://github.com/mlrun/ui/assets/63646693/1d641616-9bc5-4f02-8c72-a75255f2376a)

