### PR TITLE
Fix [General] text on data query when there is no relevant data `1.6.x`

### DIFF
--- a/src/utils/getNoDataMessage.js
+++ b/src/utils/getNoDataMessage.js
@@ -184,7 +184,7 @@ const generateNoEntriesFoundMessage = (
     const isLastElement = index === changedFilters.length - 1
 
     return message + `${label} ${value}${isLastElement ? '"' : ', '}`
-  }, `There is no ${messageNames.plural} data to show for "`)
+  }, 'No data matches the filter: "')
 }
 
 const getChangedFiltersList = (filters, filtersStore, filtersStoreKey) => {


### PR DESCRIPTION
- **General**: text on data query when there is no relevant data
   Backported to `1.6.x` from #2265 
   Jira: https://jira.iguazeng.com/browse/ML-5308