### PR TITLE
QA Sprint 163 done

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "body-parser": "^1.19.0",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "chai": "^4.3.4",
-    "chromedriver": "^122.0.0",
+    "chromedriver": "^123.0.0",
     "css-loader": "^6.5.1",
     "cucumber-html-reporter": "^5.3.0",
     "eslint": "^8.57.0",

--- a/tests/features/MLFunction.feature
+++ b/tests/features/MLFunction.feature
@@ -4,6 +4,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF005 - Check all mandatory components on ML Functions Page
         Given open url
@@ -35,6 +36,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF006 - Verify filtering by function name on Functions page
         Given open url
         And wait load page
@@ -59,6 +61,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF007 - Check all mandatory components in Item infopane on Overview tab table
         Given open url
         And wait load page
@@ -79,6 +82,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF008 - Verify all mandatory components on Delete existing function
         Given open url
         And wait load page
@@ -99,6 +103,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF009 - Verify all mandatory components on Delete existing function in Item infopane
         Given open url
         And wait load page
@@ -121,6 +126,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF003 - Check all mandatory components on Create ML Function Popup
         Given open url
@@ -151,6 +157,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF010 - Check all mandatory components in General Accordion on create New Function page
         Given open url
@@ -196,6 +203,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF011 - Check all mandatory components in Code Accordion on create New Function page
         Given open url
@@ -241,6 +249,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF012 - Check all mandatory components in Resources Accordion on create New Function page
         Given open url
@@ -331,6 +340,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF013 - Verify behaviour of Volume Paths Table in Resources Accordion on create New Function page
         Given open url
@@ -435,6 +445,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF014 - Check all mandatory components in Resources Accordion on create New Function page
         Given open url
@@ -558,6 +569,7 @@ Feature: ML Functions
         Then verify "Deploy_Button" element on "New_Function" wizard is disabled
 
     @MLF
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF015 - Save new ml-function
         * set tear-down property "function" created in "default" project with "new-aqa-function-00" value
@@ -628,6 +640,7 @@ Feature: ML Functions
         Then verify "GPU_Limit_Number_Input" input should contains "15" value in "Resources_Accordion" on "New_Function" wizard
 
     @MLF
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF016 - Deploy new ml-function with build new image option
         Given open url
@@ -656,6 +669,7 @@ Feature: ML Functions
         Then check "new-aqa-function-01" value in "name" column in "Functions_Table" table on "ML_Functions" wizard
 
     @MLF
+    @smoke
     Scenario: MLF017 - Delete ml-function
         * set tear-down property "function" created with "new-aqa-function-01" value
         * set tear-down property "project" created with "automation-test-name07" value
@@ -677,6 +691,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF018 - Check all mandatory components in Serving Runtime Configuration Accordion on create New Serving Function page
         Given open url
@@ -709,6 +724,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF019 - Check Model Table in Serving Runtime Configuration Accordion on create New Serving Function page
         Given open url
@@ -780,6 +796,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF020 - Check Secret Table in Serving Runtime Configuration Accordion on create New Serving Function page
         Given open url
@@ -836,6 +853,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF021 - Check Parameters Table in Serving Runtime Configuration Accordion on create New Serving Function page
         Given open url
@@ -903,6 +921,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF022 - Verify non-unique value input hint on Create New Function page
         Given open url
@@ -930,6 +949,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF023 - Verify non-unique value input hint on Create New Serving Function page
         Given open url
@@ -976,6 +996,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF024 - Check MLRun logo redirection
         Given open url
         And wait load page
@@ -991,6 +1012,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF025 - Verify View YAML action
         Given open url
         And wait load page
@@ -1013,6 +1035,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     Scenario: MLF026 - Verify View YAML action in Item infopane
         Given open url
         And wait load page
@@ -1031,6 +1054,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF027 - Verify Edit action visibility in action menu
         Given open url
@@ -1049,6 +1073,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF028 - Verify Edit action visibility in Item infopane for Job function
         Given open url
@@ -1067,6 +1092,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF029 - Verify Edit action visibility in Item infopane for Serving function
         Given open url
@@ -1086,6 +1112,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF030 - Verify all mandatory component on Edit Function sidebar
         * set tear-down property "project" created with "automation-test" value
@@ -1155,6 +1182,7 @@ Feature: ML Functions
         Then "Deploy_Button" element on "New_Function" should contains "Create" value
 
     @MLF
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF033 - Verify Resources values on Function Deploy and Run
         * set tear-down property "project" created with "automation-test" value
@@ -1208,6 +1236,7 @@ Feature: ML Functions
         Then verify "GPU_Limit_Number_Input" input should contains "99" value in "Resources_Accordion" on "Modal_Wizard_Form" wizard
 
     @MLF
+    @smoke
     Scenario: MLF032 - Check broken link redirection
         Given open url
         And wait load page
@@ -1231,6 +1260,7 @@ Feature: ML Functions
         Then verify redirection from "projects/default/INVALID/85957751e571a92e07213781f5e0c35bfbe42c64/overview" to "projects"
 
     @MLF
+    @smoke
     Scenario: MLF031 - Check active/highlited items with details panel on ML Function Info Pane
         Given open url
         And wait load page
@@ -1260,6 +1290,7 @@ Feature: ML Functions
         Then compare "Header" element value on "ML_Function_Info_Pane" wizard with test "name" context value
 
     @MLF
+    @smoke
     #TODO: ML-5137 - move create/edit 'function panel' to UI Demo mode
     Scenario: MLF002 - Check requirements field in Code Accordion on Create New Function page
         Given open url
@@ -1298,6 +1329,7 @@ Feature: ML Functions
 
     @MLF
     @passive
+    @smoke
     #TODO: ML-5718 - move 'Deploy' button for "Serving" function to demo mode
     Scenario: MLF034 - Verify Deploy option for serving kind functions
         Given open url

--- a/tests/features/artifacts.feature
+++ b/tests/features/artifacts.feature
@@ -4,6 +4,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA001 - Check all mandatory components on Artifacts tab
     Given open url
     And wait load page
@@ -35,6 +36,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA002 - Verify filtering by file name on Artifacts page
     Given open url
     And wait load page
@@ -61,6 +63,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA003 - Verify filtering by file label on Artifacts page
     Given open url
     And wait load page
@@ -87,6 +90,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA004 - Verify behaviour of Show iterations checkbox on Artifacts tab
     Given open url
     And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -102,7 +106,7 @@ Feature: Files Page
     And wait load page
     Then click on "Table_FilterBy_Button" element on "Files" wizard
     Then "Show_Iterations_Checkbox" element should be unchecked on "Artifacts_FilterBy_Popup" wizard
-    Then check "expand_btn" visibility in "Files_Table" on "Files" wizard
+    Then check "expand_btn" visibility in "Files_Table" on "Files" wizard with 0 offset
     Then click on cell with row index 1 in "expand_btn" column in "Files_Table" table on "Files" wizard
     And wait load page
     Then click on cell with row index 1 in "name" column in "Files_Table" table on "Files" wizard
@@ -119,6 +123,9 @@ Feature: Files Page
   @MLA
   @passive
   @inProgress
+  @FAILED_TODO
+  @smoke
+  #TODO: bug - Back and forward browser navigation does not automatically close the form  ML-6239
   Scenario: MLA005 - Check all mandatory components on Register Artifacts Popup
     Given open url
     And wait load page
@@ -195,6 +202,7 @@ Feature: Files Page
     Then verify "Title" element not exists on "Register_File_Popup" wizard
 
   @MLA
+  @smoke
   Scenario: MLA006 - Verify behaviour on Register new Artifact
     * set tear-down property "project" created with "automation-test" value
     * create "automation-test" MLRun Project with code 201
@@ -213,8 +221,7 @@ Feature: Files Page
     Then select "Table" option in "New_File_Type_Dropdown" dropdown on "Register_File_Popup" wizard
     Then click on "Register_Button" element on "Register_File_Popup" wizard
     And wait load page
-    Then value in "name" column with "text" in "Files_Table" on "Files" wizard should contains "test-artifact"
-    Then value in "type" column with "text" in "Files_Table" on "Files" wizard should contains "table"
+    Then value in "n" column with "text" in "Files_Table" on "Files" wizard should contains "table"
     Then click on cell with value "test-artifact" in "name" column in "Files_Table" table on "Files" wizard
     Then "Header" element on "Files_Info_Pane" should contains "test-artifact" value
     Then check "test-artifact" value in "key" column in "Overview_Table" table on "Files_Info_Pane" wizard
@@ -226,11 +233,21 @@ Feature: Files Page
     When select "V3IO" option in "Path_Scheme_Combobox" combobox on "Target_Path" accordion on "Register_Dataset" wizard
     When type value "target/path" to "Path_Scheme_Combobox" field on "Target_Path" on "Register_Dataset" wizard
     Then click on "Register_Button" element on "Register_File_Popup" wizard
-    Then "Register_Error_Message" component on "Register_File_Popup" should be equal "Register_Artifact"."Register_Error_Message"
+    Then verify if "Confirm_Popup" popup dialog appears
+    Then "Title" element on "Confirm_Popup" should contains "Overwrite artifact?" value
+    Then verify "Cross_Cancel_Button" element visibility on "Confirm_Popup" wizard
+    Then verify "Confirm_Dialog_Message" element visibility on "Confirm_Popup" wizard
+    Then "Confirm_Dialog_Message" component on "Confirm_Popup" should be equal "Register_Artifact"."Register_Error_Message"
+    Then verify "Cancel_Button" element visibility on "Confirm_Popup" wizard
+    Then "Cancel_Button" element on "Confirm_Popup" should contains "Cancel" value
+    Then verify "Overwrite_Button" element visibility on "Confirm_Popup" wizard
+    Then "Overwrite_Button" element on "Confirm_Popup" should contains "Overwrite" value
+    When click on "Cancel_Button" element on "Confirm_Popup" wizard
 
   @MLA
   @passive
   @inProgress
+  @smoke
   Scenario: MLA007 - Check all mandatory components in Item infopane on Overview tab table
     Given open url
     And wait load page
@@ -274,6 +291,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA013 - Check Details panel still active on page refresh
     * set tear-down property "project" created with "automation-test" value
     * set tear-down property "file" created in "automation-test" project with "test-file" value
@@ -311,6 +329,7 @@ Feature: Files Page
   @MLA
   @passive
   @inProgress
+  @smoke
   Scenario: MLA016 - Check all mandatory components in Item infopane on Preview tab table
     Given open url
     And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -336,9 +355,10 @@ Feature: Files Page
     Then verify "Pop_Out_Button" element visibility on "Files_Info_Pane" wizard 
     Then click on "Pop_Out_Button" element on "Files_Info_Pane" wizard
     And wait load page
-    Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+    Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
     Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
-    Then check "download_btn" visibility in "Preview_Header" on "Artifact_Preview_Popup" wizard
+    Then verify "Preview_Header" on "Artifact_Preview_Popup" wizard should contains "Preview_Pop_Up"."Table_Header"
+    Then check "download_btn" visibility in "Preview_Row" on "Artifact_Preview_Popup" wizard with 1 offset
     Then click on "Download_Button" element on "Artifact_Preview_Popup" wizard
     And wait load page
     And wait load page
@@ -354,6 +374,7 @@ Feature: Files Page
 #    TO DO: should be implemented mock requests
 
   @MLA
+  @smoke
   Scenario: MLA022 - Verify the Delete option state in Artifacts table and Overview details action menu 
     Given open url
     And wait load page
@@ -407,6 +428,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA018 - Check MLRun logo redirection
     Given open url
     And wait load page
@@ -422,6 +444,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA014 - Verify action menu list, Downloads action,  View YAML action
     Given open url
     And wait load page
@@ -460,6 +483,7 @@ Feature: Files Page
 
   @MLA
   @passive
+  @smoke
   Scenario: MLA015 - Verify Preview option, view Preview action
       Given open url
       And wait load page
@@ -491,6 +515,7 @@ Feature: Files Page
       
   @MLA
   @passive
+  @smoke
   Scenario: MLA019 - Verify View YAML action in Item infopane
     Given open url
     And wait load page
@@ -508,6 +533,7 @@ Feature: Files Page
     Then verify "YAML_Modal_Container" element visibility on "View_YAML" wizard
 
   @MLA 
+  @smoke
   Scenario: MLA020 - Check broken link redirection
     Given open url
     And wait load page
@@ -560,6 +586,7 @@ Feature: Files Page
     Then compare "Header" element value on "Files_Info_Pane" wizard with test "name" context value
 
   @MLA
+  @smoke
   Scenario: MLA009 - Check that version tag is filled when edit it in table view and full view on Overview tab table on Artifacts page
     Given open url
     And wait load page
@@ -584,6 +611,7 @@ Feature: Files Page
     Then verify "Cross_Close_Button" element visibility on "Files_Info_Pane" wizard
 
   @MLA
+  @smoke
   Scenario: MLA010 - Check that version tag dropdown shows all tags on filters wizard on Artifacts page
     Given open url
     And wait load page
@@ -611,6 +639,7 @@ Feature: Files Page
     Then check "newTag" value in "tag" column in "Files_Table" table on "Files" wizard
 
   @MLA
+  @smoke
   Scenario: MLA011 - Check that version tag has "Click to add" status when it's empty after edited
     Given open url
     And wait load page
@@ -638,6 +667,7 @@ Feature: Files Page
     Then "Version_Tag_Input_Placeholder" element on "Files_Info_Pane" should contains "Click to add" value
 
   @MLA
+  @smoke
   Scenario: MLA012 - Check filter by "All" tag is performed when version tag was edited
     Given open url
     And wait load page

--- a/tests/features/common-tools/common-consts.js
+++ b/tests/features/common-tools/common-consts.js
@@ -141,7 +141,7 @@ module.exports = {
       'Version tag:',
       'Code origin:',
       'Updated:',
-      'Command:',
+      'Code Entry Point:',
       'Default handler:',
       'Image:',
       'Description:'
@@ -290,7 +290,7 @@ module.exports = {
       'Google storage',
       'Databricks filesystem'
     ],
-    Register_Error_Message: /That combination of (artifact|dataset) name and (artifact|dataset) tag is already in use\. Assign a unique combination of (artifact|dataset) name and (artifact|dataset) tag\./  
+    Register_Error_Message: /That combination of (artifact|dataset) name and (artifact|dataset) tag is already in use\. If you continue, the current (artifact|dataset) will be overwritten\./  
   },
   Register_Dataset: {
     Type_Options: ['General', 'Chart', 'Plot', 'Table'],
@@ -543,5 +543,8 @@ module.exports = {
     No_Datasets_data: 'No data matches the filter: "Version tag: latest, Labels: v3io_user=123, Show best iteration only: true"',
     No_Files_data: 'No data matches the filter: "Version tag: latest, Labels: v3io_user=123, Show best iteration only: true"',
     No_Models_data: 'No data matches the filter: "Version tag: latest, Labels: MY-KEY, Show best iteration only: true"'
+  },
+  Preview_Pop_Up: {
+    Table_Header: ['Name', 'Path', 'Size', 'Updated']
   }
 }

--- a/tests/features/common/page-objects.js
+++ b/tests/features/common/page-objects.js
@@ -45,7 +45,7 @@ module.exports = {
   Create_ML_Function_Popup: interactivePopup['createMLFunctionPopup'],
   Create_New_Project: interactivePopup['createNewProject'],
   Create_New_Secret_Popup: interactivePopup['createNewSecretPopup'],
-  Delete_Confirm_Popup: interactivePopup['deleteConfirmPopup'],
+  Confirm_Popup: interactivePopup['confirmPopup'],
   Datasets: featureStore['datasets'],
   Datasets_Info_Pane: infoPane['datasetsInfoPane'],
   Demo_Project: project['demoProject'],

--- a/tests/features/common/page-objects/info-pane.po.js
+++ b/tests/features/common/page-objects/info-pane.po.js
@@ -774,7 +774,7 @@ module.exports = {
     Overview_Table: commonTable(modelsOverviewTable),
     Info_Sources_Table: commonTable(filesInfoSourcesTable),
     Labels_Field: By.css(
-      '.item-info__details .details-item:nth-of-type(2) .button-add-density_dense'
+      '.item-info__details-wrapper .details-item:nth-of-type(15) .button-add-density_dense'
     ),
     Labels_Table: commonTable(featureSetsInfoPaneLabelsTable),
     Apply_Button: By.css('.item-info__details .round-icon-cp:nth-of-type(2) button'),

--- a/tests/features/common/page-objects/interactive-popup.po.js
+++ b/tests/features/common/page-objects/interactive-popup.po.js
@@ -116,7 +116,7 @@ const deployModelTable = {
   }
 }
 
-const artifactsPreviewHeader = {
+const artifactsPreviewRow = {
   root: '.pop-up-dialog .preview-body',
   header: {
     root: '',
@@ -131,6 +131,20 @@ const artifactsPreviewHeader = {
         size: '.item-data:nth-of-type(3)',
         data: '.item-data:nth-of-type(4)',
         download_btn: '.preview-body__download'
+      }
+    }
+  }
+}
+
+const artifactsPreviewHeader = {
+  root: '.pop-up-dialog',  
+  header: {},
+  body: {
+    root: '.preview-body', 
+    row: {
+      root: '.preview-item:nth-of-type(1)',
+      fields: {
+        key: '.item-data'
       }
     }
   }
@@ -569,7 +583,7 @@ const runDetailsLabelsTable = {
         value_input: 'input.input-label-value',
         key_verify: '.edit-chip-container input.input-label-key',
         value_verify: '.edit-chip-container input.input-label-value',
-        remove_btn: '.edit-chip__icon-close'
+        remove_btn: '.item-icon-close'
       }
     }
   }
@@ -670,7 +684,7 @@ module.exports = {
     Error_Message: By.css('.pop-up-dialog .error__message'),
     New_Project_Labels_Table: commonTable(newProjectLabelsTable),
     Add_Label_Button: By.css('.create-project-dialog .form-row:nth-of-type(4) .chips .chips-wrapper button'),
-    Close_Label_Button: By.css('.create-project-dialog .form-row:nth-of-type(4) .chips .chips-wrapper .edit-chip__icon-close'),
+    Close_Label_Button: By.css('.create-project-dialog .form-row:nth-of-type(4) .chips .chips-wrapper .item-icon-close'),
     Labels_Key: inputGroup(
       generateInputGroup(
         '.create-project-dialog .form-row:nth-of-type(4) .chips .chips-wrapper',
@@ -1277,18 +1291,19 @@ module.exports = {
     Cross_Cancel_Button: commonCrossCancelButton,
     YAML_Modal_Container: By.css('.pop-up-dialog .yaml-modal-container pre')
   },
-  deleteConfirmPopup: {
+  confirmPopup: {
     Title: By.css('.pop-up-dialog .pop-up-dialog__header'),
     Cross_Cancel_Button: commonCrossCancelButton,
     Confirm_Dialog_Message: By.css('.confirm-dialog .confirm-dialog__message'),
     Cancel_Button: By.css('.confirm-dialog .pop-up-dialog__btn_cancel'),
-    Delete_Button: By.css('.confirm-dialog .btn-danger')
+    Delete_Button: By.css('.confirm-dialog .btn-danger'),
+    Overwrite_Button: By.css('.confirm-dialog .btn-primary')
   },
   previewPopup:{
     Title: By.css('.pop-up-dialog .pop-up-dialog__header'),
     Cross_Cancel_Button: commonCrossCancelButton,
     Preview_Modal_Container: By.css('.pop-up-dialog .item-artifacts__modal-preview'),
-    Download_Button: By.css('.pop-up-dialog .preview-item .preview-body__download')
+    Download_Button: By.css('.pop-up-dialog .preview-item:nth-of-type(2) .preview-body__download')
   },
   changeProjectOwnerPopup: {
     Cross_Cancel_Button: commonCrossCancelButton,
@@ -1414,7 +1429,7 @@ module.exports = {
     Tag_Input: inputGroup(
       generateInputGroup('.pop-up-dialog [data-testid="tag-form-field-input"] .form-field__wrapper', true, '.form-field__warning svg', true)
     ),
-    Description_Input: textAreaGroup(generateTextAreaGroup('.pop-up-dialog .new-feature-vector__description-row .form-field__wrapper', '.text-area__counter')),
+    Description_Input: textAreaGroup(generateTextAreaGroup('.pop-up-dialog .new-feature-vector__description-row', '.form-field__counter')),
     Labels_Table: commonTable(createFeatureVectorLabelsTable),
     Cancel_Button: commonCancelButton,
     Create_Button: commonConfirmButton
@@ -1433,8 +1448,9 @@ module.exports = {
   },
   artifactPreviewPopup: {
     Cross_Cancel_Button: commonCrossCancelButton,
+    Preview_Row: commonTable(artifactsPreviewRow),
     Preview_Header: commonTable(artifactsPreviewHeader),
-    Download_Button: By.css('.pop-up-dialog .preview-body .preview-item .preview-body__download')
+    Download_Button: By.css('.pop-up-dialog .preview-body .preview-item:nth-of-type(2) .preview-body__download')
   },
   removeMemberPopup: {
     Title: By.css('.delete-member__pop-up .pop-up-dialog__header-text'),

--- a/tests/features/common/page-objects/models.po.js
+++ b/tests/features/common/page-objects/models.po.js
@@ -265,7 +265,7 @@ module.exports = {
     ),
     Table_Sort_By_Filter: dropdownComponent(
       generateDropdownGroup(
-        '.content__action-bar-wrapper .filters .select:nth-of-type(2)',
+        '.content__action-bar-wrapper .filters .filter-column:nth-of-type(2) .select',
         '.select__header',
         '.select__body .select__item',
         '.data-ellipsis .data-ellipsis'

--- a/tests/features/common/page-objects/project-settings.po.js
+++ b/tests/features/common/page-objects/project-settings.po.js
@@ -43,7 +43,7 @@ const labelsTable = {
   header: {},
   body: {
     root: '.chips-wrapper',
-    add_row_btn: 'button.button-add',
+    add_row_btn: '[data-testid="labels-add-chip"]',
     row: {
       root: '.chip-block',
       fields: {
@@ -51,7 +51,7 @@ const labelsTable = {
         value_input: 'input.input-label-value',
         key_verify: '.edit-chip-container input.input-label-key',
         value_verify: '.edit-chip-container input.input-label-value',
-        remove_btn: '.edit-chip__icon-close'
+        remove_btn: '.item-icon-close'
       }
     }
   }

--- a/tests/features/common/page-objects/project.po.js
+++ b/tests/features/common/page-objects/project.po.js
@@ -26,10 +26,8 @@ import {
   generateInputGroup,
   generateLabelGroup,
   generateDropdownGroup,
-  generateCheckboxGroup
 } from '../../common-tools/common-tools'
 import inputGroup from '../components/input-group.component'
-import checkboxComponent from '../components/checkbox.component'
 
 const createNewObject = dropdownComponent(
   generateDropdownGroup(
@@ -298,52 +296,6 @@ const shardLagsTable = {
   }
 }
 
-const advancedEnvironmentVariablesTable = {
-  root: '.wizard-form__content .form-table',
-  header: {},
-  body: {
-    add_row_btn: '.form-table__action-row button',
-    row: {
-      root: '.form-table__row',
-      fields: {
-        edit_btn: '.form-table__actions-cell .round-icon-cp:nth-of-type(1)',
-        apply_btn: '.form-table__actions-cell .round-icon-cp:nth-of-type(1)',
-        delete_btn: '.form-table__actions-cell .round-icon-cp:nth-of-type(2)',
-        discard_btn: '.form-table__actions-cell .round-icon-cp:nth-of-type(2)',
-        checkbox: '.form-field-checkbox input',
-        name_input: '.form-field-input input',
-        name_verify: '.form-table__cell_2',
-        type_dropdown: {
-          componentType: dropdownComponent,
-          structure: generateDropdownGroup(
-            '.form-table__cell_1 .form-field-select', 
-            '.form-field__icons', 
-            '.pop-up-dialog .options-list__body .select__item', 
-            false, 
-            false)  
-        },
-        type_dropdown_verify: '.form-table__cell_1 .data-ellipsis', 
-        value_input: '.form-table__cell_3 .form-field__control input',
-        value_verify: '.form-table__cell_3 .data-ellipsis',
-        value_input_key: '.form-table__cell_3 .form-field-input:nth-of-type(2) .form-field__control input' 
-      }
-    }
-  }
-}
-
-const commonAccessKeyCheckbox = checkboxComponent(
-  generateCheckboxGroup('.job-wizard__advanced .access-key-checkbox input', false, false, false)
-)
-
-const commonAccessKeyInput = inputGroup(
-  generateInputGroup(
-    '.align-stretch .form-field-input',
-    true,
-    false,
-    '.tooltip-wrapper svg'
-  )
-)
-
 module.exports = {
   project: {
     Create_New: createNewObject,
@@ -352,6 +304,7 @@ module.exports = {
       projectDashboardRealtimeFunctionsTable
     ),
     Jobs_And_Workflows: commonTable(projectJobsAndWorkflows),
+    Recent_text: By.css('.project-data-card .project-data-card__recent-text'), 
     See_All_Jobs_Link: By.css(
       '.project-data-card:nth-of-type(1) .project-data-card__see-all-link'
     ),

--- a/tests/features/common/page-objects/projects.po.js
+++ b/tests/features/common/page-objects/projects.po.js
@@ -132,7 +132,7 @@ module.exports = {
   },
   Monitoring_Jobs_Box:{
     Monitoring_Jobs_Box_Title: By.css('.projects-monitoring-stats .stats-card:nth-of-type(1) .stats-card__title'),
-    Filtering_Time_Period: By.css('.stats-card:nth-of-type(1) [data-testid="date-picker-input"]'),
+    Filtering_Time_Period: By.css('.stats-card:nth-of-type(1) .project-card__info'),
     Total_Counter_Title: By.css('.stats-card:nth-of-type(1) .stats-card__row:nth-of-type(2) .stats__subtitle'),
     Total_Counter_Number: By.css('.stats-card:nth-of-type(1) .stats-card__row:nth-of-type(2) .stats__counter'),
     Counter_Running_Status_Number: By.css('.stats-card:nth-of-type(1) .stats-card__row:nth-of-type(2) .projects-monitoring-legend__status .link:nth-of-type(1)'),
@@ -145,7 +145,7 @@ module.exports = {
   },
   Monitoring_Workflows_Box:{
     Monitoring_Workflows_Box_Title: By.css('.projects-monitoring-stats .stats-card:nth-of-type(2) .stats-card__title'),
-    Filtering_Time_Period: By.css('.stats-card:nth-of-type(2) [data-testid="date-picker-input"]'),
+    Filtering_Time_Period: By.css('.stats-card:nth-of-type(2) .project-card__info'),
     Total_Counter_Title: By.css('.stats-card:nth-of-type(2) .stats-card__row:nth-of-type(2) .stats__subtitle'),
     Total_Counter_Number: By.css('.stats-card:nth-of-type(2) .stats-card__row:nth-of-type(2) .stats__counter'),
     Counter_Running_Status_Number: By.css('.stats-card:nth-of-type(2) .stats-card__row:nth-of-type(2) .projects-monitoring-legend__status .link:nth-of-type(1)'),
@@ -158,7 +158,7 @@ module.exports = {
   },
   Monitoring_Scheduled_Box:{
     Monitoring_Scheduled_Box_Title: By.css('.projects-monitoring-stats .stats-card:nth-of-type(3) .stats-card__title'),
-    Filtering_Time_Period: By.css('.stats-card:nth-of-type(3) [data-testid="date-picker-input"]'),
+    Filtering_Time_Period: By.css('.stats-card:nth-of-type(3) .project-card__info'),
     Total_Job_Counter_Title: By.css('.stats-card:nth-of-type(3) .stats-card__row:nth-of-type(2) .stats-card__col:nth-of-type(1) .stats__subtitle'),
     Total_Workflows_Counter_Title: By.css('.stats-card:nth-of-type(3) .stats-card__row:nth-of-type(2) .stats-card__col:nth-of-type(2) .stats__subtitle'),
     Total_Job_Counter_Number: By.css('.stats-card:nth-of-type(3) .stats-card__row:nth-of-type(2) .stats-card__col:nth-of-type(1) .stats__counter'),

--- a/tests/features/datasets.feature
+++ b/tests/features/datasets.feature
@@ -4,6 +4,7 @@ Feature: Datasets Page
     
   @MLD
   @passive
+  @smoke
   Scenario: MLD001 - Check components on Datasets page
     Given open url
     And click on row root with value "getting-started-tutorial-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -45,6 +46,7 @@ Feature: Datasets Page
 
   @MLD
   @passive
+  @smoke
   Scenario: MLD002 - Verify behaviour of Show iterations checkbox on Datasets page
     Given open url
     And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -67,7 +69,7 @@ Feature: Datasets Page
     And wait load page
     Then click on "Table_FilterBy_Button" element on "Datasets" wizard
     Then "Show_Iterations_Checkbox" element should be unchecked on "Artifacts_FilterBy_Popup" wizard
-    Then check "expand_btn" visibility in "Datasets_Table" on "Datasets" wizard
+    Then check "expand_btn" visibility in "Datasets_Table" on "Datasets" wizard with 0 offset
     Then click on cell with row index 1 in "expand_btn" column in "Datasets_Table" table on "Datasets" wizard
     And wait load page
     Then click on cell with row index 2 in "name" column in "Datasets_Table" table on "Datasets" wizard
@@ -83,6 +85,7 @@ Feature: Datasets Page
 
   @MLD
   @passive
+  @smoke
   Scenario: MLD003 - Check all mandatory components in Item infopane on Overview tab table on Datasets page
     Given open url
     And wait load page
@@ -135,6 +138,7 @@ Feature: Datasets Page
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD005 - Check Details panel still active on page refresh
     * set tear-down property "dataset" created in "automation-test" project with "test-file" value
     * create "test-dataset" Dataset with "v1" tag in "default" project with code 200
@@ -169,6 +173,7 @@ Feature: Datasets Page
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD006 - Check all mandatory components on Register Dataset form
     Given open url
     And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -178,7 +183,7 @@ Feature: Datasets Page
     Then "Register_Dataset_Button" element on "Datasets" should contains "Register dataset" value
     Then click on "Register_Dataset_Button" element on "Datasets" wizard
     Then verify if "Register_Dataset" popup dialog appears
-                Then verify options in "Path_Scheme_Combobox" combobox in "Target_Path" on "Register_Dataset" wizard should contains "Register_Dataset"."Combobox_Options"
+    Then verify options in "Path_Scheme_Combobox" combobox in "Target_Path" on "Register_Dataset" wizard should contains "Register_Dataset"."Combobox_Options"
     Then navigate back
     Then verify "Title" element not exists on "Register_Dataset" wizard
     Then navigate forward
@@ -192,7 +197,7 @@ Feature: Datasets Page
     Then type value " " to "Name_Input" field on "Register_Dataset" wizard
     And wait load page
     Then verify "Name_Input" on "Register_Dataset" wizard should display options "Input_Hint"."Artifact_Name_Hint"
-                Then verify "Name_Input" options rules on form "Register_Dataset" wizard
+    Then verify "Name_Input" options rules on form "Register_Dataset" wizard
     When select "V3IO" option in "Path_Scheme_Combobox" combobox on "Target_Path" accordion on "Register_Dataset" wizard
     When type value "  " to "Path_Scheme_Combobox" field on "Target_Path" on "Register_Dataset" wizard
     Then verify "Path_Scheme_Combobox" element in "Target_Path" on "Register_Dataset" wizard should display warning "Input_Hint"."V3IO_Path_Hint"
@@ -240,6 +245,7 @@ Feature: Datasets Page
     Then verify "Title" element not exists on "Register_Dataset" wizard
   
   @MLD
+  @smoke
   Scenario: MLD007 - Verify behaviour on Register new Dataset
     Given open url
     And wait load page
@@ -267,11 +273,20 @@ Feature: Datasets Page
     When select "V3IO" option in "Path_Scheme_Combobox" combobox on "Target_Path" accordion on "Register_Dataset" wizard
     When type value "target/path" to "Path_Scheme_Combobox" field on "Target_Path" on "Register_Dataset" wizard
     Then click on "Register_Button" element on "Register_Dataset" wizard
-    And wait load page
-    Then "Register_Error_Message" component on "Register_Dataset" should be equal "Register_Artifact"."Register_Error_Message"
+    Then verify if "Confirm_Popup" popup dialog appears
+    Then "Title" element on "Confirm_Popup" should contains "Overwrite dataset?" value
+    Then verify "Cross_Cancel_Button" element visibility on "Confirm_Popup" wizard
+    Then verify "Confirm_Dialog_Message" element visibility on "Confirm_Popup" wizard
+    Then "Confirm_Dialog_Message" component on "Confirm_Popup" should be equal "Register_Artifact"."Register_Error_Message"
+    Then verify "Cancel_Button" element visibility on "Confirm_Popup" wizard
+    Then "Cancel_Button" element on "Confirm_Popup" should contains "Cancel" value
+    Then verify "Overwrite_Button" element visibility on "Confirm_Popup" wizard
+    Then "Overwrite_Button" element on "Confirm_Popup" should contains "Overwrite" value
+    When click on "Cancel_Button" element on "Confirm_Popup" wizard
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD014 - Check filtering by name on Datasets page
     Given open url
     And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -288,6 +303,7 @@ Feature: Datasets Page
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD004 - Verify filtering by label on Datasets page
     Given open url
     And wait load page
@@ -317,6 +333,7 @@ Feature: Datasets Page
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD015 - Verify action menu list, Downloads action,  View YAML action
     Given open url
     And wait load page
@@ -353,6 +370,7 @@ Feature: Datasets Page
     Then verify "YAML_Modal_Container" element visibility on "View_YAML" wizard
 
   @MLD
+  @smoke
   Scenario: MLD018 - Verify the Delete option state in Datasets table and Overview details action menu 
     Given open url
     And wait load page
@@ -387,6 +405,7 @@ Feature: Datasets Page
   
   @MLD
   @passive
+  @smoke
   Scenario: MLD013 - Check components on Artifact Preview on Datasets page
     Given open url
     And wait load page
@@ -397,9 +416,9 @@ Feature: Datasets Page
     Then hover on cell with row index 2 in "name" column in "Datasets_Table" table on "Datasets" wizard
     When click on cell with row index 2 in "artifact_preview_btn" column in "Datasets_Table" table on "Datasets" wizard
     And wait load page
-    Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+    Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
     Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
-    Then check "download_btn" visibility in "Preview_Header" on "Artifact_Preview_Popup" wizard
+    Then check "download_btn" visibility in "Preview_Row" on "Artifact_Preview_Popup" wizard with 1 offset
     Then click on "Download_Button" element on "Artifact_Preview_Popup" wizard
     And wait load page
     And wait load page
@@ -417,9 +436,9 @@ Feature: Datasets Page
     Then verify "Pop_Out_Button" element visibility on "Datasets_Info_Pane" wizard 
     Then click on "Pop_Out_Button" element on "Datasets_Info_Pane" wizard
     And wait load page
-    Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+    Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
     Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
-    Then check "download_btn" visibility in "Preview_Header" on "Artifact_Preview_Popup" wizard
+    Then check "download_btn" visibility in "Preview_Row" on "Artifact_Preview_Popup" wizard with 1 offset
     Then click on "Download_Button" element on "Artifact_Preview_Popup" wizard
     And wait load page
     And wait load page
@@ -432,7 +451,8 @@ Feature: Datasets Page
     Then click on "Download_Pop_Up_Cross_Cancel_Button" element on "Downloads_Popup" wizard
     Then click on "Cross_Cancel_Button" element on "Artifact_Preview_Popup" wizard
   
-  @MLD 
+  @MLD
+  @smoke 
   Scenario: MLD016 - Check broken link redirection
     Given open url
     And wait load page
@@ -482,6 +502,7 @@ Feature: Datasets Page
     Then compare "Header" element value on "Datasets_Info_Pane" wizard with test "name" context value
   
   @MLD
+  @smoke
   Scenario: MLD009 - Check that version tag is filled when edit it in table view and full view on Overview tab table on Datasets page
     Given open url
     And wait load page
@@ -506,6 +527,7 @@ Feature: Datasets Page
     Then verify "Cross_Close_Button" element visibility on "Datasets_Info_Pane" wizard
 
   @MLD
+  @smoke
   Scenario: MLD010 - Check that version tag dropdown shows all tags on filters wizard on Datasets page
     Given open url
     And wait load page
@@ -533,6 +555,7 @@ Feature: Datasets Page
     Then check "newTag" value in "tag" column in "Datasets_Table" table on "Datasets" wizard
 
   @MLD
+  @smoke
   Scenario: MLD011 - Check that version tag has "Click to add" status when it's empty after edited
     Given open url
     And wait load page
@@ -560,6 +583,7 @@ Feature: Datasets Page
     Then "Version_Tag_Input_Placeholder" element on "Datasets_Info_Pane" should contains "Click to add" value
 
   @MLD
+  @smoke
   Scenario: MLD012 - Check filter by "All" tag is performed when version tag was edited
     Given open url
     And wait load page
@@ -589,6 +613,7 @@ Feature: Datasets Page
     Then compare "Header" element value on "Datasets_Info_Pane" wizard with test "name" context value
 
   @MLD
+  @smoke
   Scenario: MLD019 - Check steps, buttons components on Train Model wizard
     Given open url
     And wait load page
@@ -719,6 +744,7 @@ Feature: Datasets Page
             | model_class           |                str                   |              |
 
   @MLD
+  @smoke
   Scenario: MLD020 - Check Run Details components on Train Model wizard
     Given open url
     And wait load page
@@ -761,6 +787,7 @@ Feature: Datasets Page
     Then "Image_Name_Text_Run_Details" component on "Modal_Wizard_Form" should contains "Modal_Wizard_Form"."Image_Name_Text"
 
   @MLD
+  @smoke
   Scenario: MLD021 - Check Data Inputs components on Train Model wizard
     Given open url
     And wait load page
@@ -815,6 +842,7 @@ Feature: Datasets Page
             | name2edited |         v3io:///container-name/fileedited             |
 
   @MLD
+  @smoke
   Scenario: MLD022 - Check Parameters components on Train Model wizard
     Given open url
     And wait load page
@@ -890,8 +918,11 @@ Feature: Datasets Page
             | name2edited           |                int                   |     1234     |
 
   @MLD
+  @smoke
   Scenario: MLD023 - Check Resources components on Train Model wizard
     Given open url
+    And wait load page
+    Then turn Off MLRun CE mode
     And wait load page
     And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
     And wait load page
@@ -1029,6 +1060,7 @@ Feature: Datasets Page
     When click on "Delete_New_Row_Button" element in "Resources_Accordion" on "Modal_Wizard_Form" wizard
 
   @MLD
+  @smoke
   Scenario: MLD024 - Check Advanced components on Train Model wizard
     Given open url
     And wait load page
@@ -1071,6 +1103,7 @@ Feature: Datasets Page
             |    name3    |        secret        | sectretName2:sectretKey2 |
 
   @MLD
+  @smoke
   Scenario: MLD025 - Check Hyperparameter strategy components on Train Model wizard
     Given open url
     And wait load page
@@ -1116,6 +1149,7 @@ Feature: Datasets Page
     Then "Teardown_Checkbox" element should be checked on "Modal_Wizard_Form" wizard
 
   @MLD
+  @smoke
   Scenario: MLD026 - Verify dataset elements visibility on Datasets Table with low number of rows
     Given open url
     And wait load page
@@ -1134,7 +1168,7 @@ Feature: Datasets Page
     Then select "All" option in "Table_Tree_Filter_Dropdown" dropdown on "Artifacts_FilterBy_Popup" wizard
     Then click on "Apply_Button" element on "Artifacts_FilterBy_Popup" wizard
     And wait load page
-    Then check "expand_btn" visibility in "Datasets_Table" on "Datasets" wizard
+    Then check "expand_btn" visibility in "Datasets_Table" on "Datasets" wizard with 0 offset
     Then verify that 9 row elements are displayed in "Datasets_Table" on "Datasets" wizard
     Then click on cell with row index 1 in "expand_btn" column in "Datasets_Table" table on "Datasets" wizard
     Then verify that 10 row elements are displayed in "Datasets_Table" on "Datasets" wizard
@@ -1154,6 +1188,7 @@ Feature: Datasets Page
   @MLD
   @inProgress
   @FAILED_TODO
+  @smoke
   #TODO: Bug ML-6022 - [Artifacts, Functions] selected item is missing from the list of visible items
 # Run this test case only on full screen
   Scenario: MLD027 - Verify dataset elements visibility on Datasets Table with high number of rows
@@ -1235,4 +1270,3 @@ Feature: Datasets Page
     Then verify that 20 row elements are displayed in "Datasets_Table" on "Datasets" wizard
     Then click on "Cross_Close_Button" element on "Datasets_Info_Pane" wizard
     And wait load page
-

--- a/tests/features/featureStore.feature
+++ b/tests/features/featureStore.feature
@@ -4,6 +4,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS001 - Check all mandatory components on Feature Store tab
         Given open url
         And wait load page
@@ -39,6 +40,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS002 - Check all mandatory components on Features tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -75,6 +77,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS003 - Check all mandatory components on Feature Vectors tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -101,6 +104,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS004 - Check all mandatory components in Item infopane on Overview tab table on Feature Sets tab
         Given open url
         And wait load page
@@ -172,6 +176,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS005 - Check all mandatory components in Item infopane on Overview tab table on Feature Vectors tab
         Given open url
         And wait load page
@@ -202,6 +207,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS006 - Check all mandatory components in Item infopane with non-latest tag on Overview tab table on Feature Vectors tab
         Given open url
         And wait load page
@@ -228,6 +234,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS007 - Check all mandatory components in Item infopane on Features tab table
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -251,6 +258,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS008 - Check all mandatory components in Item infopane on Transformations tab table
         Given open url
         And click on row root with value "fraud-demo2-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -275,6 +283,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS009 - Check all mandatory components in Item infopane on Preview tab table
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -298,6 +307,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS010 - Check all mandatory components in Item infopane on Statistics tab table
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -321,6 +331,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS011 - Check all mandatory components in Item infopane on Analysis tab table
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -343,6 +354,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS012 - Check filtering by Name on Feature Store Feature Sets Tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -361,6 +373,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS013 - Check filtering by Label on Feature Store Feature Sets Tab
         Given open url
         And wait load page
@@ -383,6 +396,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS014 - Check filtering by Name on Feature Store Features Tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -401,6 +415,7 @@ Feature: Feature Store Page
     
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS015 - Check filtering by Label on Feature Store Features Tab
         Given open url
         And wait load page
@@ -425,6 +440,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS016 - Check filtering by Name on Feature Store Feature Vectors Tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -440,6 +456,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS017 - Check filtering by Label on Feature Store Feature Vectors Tab
         Given open url
         And wait load page
@@ -464,6 +481,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS018 - Check filtering by Tag on Feature Store Feature Sets Tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -478,6 +496,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS019 - Check filtering by Tag on Feature Store Feature Vectors Tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -493,6 +512,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS020 - Check all mandatory components on Feature Store Feature Set new item wizard on Data Source Accordion Parquet Kind
         Given open url
         And wait load page
@@ -522,6 +542,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS021 - Verify behaviour of Combobox element on Feature Store Feature Set new item wizard on Data Source Accordion
         Given open url
         And wait load page
@@ -564,6 +585,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS022 - Check all mandatory components on Schedule popup on Feature Store Feature Set new item wizard on Data Source Accordion Parquet Kind
         Given open url
         And wait load page
@@ -606,6 +628,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS023 - Check all mandatory components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -658,6 +681,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS024 - Check Input and Dropdown components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -682,6 +706,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS025 - Check Input and Dropdown components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -699,6 +724,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS026 - Check Schema Accordion components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -723,6 +749,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS027 - Check Target Store Accordion components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -791,6 +818,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS028 - Verify behaviour of Online and Offline Target store on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -856,6 +884,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS029 - Check Partition part in Target Store Accordion components on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -899,6 +928,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS030 - Test rows Labels on Feature Store Feature Set new item wizard
         Given open url
         And wait load page
@@ -929,6 +959,7 @@ Feature: Feature Store Page
 
     @MLFS
     @inProgress
+    @smoke
     Scenario: MLFS031 - Save new Feature Store Feature Set new item wizard
         * set tear-down property "project" created with "automation-test-name3" value
         * create "automation-test-name3" MLRun Project with code 201
@@ -980,6 +1011,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS032 - Check expand button on Feature Store tab when change tag from "latest"
         Given open url
         And wait load page
@@ -997,7 +1029,7 @@ Feature: Feature Store Page
         Then verify "Features" tab is active in "Feature_Store_Tab_Selector" on "Feature_Store_Feature_Sets_Tab" wizard
         Then check "expand_btn" not presented in "Features_Table" on "Feature_Store_Features_Tab" wizard
         When select "All" option in "Table_Tag_Filter_Dropdown" dropdown on "Feature_Store_Features_Tab" wizard
-        Then check "expand_btn" visibility in "Features_Table" on "Feature_Store_Features_Tab" wizard
+        Then check "expand_btn" visibility in "Features_Table" on "Feature_Store_Features_Tab" wizard with 0 offset
         When select "my-tag" option in "Table_Tag_Filter_Dropdown" dropdown on "Feature_Store_Features_Tab" wizard
         Then check "expand_btn" not presented in "Features_Table" on "Feature_Store_Features_Tab" wizard
         When select "Feature Vectors" tab in "Feature_Store_Tab_Selector" on "Feature_Store_Feature_Sets_Tab" wizard
@@ -1005,12 +1037,13 @@ Feature: Feature Store Page
         Then verify "Feature Vectors" tab is active in "Feature_Store_Tab_Selector" on "Feature_Store_Feature_Sets_Tab" wizard
         Then check "expand_btn" not presented in "Feature_Vectors_Table" on "Feature_Store_Features_Vectors_Tab" wizard
         When select "All" option in "Table_Tag_Filter_Dropdown" dropdown on "Feature_Store_Features_Vectors_Tab" wizard
-        Then check "expand_btn" visibility in "Feature_Vectors_Table" on "Feature_Store_Features_Vectors_Tab" wizard
+        Then check "expand_btn" visibility in "Feature_Vectors_Table" on "Feature_Store_Features_Vectors_Tab" wizard with 0 offset
         When select "test-tag" option in "Table_Tag_Filter_Dropdown" dropdown on "Feature_Store_Features_Vectors_Tab" wizard
         Then check "expand_btn" not presented in "Feature_Vectors_Table" on "Feature_Store_Features_Vectors_Tab" wizard
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS033 - Check MLRun logo redirection
         Given open url
         And wait load page
@@ -1025,6 +1058,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS034 - Verify View YAML action on Feature Sets tab
         Given open url
         And wait load page
@@ -1047,6 +1081,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS035 - Verify View YAML action on Features tab
         Given open url
         And wait load page
@@ -1065,6 +1100,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @inProgress
+    @smoke
     Scenario: MLFS036 - Verify View YAML action on Feature Vectors tab
         Given open url
         And wait load page
@@ -1090,6 +1126,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS037 - Verify View YAML action in Item infopane on Feature Sets tab
         Given open url
         And wait load page
@@ -1107,6 +1144,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS038 - Check all mandatory components on Add to feature vector popup
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1132,6 +1170,7 @@ Feature: Feature Store Page
     @MLFS
     @passive
     @FAILED_TODO
+    @smoke
     #TODO: Bug ML-6142 - [Feature Vectors] Unify the conditions for the 'Tag' field
     Scenario: MLFS039 - Check all mandatory components on Create feature vector popup
         Given open url
@@ -1186,6 +1225,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     #TODO: add check tag validation rules after fixing bug ML-6142
     Scenario: MLFS040 - Check all mandatory components on Edit feature vector Popup
         Given open url
@@ -1226,6 +1266,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS041 - Check all mandatory components on Add to feature vector tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1265,6 +1306,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS042 - Verify filtering by name and entity on Add to feature vector tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1293,7 +1335,7 @@ Feature: Feature Store Page
 
     @MLFS
     @inProgress
-    #@uniqueTag
+    @smoke
     Scenario: MLFS043 - Add to feature vector
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1366,6 +1408,7 @@ Feature: Feature Store Page
         Then value in "description" column with "text" in "Feature_Vectors_Table" on "Feature_Store_Features_Vectors_Tab" wizard should contains "Automation test description"
 
     @MLFS
+    @smoke
     Scenario: MLFS044 - Check all mandatory components in Item infopane on Requested Features tab on Feature Vectors tab
         Given open url
         And click on row root with value "fsdemo-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1460,7 +1503,8 @@ Feature: Feature Store Page
         Then verify "Apply_Changes_Button" element visibility on "Feature_Vectors_Info_Pane" wizard
         Then "Apply_Changes_Button" element on "Feature_Vectors_Info_Pane" should contains "Apply Changes" value
 
-    @MLFS  
+    @MLFS
+    @smoke  
     Scenario: MLFS045 - Verify Feature Label icon on Requested Features tab on Feature Vectors tab
         And set tear-down property "featureVector" created in "default" project with "test_vector" value
         Given open url
@@ -1492,6 +1536,7 @@ Feature: Feature Store Page
         Then value in "labelIcon" column with "tooltip" in "Requested_Features_Table" on "Requested_Features_Info_Pane" wizard should contains "Label column"
 
     @MLFS
+    @smoke
     Scenario: MLFS046 - Verify No Data message on Feature Store tabs
         * set tear-down property "project" created with "automation-test-name001" value
         * create "automation-test-name001" MLRun Project with code 201
@@ -1529,6 +1574,7 @@ Feature: Feature Store Page
         Then "No_Data_Message" component on "commonPagesHeader" should contains "No_Data_Message"."No_Data"
 
     @MLFS
+    @smoke
     Scenario: MLFS047 - Check broken link redirection
         * set tear-down property "project" created with "automation-test-010" value
         * create "automation-test-010" MLRun Project with code 201
@@ -1631,6 +1677,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS050 - Save feature set with compleated target store components and passthrough checkbox by default
         Given open url
         And wait load page
@@ -1668,6 +1715,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS051 - Save feature set with checked passthrough checkbox and unchecked TARGET STORE Online checkbox
         Given open url
         And wait load page
@@ -1706,6 +1754,7 @@ Feature: Feature Store Page
     
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS052 - Save feature set with checked passthrough checkbox and checked TARGET STORE Online checkbox
         Given open url
         And wait load page
@@ -1746,6 +1795,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS053 - Impossibility to save feature set with unchecked target store components
         Given open url
         And wait load page
@@ -1815,6 +1865,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS054 - Impossibility to save feature set without input mandatory Timestamp Key field
         Given open url
         And wait load page
@@ -1871,6 +1922,7 @@ Feature: Feature Store Page
 
     @MLFS
     @passive
+    @smoke
     Scenario: MLFS055 - Impossibility to save feature set without input 'Feature Set Name', 'URL', 'Entities' fields
         Given open url
         And wait load page
@@ -1937,6 +1989,7 @@ Feature: Feature Store Page
         # Then check "automation-test-name201" value not in "name" column in "Projects_Table" table on "Projects" wizard
 
     @MLFS
+    @smoke
     Scenario: MLFS059 - Check type Redis in online types of Target Store section of Create Set 
         Given open url
         And wait load page

--- a/tests/features/jobsAndWorkflows.feature
+++ b/tests/features/jobsAndWorkflows.feature
@@ -4,6 +4,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW001 - Check all mandatory components on Jobs Monitor tab
         Given open url
         And wait load page
@@ -46,6 +47,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW002 - Check all mandatory components on Workflows Monitor tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -71,6 +73,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW003 - Check all mandatory components on Schedule Monitor tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -95,6 +98,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW004 - Check date picker dropdown options on Jobs Monitor tab
         Given open url
         And wait load page
@@ -119,6 +123,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW005 - Verify date picker element on Jobs Monitor tab
         Given open url
         And wait load page
@@ -140,6 +145,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW006 - Verify filtering by job name on Jobs Monitor tab
         Given open url
         And wait load page
@@ -157,6 +163,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW007 - Verify filtering by job name on Schedule Monitor tab
         Given open url
         And wait load page
@@ -176,6 +183,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW008 - Verify filtering by name on Workflows Monitor tab
         Given open url
         And wait load page
@@ -199,6 +207,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW009 - Verify filtering by job label with key on Jobs Monitor tab
         Given open url
         And wait load page
@@ -226,6 +235,7 @@ Feature: Jobs and workflows
     @MLJW
     @passive
     @inProgress
+    @smoke
     Scenario: MLJW010 - Verify filtering by job label with key on Schedule tab
         Given open url
         And wait load page
@@ -249,6 +259,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW011 - Verify filtering by job status on Jobs Monitor tab
         Given open url
         And wait load page
@@ -276,6 +287,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW062 - Verify filtering Jobs after opening Batch Re-run wizard
         Given open url
         And wait load page
@@ -300,6 +312,7 @@ Feature: Jobs and workflows
     @MLJW
     @passive
     @inProgress
+    @smoke
     Scenario: MLJW064 - Verify filtering by starttime on Jobs Monitor tab
         Given open url
         And wait load page
@@ -354,6 +367,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW058 - Check all mandatory components in Item infopane on Overview tab table on Jobs Monitor Page
         Given open url
         And wait load page
@@ -388,6 +402,7 @@ Feature: Jobs and workflows
         Then verify from "01/01/2021 00:00" to "01/01/2023 00:00" filter band in "Start_Time_Filter_Dropdown" filter dropdown on "Jobs_Monitor_Tab" wizard
 
     @MLJW
+    @smoke
     Scenario: MLJW059 - Check Action menu options on Job table and Overview Job tab table on Jobs Monitor Page
         Given open url
         And wait load page
@@ -414,6 +429,7 @@ Feature: Jobs and workflows
         Then verify "Overview_Headers" on "Jobs_Monitor_Tab_Info_Pane" wizard should contains "Jobs_Monitor_Tab_Info_Pane"."Overview_Headers"
 
     @MLJW
+    @smoke
     Scenario: MLJW061 - Check confirmation message pop-up for Delete Job option in Action menu
         Given open url
         And wait load page
@@ -427,46 +443,47 @@ Feature: Jobs and workflows
         When select "Any time" option in "Start_Time_Filter_Dropdown" filter dropdown on "Jobs_Monitor_Tab" wizard
         Then select "Delete" option in action menu on "Jobs_Monitor_Tab" wizard in "Jobs_Monitor_Table" table at row with "test-m_ingest" value in "name" column
         And wait load page
-        Then verify if "Delete_Confirm_Popup" popup dialog appears
-        Then "Title" element on "Delete_Confirm_Popup" should contains "Delete job?" value
-        Then verify "Cross_Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Confirm_Dialog_Message" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Cancel_Button" element on "Delete_Confirm_Popup" should contains "Cancel" value
-        Then verify "Delete_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Delete_Button" element on "Delete_Confirm_Popup" should contains "Delete" value
-        When click on "Cancel_Button" element on "Delete_Confirm_Popup" wizard
+        Then verify if "Confirm_Popup" popup dialog appears
+        Then "Title" element on "Confirm_Popup" should contains "Delete job?" value
+        Then verify "Cross_Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then verify "Confirm_Dialog_Message" element visibility on "Confirm_Popup" wizard
+        Then verify "Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then "Cancel_Button" element on "Confirm_Popup" should contains "Cancel" value
+        Then verify "Delete_Button" element visibility on "Confirm_Popup" wizard
+        Then "Delete_Button" element on "Confirm_Popup" should contains "Delete" value
+        When click on "Cancel_Button" element on "Confirm_Popup" wizard
         When click on cell with row index 1 in "name" column in "Jobs_Monitor_Table" table on "Jobs_Monitor_Tab" wizard
         And wait load page
         Then verify options in action menu on "Jobs_Monitor_Tab" wizard in "Jobs_Monitor_Table" table with "Job" value in "type" column should contains "Jobs_And_Workflows"."Job_Action_Menu_Options"
         Then select "Delete" option in action menu on "Jobs_Monitor_Tab" wizard in "Jobs_Monitor_Table" table at row with "1b1097f5e1bf439f82b61910f03368ae" value in "name" column
         And wait load page
-        Then verify if "Delete_Confirm_Popup" popup dialog appears
-        Then "Title" element on "Delete_Confirm_Popup" should contains "Delete job?" value
-        Then verify "Cross_Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Confirm_Dialog_Message" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Cancel_Button" element on "Delete_Confirm_Popup" should contains "Cancel" value
-        Then verify "Delete_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Delete_Button" element on "Delete_Confirm_Popup" should contains "Delete" value
-        When click on "Cancel_Button" element on "Delete_Confirm_Popup" wizard
+        Then verify if "Confirm_Popup" popup dialog appears
+        Then "Title" element on "Confirm_Popup" should contains "Delete job?" value
+        Then verify "Cross_Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then verify "Confirm_Dialog_Message" element visibility on "Confirm_Popup" wizard
+        Then verify "Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then "Cancel_Button" element on "Confirm_Popup" should contains "Cancel" value
+        Then verify "Delete_Button" element visibility on "Confirm_Popup" wizard
+        Then "Delete_Button" element on "Confirm_Popup" should contains "Delete" value
+        When click on "Cancel_Button" element on "Confirm_Popup" wizard
         When click on cell with row index 1 in "name" column in "Jobs_Monitor_Table" table on "Jobs_Monitor_Tab" wizard
         And wait load page
         Then verify "Action_Menu" dropdown element on "Jobs_Monitor_Tab_Info_Pane" wizard should contains "Jobs_And_Workflows"."Job_Overview_Action_Menu_Options"
         Then select "Delete" option in action menu on "Jobs_Monitor_Tab_Info_Pane" wizard
         And wait load page
-        Then verify if "Delete_Confirm_Popup" popup dialog appears
-        Then "Title" element on "Delete_Confirm_Popup" should contains "Delete job?" value
-        Then verify "Cross_Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Confirm_Dialog_Message" element visibility on "Delete_Confirm_Popup" wizard
-        Then verify "Cancel_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Cancel_Button" element on "Delete_Confirm_Popup" should contains "Cancel" value
-        Then verify "Delete_Button" element visibility on "Delete_Confirm_Popup" wizard
-        Then "Delete_Button" element on "Delete_Confirm_Popup" should contains "Delete" value
-        When click on "Cancel_Button" element on "Delete_Confirm_Popup" wizard
+        Then verify if "Confirm_Popup" popup dialog appears
+        Then "Title" element on "Confirm_Popup" should contains "Delete job?" value
+        Then verify "Cross_Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then verify "Confirm_Dialog_Message" element visibility on "Confirm_Popup" wizard
+        Then verify "Cancel_Button" element visibility on "Confirm_Popup" wizard
+        Then "Cancel_Button" element on "Confirm_Popup" should contains "Cancel" value
+        Then verify "Delete_Button" element visibility on "Confirm_Popup" wizard
+        Then "Delete_Button" element on "Confirm_Popup" should contains "Delete" value
+        When click on "Cancel_Button" element on "Confirm_Popup" wizard
         
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW063 - Check all mandatory components in Item infopane on Logs tab table on Jobs Monitor Page
         Given open url
         And wait load page
@@ -491,6 +508,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW065 - Check all mandatory components in Item infopane on Artifacts tab on Jobs Monitor Page
         Given open url
         And wait load page
@@ -501,6 +519,8 @@ Feature: Jobs and workflows
         And wait load page
         Then verify "Monitor Jobs" tab is active in "Jobs_Tab_Selector" on "Jobs_Monitor_Tab" wizard
         When select "Any time" option in "Start_Time_Filter_Dropdown" filter dropdown on "Jobs_Monitor_Tab" wizard
+        Then select "Completed" option in "Status_Filter_Dropdown" filter dropdown on "Jobs_Monitor_Tab" wizard
+        And wait load page
         When click on cell with value "trainer-train" in "name" column in "Jobs_Monitor_Table" table on "Jobs_Monitor_Tab" wizard
         And wait load page
         When click on cell with row index 1 in "name" column in "Jobs_Monitor_Table" table on "Jobs_Monitor_Tab" wizard
@@ -513,7 +533,7 @@ Feature: Jobs and workflows
         Then click on cell with row index 1 in "name" column in "Artifacts_Table" table on "Artifacts_Info_Pane" wizard
         Then click on "Artifact_Preview_Button" element on "Artifacts_Info_Pane" wizard
         And wait load page
-        Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+        Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
         Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
         Then click on "Cross_Cancel_Button" element on "Artifact_Preview_Popup" wizard
         And wait load page
@@ -523,7 +543,7 @@ Feature: Jobs and workflows
         Then verify "Artifacts_Table" element visibility on "Artifacts_Info_Pane" wizard
         Then click on cell with row index 1 in "name" column in "Artifacts_Table" table on "Artifacts_Info_Pane" wizard
         Then click on "Artifact_Preview_Button" element on "Artifacts_Info_Pane" wizard
-        Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+        Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
         Then click on "Cross_Cancel_Button" element on "Artifact_Preview_Popup" wizard
         Then select "2" option in "Iterations_Dropdown" dropdown on "Artifacts_Info_Pane" wizard
         And wait load page
@@ -531,6 +551,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW066 - Check all mandatory components in Item infopane on Overview tab table on Schedule Page
         Given open url
         And wait load page
@@ -555,6 +576,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW067 - Verify all mandatory components on Delete existing scheduled job
         Given open url
         And wait load page
@@ -576,6 +598,7 @@ Feature: Jobs and workflows
         Then "Delete_Button" element on "Common_Popup" should contains "Delete" value
 
     @MLJW
+    @smoke
     Scenario: MLJW068 - Delete Scheduled Job
         Given open url
         And wait load page
@@ -1407,6 +1430,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW060 - Verify View YAML action on Jobs Monitor tab
         Given open url
         And wait load page
@@ -1436,6 +1460,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW069 - Verify View YAML action on Workflows Monitor tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1454,6 +1479,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW070 - Verify View YAML action on Schedule Monitor tab
         Given open url
         And wait load page
@@ -1479,6 +1505,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW071 - Check all mandatory components on Workflow List View
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1498,6 +1525,7 @@ Feature: Jobs and workflows
 
     @MLJW 
     @passive
+    @smoke
     Scenario: MLJW072 - Check all mandatory components on Overview tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1524,6 +1552,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW073 - Check all mandatory components on Logs tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1546,6 +1575,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW074 - Check all mandatory components on Inputs tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1567,6 +1597,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW075 - Check all mandatory components on Artifacts tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1588,6 +1619,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW076 - Check all mandatory components on Results tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1609,6 +1641,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW080 - Verify visibility of main components on Batch re-run Workflow wizard
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1679,6 +1712,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW082 - Check Artifacts preview action on Artifacts tab Item infopane on Workflow List View Tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1699,11 +1733,12 @@ Feature: Jobs and workflows
         Then click on cell with row index 1 in "name" column in "Artifacts_Table" table on "Artifacts_Info_Pane" wizard
         Then click on "Artifact_Preview_Button" element on "Artifacts_Info_Pane" wizard
         And wait load page
-        Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+        Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
         Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW057 - Check options in action menu on Jobs Monitor tab
         Given open url
         And wait load page
@@ -1728,6 +1763,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW077 - Check options in action menu on Workflows Monitor tab
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1743,6 +1779,7 @@ Feature: Jobs and workflows
 
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW078 - Check options in action menu on Schedule tab
         Given open url
         And wait load page
@@ -1759,6 +1796,7 @@ Feature: Jobs and workflows
         
     @MLJW
     @passive
+    @smoke
     Scenario: MLJW079 - Verify visibility of main components on Edit Scheduled Job wizard
         Given open url
         And wait load page
@@ -1823,6 +1861,7 @@ Feature: Jobs and workflows
     @MLJW
     #TODO: arrow lines position - y not found
     @passive
+    @smoke
     Scenario: MLJW081 - Check visibility of main components on Workflow graph View
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1852,6 +1891,7 @@ Feature: Jobs and workflows
     @MLJW
     @passive
     @links
+    @smoke
     Scenario: MLJW030 - Check redirect to project`s Function Infopane from Job Overview
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1912,6 +1952,7 @@ Feature: Jobs and workflows
 
 
     @MLJW
+    @smoke
     Scenario: MLJW083 - Check redirection to Last Run Drill-down from Schedules tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -1942,6 +1983,7 @@ Feature: Jobs and workflows
         And verify "No_Data_Message" element visibility on "commonPagesHeader" wizard
 
     @MLJW
+    @smoke
     Scenario: MLJW084 - Check redirection to Function details from Schedules tab
         Given open url
         And wait load page
@@ -1959,7 +2001,6 @@ Feature: Jobs and workflows
         Then compare current browser URL with test "href" context value
 
     @oldJobWizard
-    #@uniqueTag
     Scenario: Check messages when create a new Schedule
         Given open url
         And wait load page
@@ -2067,6 +2108,7 @@ Feature: Jobs and workflows
         Then verify "GPU_Limit_Number_Input" input should contains "" value in "Resources_Accordion" on "New_JobTemplate_Edit" wizard
 
     @MLJW
+    @smoke
     Scenario: MLJW085 - Check broken link redirection on Monitor Jobs and Schedules screens
         Given open url
         And wait load page
@@ -2109,6 +2151,7 @@ Feature: Jobs and workflows
         Then verify redirection from "projects/default/INVALID/monitor-jobs" to "projects"
 
     @MLJW
+    @smoke
     #TODO: getPipelines func - update with 'create at' filter
     #TODO: Bug ML-5787 - The 'Created At' filter doesn't keep the selected type
     Scenario: MLJW086 - Check broken link redirection on Monitor Workflows and Schedules screens
@@ -2155,6 +2198,9 @@ Feature: Jobs and workflows
         Then verify redirection from "projects/INVALID/jobs/monitor-workflows/workflow/eaae138e-439a-47fa-93c6-ba0fe1dc3b79/07f98fb46a424b2dbee5247b35f37727/overview" to "projects"
 
     @MLJW
+    @FAILED_TODO
+    @smoke
+    #TODO: [Batch Run] Unexpected Application Error screen ML-6250
     Scenario: MLJW012 - Check all mandatory components on Batch Run wizard - Function selection
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2241,6 +2287,7 @@ Feature: Jobs and workflows
         Then verify "Run_Button" element on "Modal_Wizard_Form" wizard is enabled
     
     @MLJW
+    @smoke
     Scenario: MLJW013 - Verify behaviour of Filter by category on Batch Run wizard - Function selection (Hub tab)
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2280,6 +2327,7 @@ Feature: Jobs and workflows
         Then value in "labels" column with "attribute" in "Functions_Table" on "Modal_Wizard_Form" wizard should contains "Utilities"
 
     @MLJW
+    @smoke
     Scenario: MLJW042 - Check all mandatory components on Batch Run wizard - Run Details without Method
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2341,6 +2389,7 @@ Feature: Jobs and workflows
             |    key2    |    value2    |
 
     @MLJW
+    @smoke
     Scenario: MLJW044 - Check "Max Iterations", "Max errors" inputs field availability according to the strategy type in Hyperparameter strategy
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2372,6 +2421,7 @@ Feature: Jobs and workflows
         Then verify "Max_Errors" element in "Hyperparameter_Strategy_Accordion" on "Modal_Wizard_Form" wizard is enabled by class name
 
     @MLJW
+    @smoke
     Scenario: MLJW051 - Check all mandatory components on Batch Run wizard - Run Details with Method
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2421,6 +2471,7 @@ Feature: Jobs and workflows
             |    key3    |    value3    |
 
     @MLJW
+    @smoke
     Scenario: MLJW053 - Check changing "Method" after "Hyperparameter" check in Run Details section of Batch Run
         Given open url
 	    And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2444,6 +2495,7 @@ Feature: Jobs and workflows
         Then "Method_Dropdown_Option" element on "Modal_Wizard_Form" should contains "plot_stat" value
 
     @MLJW
+    @smoke
     Scenario: MLJW054 - Check "Image name" field in Run Details section of Batch Run
         Given open url
 	    And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2465,6 +2517,7 @@ Feature: Jobs and workflows
         Then "Image_Name_Text_Run_Details" component on "Modal_Wizard_Form" should contains "Modal_Wizard_Form"."Image_Name_Text"
 
     @MLJW
+    @smoke
     Scenario: MLJW039 - Check all mandatory components on Batch Run wizard - Data Inputs
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2526,6 +2579,7 @@ Feature: Jobs and workflows
             | name2edited | v3io:///container-name/fileedited |
     
     @MLJW
+    @smoke
     Scenario: MLJW038 - Check all mandatory components on Batch Run wizard - Parameters
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2610,8 +2664,12 @@ Feature: Jobs and workflows
 
     @MLJW
     @inProgress
+    @smoke
     Scenario: MLJW037 - Check all mandatory components on Batch Run wizard - Step 5 (Resources)
         Given open url
+        And wait load page
+        Then turn Off MLRun CE mode
+        And wait load page
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
         And wait load page
         And hover "Project_Navigation_Toggler" component on "commonPagesHeader" wizard
@@ -2745,6 +2803,7 @@ Feature: Jobs and workflows
         Then verify "Volumes_Subheader" element in "Resources_Accordion" on "Modal_Wizard_Form" wizard should display hint "Label_Hint"."New_Job_Volumes"
 
     @MLJW
+    @smoke
     Scenario: MLJW043 - Check Batch-Run running after edit GPU limit in Resources section
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2767,6 +2826,7 @@ Feature: Jobs and workflows
         Then value in "name" column with "text" in "Jobs_Monitor_Table" on "Jobs_Monitor_Tab" wizard should contains "test"
 
     @MLJW
+    @smoke
     Scenario: MLJW025 - Check Minimum CPU value on Batch Run wizard - Resources
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2809,6 +2869,7 @@ Feature: Jobs and workflows
             |               V3IO               |            Volume_Name_2             |       /path/to/happines2      |         Container_Input_2          |           Access_Key_2              |            /resource/path_2            |         yes        |                       |
 
     @MLJW
+    @smoke
     Scenario: MLJW026 - Check tip and warning messages in Volumes section on Batch Run wizard - Resources
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2866,6 +2927,7 @@ Feature: Jobs and workflows
         When click on "Delete_New_Row_Button" element in "Resources_Accordion" on "Modal_Wizard_Form" wizard
 
     @MLJW
+    @smoke
     Scenario: MLJW031 - Check mandatory of Container and Resource Path fields for V3IO volume - Batch Run - Resources
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2893,6 +2955,7 @@ Feature: Jobs and workflows
         Then value in "name" column with "text" in "Jobs_Monitor_Table" on "Jobs_Monitor_Tab" wizard should contains "test"
 
     @MLJW
+    @smoke
     Scenario: MLJW033 - Check autocomplete without tags MLRun Store path for datasets, artifacts, models, feature vectors - Batch Run - Data input
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2931,6 +2994,7 @@ Feature: Jobs and workflows
             |     data_tag    |      store://datasets/default/test-i#0:latest        |
 
     @MLJW
+    @smoke
     Scenario: MLJW034 - Check setting schedule for a job - Batch Run - Schedule for later 
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -2962,6 +3026,7 @@ Feature: Jobs and workflows
         Then verify "Schedule_Button" not input element in "Schedule_For_Later" on "Schedule_PopUp" wizard is disabled
 
     @MLJW
+    @smoke
     Scenario: MLJW035 - Check environment variables table types components on Batch Run in Advanced section
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -3001,6 +3066,7 @@ Feature: Jobs and workflows
             |  V3IO_FRAMESD   |        value         |    http://framesd:8080   |
 
     @MLJW
+    @smoke
     Scenario: MLJW036 - Check setting schedule for a job - Batch Run - Schedule for later 
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -3073,6 +3139,7 @@ Feature: Jobs and workflows
         Then type value "01:45" to "At_time_Input" field on "Schedule_For_Later" on "Schedule_PopUp" wizard
 
     @MLJW
+    @smoke
     Scenario: MLJW045 - Check back navigation from Job overview to Jobs Monitor tab and forward to Job overview
         Given open url
         And wait load page
@@ -3106,6 +3173,7 @@ Feature: Jobs and workflows
         Then verify "Info_Pane_Tab_Selector" on "Jobs_Monitor_Tab_Info_Pane" wizard should contains "Jobs_Monitor_Tab_Info_Pane"."Tab_List"
 
     @MLJW
+    @smoke
     Scenario: MLJW046 - Check components in Parameters section on Batch Run wizard with checked Hyper
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard

--- a/tests/features/models.feature
+++ b/tests/features/models.feature
@@ -5,6 +5,7 @@ Feature: Models Page
   @MLM
   #TODO: Register_Model_Button hidden from 1.4.0, running on demo mode
   @passive
+  @smoke
   Scenario: MLM001 - Check all mandatory components on Models tab
     Given open url
     And turn on demo mode
@@ -46,8 +47,7 @@ Feature: Models Page
 
   @MLM
   @passive
-  @FAILED_TODO
-  #TODO: Bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6)
+  @smoke
   Scenario: MLM002 - Check all mandatory components on Model Endpoints tab
     Given open url
     And wait load page
@@ -76,6 +76,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM003 - Check all mandatory components on Real-Time Pipelines tab
     Given open url
     And wait load page
@@ -96,6 +97,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM004 - Verify filtering by model name on Models tab
     Given open url
     And wait load page
@@ -113,6 +115,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM005 - Verify behaviour of Show iterations checkbox on Models tab
     Given open url
     And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -128,7 +131,7 @@ Feature: Models Page
     And wait load page
     Then click on "Table_FilterBy_Button" element on "Models" wizard
     Then "Show_Iterations_Checkbox" element should be unchecked on "Artifacts_FilterBy_Popup" wizard
-    Then check "expand_btn" visibility in "Models_Table" on "Models" wizard
+    Then check "expand_btn" visibility in "Models_Table" on "Models" wizard with 0 offset
     Then click on cell with row index 1 in "expand_btn" column in "Models_Table" table on "Models" wizard
     And wait load page
     Then click on cell with row index 1 in "name" column in "Models_Table" table on "Models" wizard
@@ -143,6 +146,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM006 - Verify filtering by name on Real-Time Pipelines tab
     Given open url
     And wait load page
@@ -166,6 +170,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM007 - Verify filtering by label with key on Models tab
     Given open url
     And wait load page
@@ -193,8 +198,7 @@ Feature: Models Page
 
   @MLM
   @passive
-  @FAILED_TODO
-  #TODO: Bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6)
+  @smoke
   Scenario: MLM008 - Verify filtering by label on Model Endpoints tab
     Given open url
     And wait load page
@@ -221,8 +225,10 @@ Feature: Models Page
     And verify "No_Data_Message" element visibility on "commonPagesHeader" wizard
 
   @MLM
+  @FAILED_TODO
+  @smoke
   #TODO: Register_Model_Button hidden from 1.4.0, running on demo mode
-  @passive
+  #TODO: bug - Back and forward browser navigation does not automatically close the form  ML-6239
   Scenario: MLM009 - Check all mandatory components on Register Model Popup
     Given open url
     And turn on demo mode
@@ -313,6 +319,7 @@ Feature: Models Page
     Then verify "Title" element not exists on "Register_Model_Popup" wizard
 
   @MLM
+  @smoke
   #TODO: Register_Model_Button hidden from 1.4.0, running on demo mode
   Scenario: MLM010 - Verify behaviour on Register new Model
     * set tear-down property "model" created in "default" project with "automation-model" value
@@ -341,6 +348,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM011 - Check MLRun logo redirection
     Given open url
     And wait load page
@@ -356,6 +364,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM012 - Verify action menu list, Downloads action,  View YAML action
     Given open url
     And wait load page
@@ -393,6 +402,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM013 - Verify View YAML action in Item infopane
     Given open url
     And wait load page
@@ -411,6 +421,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM014 - Check all mandatory components in Item infopane on Overview tab table
     Given open url
     And wait load page
@@ -463,6 +474,7 @@ Feature: Models Page
     Then verify "Cross_Close_Button" element visibility on "Models_Info_Pane" wizard
 
   @MLM
+  @smoke
   Scenario: MLM026 - Verify the Delete option state in Models table and Overview details action menu 
     Given open url
     And wait load page
@@ -497,6 +509,9 @@ Feature: Models Page
 
   @MLM
   @passive
+  @FAILED_TODO
+  @smoke
+  #TODO: Bug ML-6217 - [Breadcrumbs] request is not sent when changing project
   Scenario: MLM025 - Verify Preview, Deploy option, view Preview, Deploy action, Preview tab
       Given open url
       And wait load page
@@ -538,9 +553,9 @@ Feature: Models Page
       Then verify "Pop_Out_Button" element visibility on "Models_Info_Pane" wizard 
       Then click on "Pop_Out_Button" element on "Models_Info_Pane" wizard
       And wait load page
-      Then verify "Preview_Header" element visibility on "Artifact_Preview_Popup" wizard
+      Then verify "Preview_Row" element visibility on "Artifact_Preview_Popup" wizard
       Then verify "Cross_Cancel_Button" element visibility on "Artifact_Preview_Popup" wizard
-      Then check "download_btn" visibility in "Preview_Header" on "Artifact_Preview_Popup" wizard
+      Then check "download_btn" visibility in "Preview_Row" on "Artifact_Preview_Popup" wizard with 1 offset
       Then click on "Download_Button" element on "Artifact_Preview_Popup" wizard
       And wait load page
       And wait load page
@@ -564,8 +579,8 @@ Feature: Models Page
       Then click on "Cross_Cancel_Button" element on "Deploy_Model_Popup" wizard
 
   @MLM
+  @smoke
   Scenario: MLM015 - Check Labels table components in Item infopane on Overview tab table
-    * set tear-down property "model" created in "default" project with "test-model" value
     * create "test-model" Model with "latest" tag in "default" project with code 200
     Given open url
     And wait load page
@@ -611,6 +626,8 @@ Feature: Models Page
     Then click on "Labels_Apply_Button" element on "Models_Info_Pane" wizard
     Then click on "Apply_Changes_Button" element on "Models_Info_Pane" wizard
     And wait load page
+    And hover "Labels_Field" component on "Models_Info_Pane" wizard
+    And wait load page
     When add rows to "Labels_Table" table on "Models_Info_Pane" wizard
             | key_input | value_input |
             |    key3   |    value3   |
@@ -625,8 +642,7 @@ Feature: Models Page
     
   @MLM
   @passive
-  @FAILED_TODO
-  #TODO: Bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6)
+  @smoke
   Scenario: MLM016 - Check all mandatory components in Item infopane on Overview tab table on Model Endpoints tab
     Given open url
     And wait load page
@@ -651,6 +667,7 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
   Scenario: MLM027 - Check Details panel still active on page refresh
     * set tear-down property "model" created in "default" project with "test-model" value
     * create "test-model" Model with "v1" tag in "default" project with code 200
@@ -678,6 +695,7 @@ Feature: Models Page
   @MLM
   @passive
   @inProgress
+  @smoke
   Scenario: MLM028 - Check tab list compontnts on Model Item infopane
     Given open url
     And wait load page
@@ -695,6 +713,9 @@ Feature: Models Page
 
   @MLM
   @passive
+  @smoke
+  @FAILED_TODO
+  #TODO: bug - Back and forward browser navigation does not automatically close the form  ML-6239
   Scenario: MLM029 - Check components on Deploy Model Popup
     * set tear-down property "function" created in "default" project with "automation-test-function-1" value
     * set tear-down property "function" created in "default" project with "automation-test-function-2" value
@@ -774,6 +795,7 @@ Feature: Models Page
     Then verify "Title" element not exists on "Deploy_Model_Popup" wizard
 
     @MLM
+    @smoke
     Scenario: MLM030 - Verify behaviour of key-value table on Deploy Model Popup
      Given open url
      And wait load page
@@ -840,6 +862,7 @@ Feature: Models Page
   @MLM
   #TODO: arrow lines position - y not found
   @passive
+  @smoke
   Scenario: MLM031 - Verify behaviour of Real-Time Pipelines table
     Given open url
     And wait load page
@@ -857,7 +880,7 @@ Feature: Models Page
     And select "Real-Time Pipelines" tab in "Models_Tab_Selector" on "Models" wizard
     And wait load page
     Then verify "Real-Time Pipelines" tab is active in "Models_Tab_Selector" on "Models" wizard
-    Then check "expand_btn" visibility in "Real_Time_Pipelines_Table" on "Real_Time_Pipelines" wizard
+    Then check "expand_btn" visibility in "Real_Time_Pipelines_Table" on "Real_Time_Pipelines" wizard with 0 offset
     Then save to context "name" column and "href" attribute on 1 row from "Real_Time_Pipelines_Table" table on "Real_Time_Pipelines" wizard
     When click on cell with row index 1 in "name" column in "Real_Time_Pipelines_Table" table on "Real_Time_Pipelines" wizard
     And wait load page
@@ -878,8 +901,7 @@ Feature: Models Page
     Then compare "Header" element value on "ML_Function_Info_Pane" wizard with test "function" context value
 
   @MLM
-  @FAILED_TODO
-  #TODO: Bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6)
+  @smoke
   Scenario: MLM032 - Check broken link redirection
     Given open url
     And wait load page
@@ -921,8 +943,7 @@ Feature: Models Page
     Then verify redirection from "projects/INVALID/models/real-time-pipelines" to "projects"
   
   @MLM
-  @FAILED_TODO
-  #TODO: Bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6)
+  @smoke
   Scenario: MLM033 - Check active/highlited items with details panel on Model Endpoints tab
     Given open url
     And wait load page
@@ -953,6 +974,7 @@ Feature: Models Page
     Then compare "Header" element value on "Models_Info_Pane" wizard with test "name" context value
 
   @MLM
+  @smoke
   Scenario: MLM034 - Check active/highlited items with details panel on Models tab
     Given open url
     And wait load page
@@ -978,7 +1000,8 @@ Feature: Models Page
     Then save to context "name" column on 2 row from "Models_Table" table on "Models" wizard
     Then compare "Header" element value on "Models_Info_Pane" wizard with test "name" context value
 
-  @MLM  
+  @MLM
+  @smoke
   Scenario: MLM020 - Check that version tag is filled when edit it in table view and full view on Overview tab table on Models page
     Given open url
     And wait load page
@@ -1003,6 +1026,7 @@ Feature: Models Page
     Then verify "Cross_Close_Button" element visibility on "Models_Info_Pane" wizard
 
   @MLM
+  @smoke
   Scenario: MLM021 - Check that version tag dropdown shows all tags on filters wizard on Models page
     Given open url
     And wait load page
@@ -1030,6 +1054,7 @@ Feature: Models Page
     Then check "newTag" value in "tag" column in "Models_Table" table on "Models" wizard
 
   @MLM
+  @smoke
   Scenario: MLM023 - Check that version tag has "Click to add" status when it's empty after edited
     Given open url
     And wait load page
@@ -1057,6 +1082,7 @@ Feature: Models Page
     Then "Version_Tag_Input_Placeholder" element on "Models_Info_Pane" should contains "Click to add" value
 
   @MLM
+  @smoke
   Scenario: MLM024 - Check filter by "All" tag is performed when version tag was edited
     Given open url
     And wait load page

--- a/tests/features/projectMonitoring.feature
+++ b/tests/features/projectMonitoring.feature
@@ -4,6 +4,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM002 - Check all mandatory components
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -21,6 +22,7 @@ Feature: MLRun Project Page
     
     @MLPM
     @passive
+    @smoke
     Scenario: MLNB001 - Check all mandatory components on Navigation Bar
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -117,6 +119,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM003 - Check MLRun logo redirection
         Given open url
         And wait load page
@@ -128,8 +131,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
-    @FAILED_TODO
-    #TODO: bug #2339 Fix [Artifacts] refine UI text for Register Artifact
+    @smoke
     Scenario: MLPM004 - Check all mandatory components on Register File Popup
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -180,6 +182,7 @@ Feature: MLRun Project Page
     @FAILED_TODO
     #TODO: 'Register Model' option is missing in list of 'Create New' dropdown in demo mode
     @passive
+    @smoke
     Scenario: MLPM005 - Check all mandatory components on Register Model Popup
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -222,6 +225,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM006 - Check all mandatory components on Register Dataset Popup
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -264,6 +268,7 @@ Feature: MLRun Project Page
     
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM007 - Check all mandatory components on Batch run
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -334,7 +339,7 @@ Feature: MLRun Project Page
         Then verify "Advanced_Environment_Variables_Table" element visibility on "Modal_Wizard_Form" wizard
         Then verify "Default_Input_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
         Then verify "Default_Artifact_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
-        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts/{{run.uid}}" attribute value
+        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts" attribute value
         Then verify "Access_Key_Checkbox" element visibility on "Modal_Wizard_Form" wizard
         Then uncheck "Access_Key_Checkbox" element on "Modal_Wizard_Form" wizard
         Then verify "Access_Key_Input" element visibility on "Modal_Wizard_Form" wizard
@@ -357,6 +362,7 @@ Feature: MLRun Project Page
     
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM008 - Check all mandatory components on Create ML Function - Job runtime
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -414,6 +420,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM009 - Check all mandatory components on Create ML Function - Serving runtime
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -479,6 +486,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM010 - Check all mandatory components on Create New Feature Set
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -519,6 +527,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM011 - Check Project Counter redirection to Models page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -539,6 +548,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM012 - Check Project Counter redirection to Feature Sets page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -561,6 +571,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM013 - Check Project Counter redirection to Artifacts page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -579,6 +590,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM014 - Check Project Counter redirection to Monitor Jobs tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -595,6 +607,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM015 - Check Project Counter redirection to Schedules tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -609,6 +622,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLB003 - Verify behaviour of Breadcrumbs menu
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -631,6 +645,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM016 - Check redirect to Jobs and workflows page using See All link
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -654,6 +669,8 @@ Feature: MLRun Project Page
         Then click on "Project_Monitoring_Button" element on "commonPagesHeader" wizard
         And hover "MLRun_Logo" component on "commonPagesHeader" wizard
         And wait load page
+        Then verify "Recent_text" element visibility on "Project" wizard
+        Then verify "Create_New" dropdown element on "Project" wizard should contains "Project"."Create_New_Options"
         Then click on "See_All_Jobs_Link" element on "Project" wizard
         And wait load page
         Then verify breadcrumbs "tab" label should be equal "Jobs and workflows" value
@@ -668,6 +685,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM017 - Check redirect to Job Info Pane overview from Project Monitoring Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -688,6 +706,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM018 - Check all mandatory components on Consumer Groups tab
         Given open url
         And wait load page
@@ -713,6 +732,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM019 - Verify filtering by name on Consumer Groups tab
         Given open url
         And wait load page
@@ -731,6 +751,7 @@ Feature: MLRun Project Page
 
     @MLPM
     @passive
+    @smoke
     Scenario: MLPM020 - Verify all mandatory components on Consumer Groups drill-down
         Given open url
         And wait load page
@@ -760,6 +781,7 @@ Feature: MLRun Project Page
         Then "Description" element on "Consumer_Groups" should contains "This report displays the project's consumer groups for Iguazio v3io streams" value
     
     @MLPM
+    @smoke
     Scenario: MLPM021 - Verify filtering by name on Consumer Groups drill-down
         Given open url
         And wait load page

--- a/tests/features/projectSettings.feature
+++ b/tests/features/projectSettings.feature
@@ -5,6 +5,7 @@ Feature: Project Settings page
 
     @MLPS
     @inProgress
+    @smoke
     Scenario: MLPS001 - Verify all mandatory components on General Tab
         Given open url
         And click on row root with value "cat-vs-dog-classification" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -47,6 +48,7 @@ Feature: Project Settings page
             | labelKeyTest2 | labelValueTest2 |
 
     @MLPS
+    @smoke
     Scenario: MLPS002 - Verify behaviour of editing labels on General tab
         Given open url
         Then type value "cat-vs-dog-classification" to "Search_Projects_Input" field on "Projects" wizard
@@ -63,11 +65,15 @@ Feature: Project Settings page
         And hover "Project_Navigation_Toggler" component on "commonPagesHeader" wizard
         Then click on "Project_Settings_Button" element on "commonPagesHeader" wizard
         And hover "MLRun_Logo" component on "commonPagesHeader" wizard
+        Then type value "   " to "Source_URL_Input" field on "Project_Settings_General_Tab" wizard
+        Then verify "Source_URL_Input" on "Project_Settings_General_Tab" wizard should display warning "Input_Hint"."Input_Field_Invalid"
         When add rows to "Labels_Table" table on "Project_Settings_General_Tab" wizard
             | key_input | value_input |
             | a         | b           |
             | c         | d           |
             | e         | f           |
+        Then type value "test" to "Source_URL_Input" field on "Project_Settings_General_Tab" wizard
+        And wait load page
         And click on "MLRun_Logo" element on "commonPagesHeader" wizard
         And wait load page
         Then type value "cat-vs-dog-classification" to "Search_Projects_Input" field on "Projects" wizard
@@ -75,6 +81,7 @@ Feature: Project Settings page
         Then click on "Active_Projects_Button" element on "Projects" wizard
         Then value in "labels" column with "dropdowns" in "Projects_Table" on "Projects" wizard should contains "e=f" in "Overlay"
         And click on row root with value "cat-vs-dog-classification" in "name" column in "Projects_Table" table on "Projects" wizard
+        And wait load page
         And hover "Project_Navigation_Toggler" component on "commonPagesHeader" wizard
         Then click on "Project_Settings_Button" element on "commonPagesHeader" wizard
         And wait load page
@@ -84,11 +91,14 @@ Feature: Project Settings page
             |     a      |
             |     c      |
             |     e      |
+        Then type value "   " to "Source_URL_Input" field on "Project_Settings_General_Tab" wizard
+        Then verify "Source_URL_Input" on "Project_Settings_General_Tab" wizard should display warning "Input_Hint"."Input_Field_Invalid"
         When add rows to "Labels_Table" table on "Project_Settings_General_Tab" wizard
             | key_input         | value_input         |
             | a                 | b                   |
             | project_label_key | project_label_value |
             | a12345            | b54321              |
+        Then type value "test" to "Source_URL_Input" field on "Project_Settings_General_Tab" wizard
         And click on "MLRun_Logo" element on "commonPagesHeader" wizard
         And wait load page
         Then type value "cat-vs-dog-classification" to "Search_Projects_Input" field on "Projects" wizard
@@ -97,6 +107,7 @@ Feature: Project Settings page
         Then value in "labels" column with "dropdowns" in "Projects_Table" on "Projects" wizard should contains "a12345=b54321" in "Overlay"
         Then click on "Active_Projects_Button" element on "Projects" wizard
         And click on row root with value "cat-vs-dog-classification" in "name" column in "Projects_Table" table on "Projects" wizard
+        And wait load page
         And hover "Project_Navigation_Toggler" component on "commonPagesHeader" wizard
         Then click on "Project_Settings_Button" element on "commonPagesHeader" wizard
         And wait load page
@@ -116,6 +127,7 @@ Feature: Project Settings page
 
     @MLPS
     @inProgress
+    @smoke
     Scenario: MLPS003 - Verify Parameters Table on General Tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -161,6 +173,7 @@ Feature: Project Settings page
 
     @MLPS
     @passive
+    @smoke
     Scenario: MLPS006 - Check MLRun logo redirection
         Given open url
         And wait load page
@@ -175,6 +188,7 @@ Feature: Project Settings page
 
     @MLPS
     @passive
+    @smoke
     Scenario: MLPS007 - Verify all mandatory components on Secrets tab
         Given open url
         And wait load page
@@ -198,6 +212,7 @@ Feature: Project Settings page
 
     @MLPS
     @inProgress
+    @smoke
     Scenario: MLPS008 - Verify Secrets table on Secrets tab
         Given open url
         And wait load page
@@ -234,6 +249,7 @@ Feature: Project Settings page
     @passive
     @inProgress
     @enabledProjectMembership
+    @smoke
     Scenario: MLPS009 - Check all mandatory components on Project Owner
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -254,6 +270,7 @@ Feature: Project Settings page
     @passive
     @inProgress
     @enabledProjectMembership
+    @smoke
     Scenario: MLPS010 - Check all mandatory components on Members tab
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -355,6 +372,7 @@ Feature: Project Settings page
         And remove "automation-test" MLRun Project with code 204
 
     @MLPS
+    @smoke
     Scenario: MLPS005 - Check broken link redirection
         Given open url
         And wait load page

--- a/tests/features/projectsPage.feature
+++ b/tests/features/projectsPage.feature
@@ -4,6 +4,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     #TODO: last two steps are unstable on small screen extensions because scroll change the screen coordinates, it needs another solution
     Scenario: MLPr001 - Check all mandatory components
         Given open url
@@ -23,6 +24,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr002 - Verify searching by project name
         Given open url
         And wait load page
@@ -49,6 +51,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr003 - Sort projects in ascending and descending order
         Given open url
         And wait load page
@@ -60,6 +63,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr004 - Verify all mandatory components on Create new ML Project
         Given open url
         And wait load page
@@ -81,6 +85,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr005 - Verify all mandatory components on Archive ML Project
         Given open url
         And wait load page
@@ -94,6 +99,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr006 - Verify all mandatory components on Delete existing ML Project
         Given open url
         And wait load page
@@ -107,6 +113,7 @@ Feature: MLRun Projects Page
 
     @MLPr
     @sanity
+    @smoke
     Scenario: MLPr007 - Create new ML Project with description
         Given open url
         And wait load page
@@ -133,6 +140,7 @@ Feature: MLRun Projects Page
     
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr008 - Archive ML Project
         * set tear-down property "project" created with "automation-test-name1" value
         * create "automation-test-name1" MLRun Project with code 201
@@ -148,6 +156,7 @@ Feature: MLRun Projects Page
     
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr009 - Delete existing ML Project
         * set tear-down property "project" created with "automation-test-name2" value
         * create "automation-test-name2" MLRun Project with code 201
@@ -175,6 +184,7 @@ Feature: MLRun Projects Page
     
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr010 - Unarchive ML Project
         * set tear-down property "project" created with "automation-test-name7" value
         * create "automation-test-name7" MLRun Project with code 201
@@ -200,6 +210,7 @@ Feature: MLRun Projects Page
     
     @MLPr
     @passive
+    @smoke
     Scenario: MLPr011 - Verify View YAML action
         Given open url
         And wait load page
@@ -214,6 +225,7 @@ Feature: MLRun Projects Page
     
     @MLPr    
     @danger
+    @smoke
 #   Run this test case only with mocked backend!!!
     Scenario: MLPr012 - Check projects limit message
         Then create up to limit projects with code 201
@@ -226,6 +238,9 @@ Feature: MLRun Projects Page
 
     @MLPr
     @passive
+    @smoke
+    @FAILED_TODO
+    #TODO: change mock api getIguazioProjects for owner
     Scenario: MLPr013 - Create new ML Project and check navigation through project navigation menu
         Given open url
         And wait load page
@@ -269,7 +284,7 @@ Feature: MLRun Projects Page
         Then verify breadcrumbs "tab" label should be equal "Settings" value
 
     @MLPr
-    @uniqueTag
+    @smoke
     Scenario: MLPr015 - Check components on Monitoring container on Projects page
         Given open url
         And wait load page
@@ -311,7 +326,7 @@ Feature: MLRun Projects Page
         Then verify "Monitoring_Scheduled_Box" element visibility in "Projects_Monitoring_Container" on "Projects" wizard
 
     @MLPr
-    @uniqueTag
+    @smoke
     Scenario: MLPr016 - Check components on Jobs counter box
         Given open url
         And wait load page
@@ -363,7 +378,7 @@ Feature: MLRun Projects Page
         Then verify "Monitoring_Container" element visibility in "Projects_Monitoring_Container" on "Projects" wizard
 
     @MLPr
-    @uniqueTag
+    @smoke
     Scenario: MLPr017 - Check components on Workflows counter box
         Given open url
         And wait load page
@@ -414,7 +429,7 @@ Feature: MLRun Projects Page
         Then verify "Monitoring_Container" element visibility in "Projects_Monitoring_Container" on "Projects" wizard
 
     @MLPr
-    @uniqueTag
+    @smoke
     Scenario: MLPr018 - Check components on Sheduled counter box
         Given open url
         And wait load page

--- a/tests/features/quickActions.feature
+++ b/tests/features/quickActions.feature
@@ -3,6 +3,7 @@ Feature: MLRun Project Home Page
     Testcases that verifies functionality on MLRun Project Home Page
 
     @MLPH
+    @smoke
     Scenario: MLPH001 - Check all mandatory components on Project Home
         * set tear-down property "project" created with "automation-test-1002" value
         * create "automation-test-1002" MLRun Project with code 201
@@ -82,6 +83,9 @@ Feature: MLRun Project Home Page
             |     Monitoring      |
     
     @MLPH
+    @smoke
+    @FAILED_TODO
+    #TODO: bug - Redirection is missing after registering artifacts from the Quick Actions page ML-6247
     Scenario: MLPH002 - Verify behaviour on Register Model Popup on Project Home Page
         Given open url
         * turn on demo mode
@@ -133,6 +137,7 @@ Feature: MLRun Project Home Page
         Then check "v3io:///target/" value in "path" column in "Overview_Table" table on "Models_Info_Pane" wizard
     
     @MLPH
+    @smoke
     @passive
     Scenario: MLPH003 - Check all mandatory components on Create New Feature Set on Project Home Page
         Given open url
@@ -179,6 +184,9 @@ Feature: MLRun Project Home Page
     
     @MLPH
     @passive
+    @smoke
+    @FAILED_TODO
+    #TODO: bug - Redirection is missing after registering artifacts from the Quick Actions page ML-6247
     Scenario: MLPH004 - Check all mandatory components on Register Dataset Popup on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -234,6 +242,7 @@ Feature: MLRun Project Home Page
     
     @MLPH 
     @passive
+    @smoke
     Scenario: MLPH005 - Check all mandatory components on Create ML Function on Project Home Page
         * set tear-down property "project" created with "automation-test-1003" value
         * create "automation-test-1003" MLRun Project with code 201
@@ -264,6 +273,9 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
+    @FAILED_TODO
+    #TODO: bug - Redirection is missing after registering artifacts from the Quick Actions page ML-6247
     Scenario: MLPH006 - Check all mandatory components on Batch run wizard
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -338,7 +350,7 @@ Feature: MLRun Project Home Page
         Then verify "Advanced_Environment_Variables_Table" element visibility on "Modal_Wizard_Form" wizard
         Then verify "Default_Input_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
         Then verify "Default_Artifact_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
-        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts/{{run.uid}}" attribute value
+        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts" attribute value
         Then verify "Access_Key_Checkbox" element visibility on "Modal_Wizard_Form" wizard
         Then uncheck "Access_Key_Checkbox" element on "Modal_Wizard_Form" wizard
         Then verify "Access_Key_Input" element visibility on "Modal_Wizard_Form" wizard
@@ -367,7 +379,7 @@ Feature: MLRun Project Home Page
     @MLPH
     @passive
     @FAILED_TODO
-    #TODO: bug #2339 Fix [Artifacts] refine UI text for Register Artifact
+    #TODO: bug - Redirection is missing after registering artifacts from the Quick Actions page ML-6247
     Scenario: MLPH007 - Check all mandatory components on Register File Popup on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -428,6 +440,7 @@ Feature: MLRun Project Home Page
     
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH008 - Check all mandatory components on Create a Feature Vector Popup on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -444,13 +457,14 @@ Feature: MLRun Project Home Page
         Then verify "Cross_Cancel_Button" element visibility on "Create_Feature_Vector_Popup" wizard
         Then verify "Name_Input" element visibility on "Create_Feature_Vector_Popup" wizard
         Then type value "   " to "Name_Input" field on "Create_Feature_Vector_Popup" wizard
-        Then verify "Name_Input" options rules on "Create_Feature_Vector_Popup" wizard
+        Then verify "Name_Input" options rules on form "Create_Feature_Vector_Popup" wizard
         Then verify "Tag_Input" element visibility on "Create_Feature_Vector_Popup" wizard
         Then verify "Description_Input" element visibility on "Create_Feature_Vector_Popup" wizard
         Then verify "Labels_Table" element visibility on "Create_Feature_Vector_Popup" wizard
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH009 - Check all mandatory components on Feature Set tab on Project Home Page
         Given open url
         * turn on demo mode
@@ -482,6 +496,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH010 - Check all mandatory components on Files tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -507,6 +522,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH011 - Check all mandatory components on Datasets tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -531,6 +547,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH012 - Check all mandatory components on Feature Vectors tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -551,6 +568,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH013 - Check all mandatory components on ML Functions tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -574,6 +592,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH014 - Check all mandatory components on Monitor Jobs tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -597,6 +616,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH015 - Check all mandatory components on Models tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -625,6 +645,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH016 - Check all mandatory components on Monitor Workflows tab on Project Home Page
         Given open url
         And click on row root with value "churn-project-admin" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -644,8 +665,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
-    @FAILED_TODO
-    #TODO: bug - UI crash upon navigating to model endpoints tab ML-5919 (fixed on rc6) - failed
+    @smoke
     Scenario: MLPH017 - Check all mandatory components on Models Endpoint tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -666,6 +686,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH018 - Check all mandatory components on Real-Time Piplines tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -685,6 +706,7 @@ Feature: MLRun Project Home Page
 
     @MLPH
     @passive
+    @smoke
     Scenario: MLPH019 - Check all mandatory components on Monitoring tab on Project Home Page
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -709,6 +731,9 @@ Feature: MLRun Project Home Page
         Then verify "General_Info_Quick_Links" element visibility on "commonPagesHeader" wizard
     
     @MLPH
+    @smoke
+    @FAILED_TODO
+    #TODO: bug - Redirection is missing after registering artifacts from the Quick Actions page ML-6247
     Scenario: MLPH020 - Check all mandatory components on Batch inference in Advanced section
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -775,6 +800,7 @@ Feature: MLRun Project Home Page
             |    name5    |        secret        | sectretName3:sectretKey3 |
             |    name7    |        secret        | sectretName4:sectretKey4 |
             |    name8    |        value         |          value4          |
+        And wait load page
         Then edit 1 row in "Advanced_Environment_Variables_Table" key-value table on "Modal_Wizard_Form" wizard
             | name_input | value_input | 
             |   edited   |    edited   |
@@ -785,6 +811,7 @@ Feature: MLRun Project Home Page
             |    name5    |        secret        |    sectretName3:sectretKey3    |
             |    name7    |        secret        |    sectretName4:sectretKey4    |
             |    name8    |        value         |             value4             |
+        And wait load page
         Then edit 5 row in "Advanced_Environment_Variables_Table" key-value table on "Modal_Wizard_Form" wizard
             | name_input | value_input | 
             |   edited   |    edited   |
@@ -795,10 +822,16 @@ Feature: MLRun Project Home Page
             |    name5    |        secret        |    sectretName3:sectretKey3    |
             |    name7    |        secret        |    sectretName4:sectretKey4    |
             | name8edited |        value         |          value4edited          |
+        And wait load page
+        When click on "delete_btn" in "Advanced_Environment_Variables_Table" table on "Modal_Wizard_Form" wizard with offset "false"
+            | name_verify |
+            |    name4    |
+            |    name5    |
+        And wait load page    
         Then verify "Default_Input_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
         Then type value "test" to "Default_Input_Path_Input" field on "Advanced_Accordion" on "Modal_Wizard_Form" wizard
         Then verify "Default_Artifact_Path_Input" element visibility in "Advanced_Accordion" on "Modal_Wizard_Form" wizard
-        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts/{{run.uid}}" attribute value
+        Then "Default_Artifact_Path_Input" element in "Advanced_Accordion" on "Modal_Wizard_Form" should contains "v3io:///projects/{{run.project}}/artifacts" attribute value
         Then verify "Access_Key_Checkbox" element visibility on "Modal_Wizard_Form" wizard
         Then uncheck "Access_Key_Checkbox" element on "Modal_Wizard_Form" wizard
         Then verify "Access_Key_Input" element visibility on "Modal_Wizard_Form" wizard
@@ -814,6 +847,7 @@ Feature: MLRun Project Home Page
     
     @MLPH
     @inProgress
+    @smoke
     Scenario: MLPH023 - Check components - batch inference_v2, preview text, path type
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard
@@ -839,6 +873,7 @@ Feature: MLRun Project Home Page
         #TODO: check Data Inputs path type (Data_Inputs_Inference_Table)
 
     @MLPH
+    @smoke
     Scenario: MLPH024 - Check Train model wizard opens up
         Given open url
         And click on row root with value "default" in "name" column in "Projects_Table" table on "Projects" wizard

--- a/tests/features/step-definitions/steps.js
+++ b/tests/features/step-definitions/steps.js
@@ -142,6 +142,12 @@ When('turn on staging mode', async function() {
   await navigateToPage(this.driver, `${url}?mode=staging`)
 })
 
+Then('turn Off MLRun CE mode', async function() {
+  await this.driver.executeScript(function() {
+    localStorage.setItem('igzFullVersion', '3.5.5')
+  })
+}) 
+
 Then('additionally redirect by INVALID-TAB', async function() {
   const beforeURL = await this.driver.getCurrentUrl()
   const urlNodesArr = beforeURL.split('/')
@@ -1413,7 +1419,7 @@ When('hover {string} component on {string} wizard', async function(
   await hoverComponent(
     this.driver,
     pageObjects[wizardName][componentName],
-    false
+    true
   )
 })
 

--- a/tests/features/step-definitions/table.steps.js
+++ b/tests/features/step-definitions/table.steps.js
@@ -180,7 +180,7 @@ When('add rows to {string} table on {string} wizard', async function (table, wiz
       )
     }
     await clickNearComponent(this.driver, pageObjects[wizard][table]['root'])
-    await this.driver.sleep(100)
+    await this.driver.sleep(250)
   }
 })
 
@@ -1709,13 +1709,13 @@ Then(
 )
 
 Then(
-  'check {string} visibility in {string} on {string} wizard',
-  async function (cellName, tableName, wizardName) {
+  'check {string} visibility in {string} on {string} wizard with {int} offset',
+  async function (cellName, tableName, wizardName, indexOffset) {
     const rowsNumber = await getTableRows(this.driver, pageObjects[wizardName][tableName])
     for (let i = 0; i < rowsNumber; i++) {
       await componentIsVisible(
         this.driver,
-        pageObjects[wizardName][tableName].tableFields[cellName](i + 1)
+        pageObjects[wizardName][tableName].tableFields[cellName](i + 1 + indexOffset)
       )
     }
   }


### PR DESCRIPTION
Updated tests according to requirements
- changed description counter selector on Feature Vector
- changed selector for remove button Run Details label table on Batch Run
- changed command column to Code Entry Point on ML Functions, Jobs detail panel due to ML-4977
- added filtering by status due to lazy loading on Monitor Jobs tab due to ML-5092
- added visibility of Recent text on Project Monitoring page
- changed selector for Sorted by filter on Models
- added preview table headers - ML-5719
- added 'Overwrite artifact?' popup - ML-6059
- added step turn Off MLRun CE mode - ML-6111
- changed Default artifact path - ML-6094
- changed selector for remove button in label table on Projects Settings General tab
- changed selector for Close button in label table on create Project popup
- removed date picker selector to project card info - ML-6104