### PR TITLE
Fix [Project Settings] "Invite New Members" does not return full list of users `1.6.x`

### DIFF
--- a/src/elements/MembersPopUp/MembersPopUp.js
+++ b/src/elements/MembersPopUp/MembersPopUp.js
@@ -248,15 +248,15 @@ const MembersPopUp = ({
     let paramsUserGroups = { 'filter[name]': `[$match-i]^.*${searchQuery}.*$`, 'page[size]': 200 }
 
     if (isIgzVersionCompatible(requiredIgzVersion)) {
-      paramsScrubbedUsers = { 'filter[username]': `[$contains_istr]${searchQuery}` }
-      paramsUserGroups = { 'filter[name]': `[$contains_istr]${searchQuery}` }
+      paramsScrubbedUsers['filter[username]'] = `[$contains_istr]${searchQuery}`
+      paramsUserGroups['filter[name]'] = `[$contains_istr]${searchQuery}`
     }
 
     const getUsersPromise = projectsIguazioApi.getScrubbedUsers({
-      paramsScrubbedUsers
+      params: paramsScrubbedUsers
     })
     const getUserGroupsPromise = projectsIguazioApi.getScrubbedUserGroups({
-      paramsUserGroups
+      params: paramsUserGroups
     })
     const suggestionList = []
 


### PR DESCRIPTION
- **Project Settings**: "Invite New Members" does not return full list of users
   Backported to `1.6.x` from #2331 
   Jira: https://iguazio.atlassian.net/browse/ML-5907