### PR TITLE
Fix [Project Settings] "Members" tab is not present for user with "project security admin" policy

### DIFF
--- a/src/components/ProjectSettings/projectSettings.util.js
+++ b/src/components/ProjectSettings/projectSettings.util.js
@@ -131,8 +131,10 @@ export const isProjectMembersTabShown = (
     return false
   }
 
+  const userIsProjectSecurityAdmin =
+    activeUser.attributes?.assigned_policies?.includes('Project Security Admin') ?? false
   const userIsAdmin = members.some(member => member.role === 'Admin' && member.id === activeUser.id)
   const userIsOwner = activeUser.id === projectInfo.owner.id
 
-  return userIsOwner || userIsAdmin
+  return userIsOwner || userIsAdmin || userIsProjectSecurityAdmin
 }


### PR DESCRIPTION
- **Project Settings**: "Members" tab is not present for user with "project security admin" policy   
   Jira: https://jira.iguazeng.com/browse/ML-5095