### PR TITLE
Fix [Breadcrumbs] page crash when project list is not loaded

### DIFF
--- a/src/common/Breadcrumbs/Breadcrumbs.js
+++ b/src/common/Breadcrumbs/Breadcrumbs.js
@@ -95,7 +95,7 @@ const Breadcrumbs = ({ onClick, projectStore, fetchProjectsNames }) => {
     searchValue
       ? projectListRef.current.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
       : setTimeout(() => {
-          selectedOptionEl.scrollIntoView(
+          selectedOptionEl?.scrollIntoView(
             {
               behavior: 'smooth',
               block: 'center'

--- a/src/elements/TableLinkCell/tableLinkCell.scss
+++ b/src/elements/TableLinkCell/tableLinkCell.scss
@@ -49,6 +49,7 @@
       font-family: Roboto, sans-serif;
       font-style: normal;
       margin-top: 5px;
+      width: max-content;
 
       & > span {
         margin-right: 10px;


### PR DESCRIPTION
- **Breadcrumbs** page crash when project list is not loaded
   - Navigate to "Artifacts" with long response time, when receiving popup "Response is too large"
   - Try to open projects list from the breadcrumbs first arrow
   Result: Page crash on "selectedOptionEl"
   
   - Fix table name column UID row width