### PR TITLE
Fix [Schedule Jobs] Last run link is missing after running a scheduled job

### DIFF
--- a/src/elements/TableLinkCell/TableLinkCell.js
+++ b/src/elements/TableLinkCell/TableLinkCell.js
@@ -91,7 +91,7 @@ const TableLinkCell = ({
               </Tooltip>
             )}
           </div>
-          {(link.match(/jobs/) ||
+          {(data.showUidRow ||
             ((link.match(/functions/) ||
               link.match(/models/) ||
               link.match(/files/) ||

--- a/src/utils/createJobsContent.js
+++ b/src/utils/createJobsContent.js
@@ -75,7 +75,8 @@ export const createJobsMonitorTabContent = (jobs, jobName, isStagingMode) => {
           className: 'table-cell-name',
           type: type === JOB_KIND_WORKFLOW && !isStagingMode ? 'hidden' : 'link',
           getLink,
-          showStatus: true
+          showStatus: true,
+          showUidRow: true
         },
         {
           headerId: 'type',
@@ -227,7 +228,8 @@ export const createJobsScheduleTabContent = jobs => {
           id: `lastRun.${identifierUnique}`,
           value: formatDatetime(job.startTime),
           className: 'table-cell-1',
-          getLink: lastRunLink
+          getLink: lastRunLink,
+          type: 'link'
         },
         {
           headerId: 'createdtime',
@@ -363,7 +365,8 @@ export const createJobsWorkflowContent = (
               MONITOR_WORKFLOWS_TAB
             )
           },
-          showStatus: true
+          showStatus: true,
+          showUidRow: true
         },
         {
           headerId: 'kind',


### PR DESCRIPTION
- **Schedule Jobs**: Last run link is missing after running a scheduled job
   Jira: https://jira.iguazeng.com/browse/ML-5672