### PR TITLE
Fix [Project settings] no redirection after changing project owner `1.6.x`

### DIFF
--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -187,7 +187,7 @@ const ProjectSettings = ({ frontendSpec }) => {
     const prevOwner = membersState.projectInfo.owner.id
 
     return fetchProjectIdAndOwner().then(() => {
-      if (!membersState.members.some(member => member.id === prevOwner)) {
+      if (!membersState.users.some(member => member.id === prevOwner)) {
         navigate('/projects/')
       }
     })


### PR DESCRIPTION
- **Project settings**: no redirection after changing project owner
   Backported to `1.6.x` from #2293 
   Jira: https://jira.iguazeng.com/browse/ML-5749