### PR TITLE
Fix [Projects, Monitoring container] Jobs with 'aborted' status are not accounted for any of the the counters statuses

### DIFF
--- a/src/utils/generateMonitoringData.js
+++ b/src/utils/generateMonitoringData.js
@@ -77,7 +77,9 @@ export const generateMonitoringGroupedData = (data, setData, handleDispatchData)
       element => element.status?.state === 'running' || element.state?.value === 'running'
     ),
     failed: data.filter(element =>
-      ['error', 'failed'].includes(element.status?.state || element.state?.value)
+      ['aborting', 'aborted', 'error', 'failed'].includes(
+        element.status?.state || element.state?.value
+      )
     ),
     completed: data.filter(
       element => element.status?.state === 'completed' || element.state?.value === 'completed'


### PR DESCRIPTION
**Projects, Monitoring container**: Jobs with 'aborted' status are not accounted for any of the the counters statuses
   Jira: [ML-6097](https://iguazio.atlassian.net/browse/ML-6097)

[ML-6097]: https://iguazio.atlassian.net/browse/ML-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ