### PR TITLE
Fix [Breadcrumbs] The projects pages dropdown doesn't open up after model/dataset tag editing

### DIFF
--- a/src/components/Datasets/Datasets.js
+++ b/src/components/Datasets/Datasets.js
@@ -206,7 +206,7 @@ const Datasets = () => {
 
       if (changes.data.tag.currentFieldValue) {
         navigate(
-          `/projects/${params.projectName}/${DATASETS_PAGE}/${params.name}/${changes.data.tag.currentFieldValue}/overview`,
+          `/projects/${params.projectName}/${DATASETS_PAGE.toLowerCase()}/${params.name}/${changes.data.tag.currentFieldValue}/overview`,
           { replace: true }
         )
       }

--- a/src/components/ModelsPage/Models/Models.js
+++ b/src/components/ModelsPage/Models/Models.js
@@ -273,7 +273,7 @@ const Models = ({ fetchModelFeatureVector }) => {
 
       if (changes.data.tag.currentFieldValue) {
         navigate(
-          `/projects/${params.projectName}/${MODELS_PAGE}/${MODELS_TAB}/${params.name}/${changes.data.tag.currentFieldValue}/overview`,
+          `/projects/${params.projectName}/${MODELS_PAGE.toLowerCase()}/${MODELS_TAB}/${params.name}/${changes.data.tag.currentFieldValue}/overview`,
           { replace: true }
         )
       }


### PR DESCRIPTION
- **Breadcrumbs**: The projects pages dropdown doesn't open up after model/dataset tag editing
   Jira: [ML-4777](https://jira.iguazeng.com/browse/ML-4777)