### PR TITLE
Fix [Project settings] "select new owner" does not return full list of users when there are 100+ users in system `1.6.x`

### DIFF
--- a/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
+++ b/src/elements/ChangeOwnerPopUp/ChangeOwnerPopUp.js
@@ -113,7 +113,8 @@ const ChangeOwnerPopUp = ({ changeOwnerCallback, projectId }) => {
 
   const generateSuggestionList = debounce(async (memberName, resolve) => {
     const params = {
-      'filter[assigned_policies]': '[$contains_any]Developer,Project Admin'
+      'filter[assigned_policies]': '[$contains_any]Developer,Project Admin',
+      'page[size]': 200
     }
     const requiredIgzVersion = '3.5.3'
     let formattedUsers = []


### PR DESCRIPTION
- **Project settings**: "select new owner" does not return full list of users when there are 100+ users in system
   Backported to `1.6.x` from #2372 
   Jira: https://iguazio.atlassian.net/browse/ML-6045