### PR TITLE
Fix [Project settings] Group with 'Project security admin' policy cannot see members tab of projects `1.6.2`

### DIFF
--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -114,9 +114,18 @@ const ProjectSettings = ({ frontendSpec }) => {
   }
   const fetchActiveUser = () => {
     projectsIguazioApi.getActiveUser().then(response => {
+      const activeUser = response.data
+      activeUser.data.attributes.user_policies_collection = new Set([
+        ...activeUser.data.attributes.assigned_policies,
+        ...(activeUser.included?.reduce?.(
+          (policies, group) => [...policies, ...group.attributes.assigned_policies],
+          []
+        ) || [])
+      ])
+      
       membersDispatch({
         type: membersActions.SET_ACTIVE_USER,
-        payload: response.data
+        payload: activeUser
       })
     })
   }

--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -116,7 +116,7 @@ const ProjectSettings = ({ frontendSpec }) => {
     projectsIguazioApi.getActiveUser().then(response => {
       membersDispatch({
         type: membersActions.SET_ACTIVE_USER,
-        payload: response.data.data
+        payload: response.data
       })
     })
   }

--- a/src/components/ProjectSettings/projectSettings.util.js
+++ b/src/components/ProjectSettings/projectSettings.util.js
@@ -151,11 +151,7 @@ export const isProjectMembersTabShown = (
   }
 
   const userIsProjectSecurityAdmin =
-    (activeUser.data?.attributes?.assigned_policies?.includes('Project Security Admin') ||
-      activeUser.included?.some?.(group =>
-        group?.attributes?.assigned_policies?.includes('Project Security Admin')
-      )) ??
-    false
+    activeUser.data?.attributes?.user_policies_collection?.has('Project Security Admin') ?? false
   const userIsAdmin = members.some(
     member =>
       member.role === ADMIN_ROLE &&

--- a/src/components/ProjectSettings/projectSettings.util.js
+++ b/src/components/ProjectSettings/projectSettings.util.js
@@ -151,15 +151,21 @@ export const isProjectMembersTabShown = (
   }
 
   const userIsProjectSecurityAdmin =
-    activeUser.attributes?.assigned_policies?.includes('Project Security Admin') ?? false
+    (activeUser.data?.attributes?.assigned_policies?.includes('Project Security Admin') ||
+      activeUser.included?.some?.(group =>
+        group?.attributes?.assigned_policies?.includes('Project Security Admin')
+      )) ??
+    false
   const userIsAdmin = members.some(
     member =>
       member.role === ADMIN_ROLE &&
-      (member.id === activeUser.id ||
+      (member.id === activeUser.data?.id ||
         (member.type === USER_GROUP_ROLE &&
-          activeUser.relationships?.user_groups?.data?.some?.(group => group.id === member.id)))
+          activeUser.data?.relationships?.user_groups?.data?.some?.(
+            group => group.id === member.id
+          )))
   )
-  const userIsOwner = activeUser.id === projectInfo.owner.id
+  const userIsOwner = activeUser.data?.id === projectInfo.owner.id
 
   return userIsOwner || userIsAdmin || userIsProjectSecurityAdmin
 }


### PR DESCRIPTION
- **Project settings**: Group with 'Project security admin' policy cannot see members tab of projects
   Backported to `1.6.2` from #2360 
   Jira: https://iguazio.atlassian.net/browse/ML-6025