### PR TITLE
Fix [Batch Run] Default artifact path not sourced from frontend-spec `1.6.x`

### DIFF
--- a/src/components/JobWizard/JobWizard.util.js
+++ b/src/components/JobWizard/JobWizard.util.js
@@ -163,7 +163,7 @@ export const generateJobWizardData = (
     },
     [ADVANCED_STEP]: {
       inputPath: null,
-      outputPath: JOB_DEFAULT_OUTPUT_PATH,
+      outputPath: frontendSpec.default_artifact_path || JOB_DEFAULT_OUTPUT_PATH,
       accessKey: true,
       accessKeyInput: '',
       environmentVariablesTable: parseEnvironmentVariables(environmentVariables)


### PR DESCRIPTION
- **Batch Run**: Default artifact path not sourced from frontend-spec
   Backported to `1.6.3` from #2385 
   Jira: https://iguazio.atlassian.net/browse/ML-6094