### PR TITLE
Fix [Workflows] Cannot read properties of null (reading toLowerCase) on attempt to filter workflows by status "All"

### DIFF
--- a/src/utils/parseWorkflows.js
+++ b/src/utils/parseWorkflows.js
@@ -24,7 +24,11 @@ export const parseWorkflows = workflows => {
   return workflows.map(workflow => {
     return {
       ...workflow,
-      state: getState(workflow.status.toLowerCase(), MONITOR_WORKFLOWS_TAB, JOB_KIND_WORKFLOW),
+      state: getState(
+        workflow.status ? workflow.status.toLowerCase() : '',
+        MONITOR_WORKFLOWS_TAB,
+        JOB_KIND_WORKFLOW
+      ),
       ui: {
         originalContent: workflow
       }

--- a/src/utils/parseWorkflows.js
+++ b/src/utils/parseWorkflows.js
@@ -25,7 +25,7 @@ export const parseWorkflows = workflows => {
     return {
       ...workflow,
       state: getState(
-        workflow.status ? workflow.status.toLowerCase() : '',
+        (workflow.status ?? '').toLowerCase(),
         MONITOR_WORKFLOWS_TAB,
         JOB_KIND_WORKFLOW
       ),


### PR DESCRIPTION
- **Workflows**: Cannot read properties of null (reading 'toLowerCase')' on attempt to filter workflows by status "All"
   Jira: [ML-5384](https://jira.iguazeng.com/browse/ML-5384)