### PR TITLE
Fix [Batch Run] Blank project screen after setting model target path `1.6.x`

### DIFF
--- a/src/common/TargetPath/targetPath.util.js
+++ b/src/common/TargetPath/targetPath.util.js
@@ -304,9 +304,9 @@ export const generateArtifactsReferencesList = artifacts => {
       const [nextRefIter, nextRefTree] = nextRef.id.split('@')
 
       if (prevRefTree === nextRefTree) {
-        return prevRefIter.localeCompare(nextRefIter)
+        return prevRefIter && prevRefIter.localeCompare(nextRefIter)
       } else {
-        return prevRefTree.localeCompare(nextRefTree)
+        return prevRefTree && prevRefTree.localeCompare(nextRefTree)
       }
     })
 


### PR DESCRIPTION
- **Batch Run**: Blank project screen after setting model target path
   Backported to `1.6.x` from #2226 
   Jira: [ML-5591](https://jira.iguazeng.com/browse/ML-5591)