### PR TITLE
Fix [UI] Missing header columns in the artifacts preview screens

### DIFF
--- a/src/elements/PreviewModal/PreviewModal.js
+++ b/src/elements/PreviewModal/PreviewModal.js
@@ -62,6 +62,13 @@ const PreviewModal = ({ artifact }) => {
       <div className="item-artifacts__modal-preview">
         <div className="preview-body">
           <div className="preview-item">
+            <div className="item-data">Name</div>
+            <div className="item-data item-data__path">Path</div>
+            {(artifact.ui.size || artifact.size) && <div className="item-data">Size</div>}
+            <div className="item-data">Updated</div>
+            <div className="preview-body__download"></div>
+          </div>
+          <div className="preview-item">
             <div className="item-data item-data__name data-ellipsis">
               <Tooltip template={<TextTooltipTemplate text={artifact.db_key || artifact.key} />}>
                 {artifact.db_key || artifact.key}
@@ -78,8 +85,8 @@ const PreviewModal = ({ artifact }) => {
                 {artifact.ui.size
                   ? artifact.ui.size
                   : typeof artifact.size === 'string'
-                  ? artifact.size
-                  : prettyBytes(artifact.size)}
+                    ? artifact.size
+                    : prettyBytes(artifact.size)}
               </div>
             )}
             <div className="item-data">


### PR DESCRIPTION
- **UI**: Missing header columns in the artifacts preview screens
   Jira: [ML-5719](https://iguazio.atlassian.net/browse/ML-5719)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/3e1096dc-a3ab-414d-9bc5-2e4f60cbf352)

   After:
   <img width="1519" alt="Screenshot 2024-04-14 at 13 31 19" src="https://github.com/mlrun/ui/assets/63646693/715e9019-abd8-4dc1-93ec-ea4edeea73f2">


[ML-5719]: https://iguazio.atlassian.net/browse/ML-5719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ