### PR TITLE
Fix [Node Selector] Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "2.0.3",
+    "iguazio.dashboard-react-controls": "2.0.4",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
- **Node Selector**: Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func
   Depends On: https://github.com/iguazio/dashboard-react-controls/pull/270
   Jira: [ML-6303](https://iguazio.atlassian.net/browse/ML-6303)

[ML-6303]: https://iguazio.atlassian.net/browse/ML-6303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ