### PR TITLE
Fix [Jobs] change Abort Job confirm message `1.6.x`

### DIFF
--- a/src/components/Jobs/MonitorJobs/MonitorJobs.js
+++ b/src/components/Jobs/MonitorJobs/MonitorJobs.js
@@ -305,7 +305,8 @@ const MonitorJobs = ({
       setConfirmData({
         item: job,
         header: 'Abort job?',
-        message: `You try to abort job "${job.name}".`,
+        message: <div>You try to abort job "{job.name}". <br/>
+          This is a local run. You can abort the run, though the actual process will continue.</div>,
         btnConfirmLabel: 'Abort',
         btnConfirmType: DANGER_BUTTON,
         rejectHandler: () => {

--- a/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
+++ b/src/components/Jobs/MonitorWorkflows/MonitorWorkflows.js
@@ -283,7 +283,8 @@ const MonitorWorkflows = ({
       setConfirmData({
         item: job,
         header: 'Abort job?',
-        message: `You try to abort job "${job.name}".`,
+        message: <div>You try to abort job "{job.name}". <br/>
+          This is a local run. You can abort the run, though the actual process will continue.</div>,
         btnConfirmLabel: 'Abort',
         btnConfirmType: DANGER_BUTTON,
         rejectHandler: () => {


### PR DESCRIPTION
- **Jobs**: change Abort Job confirm message
   Backported to `1.6.x` from #2246 
   Depends On: https://github.com/iguazio/dashboard-react-controls/pull/233
   Jira: https://jira.iguazeng.com/browse/ML-4857
   
   After:
   ![image](https://github.com/mlrun/ui/assets/78905712/7f99964a-affe-4f74-b6f6-97d6be1752fe)
