### PR TITLE
Fix [Models] unable to navigate to additional metrics (+) `1.6.x`

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -187,6 +187,14 @@ export const createModelsRowData = (
       className: 'table-cell-1'
     },
     {
+      id: `metrics.${artifact.ui.identifierUnique}`,
+      headerId: 'metrics',
+      headerLabel: 'Metrics',
+      value: parseKeyValues(artifact.metrics),
+      className: 'table-cell-1',
+      type: 'metrics'
+    },
+    {
       id: `frameWorkAndAlgorithm.${artifact.ui.identifierUnique}`,
       headerId: 'frameWorkAndAlgorithm',
       headerLabel: (
@@ -207,14 +215,6 @@ export const createModelsRowData = (
           ''
         ),
       className: 'table-cell-1'
-    },
-    {
-      id: `metrics.${artifact.ui.identifierUnique}`,
-      headerId: 'metrics',
-      headerLabel: 'Metrics',
-      value: parseKeyValues(artifact.metrics),
-      className: 'table-cell-1',
-      type: 'metrics'
     },
     {
       id: `version.${artifact.ui.identifierUnique}`,


### PR DESCRIPTION
- **Models**: unable to navigate to additional metrics (+)
   Backported to `1.6.x` from #2250 
   Jira: https://jira.iguazeng.com/browse/ML-5663