### PR TITLE
Fix [Datasets] tooltip is not shown for short producer names

### DIFF
--- a/src/elements/TableProducerCell/TableProducerCell.js
+++ b/src/elements/TableProducerCell/TableProducerCell.js
@@ -52,6 +52,7 @@ const TableProducerCell = ({ bodyCellClassName, className, producer }) => {
                     owner={producer.owner ? producer.owner : ''}
                   />
                 }
+                textShow
               >
                 {producer.name}
               </Tooltip>


### PR DESCRIPTION
- **Datasets**: tooltip is not shown for short producer names
   Jira: https://jira.iguazeng.com/browse/ML-5431