### PR TITLE
Impl [UI] Add metric type icons to Metrics Selector dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "2.0.9",
+    "iguazio.dashboard-react-controls": "2.0.10",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^4.1.0",

--- a/src/elements/MetricsSelector/MetricsSelector.js
+++ b/src/elements/MetricsSelector/MetricsSelector.js
@@ -37,6 +37,8 @@ import { METRICS_SELECTOR_OPTIONS } from '../../types'
 
 import { ReactComponent as Arrow } from 'igz-controls/images/arrow.svg'
 import { ReactComponent as SearchIcon } from 'igz-controls/images/search.svg'
+import { ReactComponent as MetricIcon } from 'igz-controls/images/circled-M.svg'
+import { ReactComponent as ResultIcon } from 'igz-controls/images/circled-R.svg'
 
 import './metricsSelector.scss'
 
@@ -146,10 +148,7 @@ const MetricsSelector = ({ maxSelectionNumber, metrics, name, onSelect, preselec
           style={{ backgroundColor: metric.color }}
         />
         <span className="data-ellipsis">{metric.name}</span>
-        {/*// todo: metrics - change according to design when ready  */}
-        <span style={{ marginLeft: '5px' }}>
-          {metric.type === metricsTypes.metric ? ' (M)' : ' (R)'}
-        </span>
+        {metric.type === metricsTypes.metric ? <MetricIcon /> : <ResultIcon />}
       </>
     )
   }

--- a/src/elements/MetricsSelector/MetricsSelector.js
+++ b/src/elements/MetricsSelector/MetricsSelector.js
@@ -37,8 +37,8 @@ import { METRICS_SELECTOR_OPTIONS } from '../../types'
 
 import { ReactComponent as Arrow } from 'igz-controls/images/arrow.svg'
 import { ReactComponent as SearchIcon } from 'igz-controls/images/search.svg'
-import { ReactComponent as MetricIcon } from 'igz-controls/images/circled-M.svg'
-import { ReactComponent as ResultIcon } from 'igz-controls/images/circled-R.svg'
+import { ReactComponent as MetricIcon } from 'igz-controls/images/circled-m.svg'
+import { ReactComponent as ResultIcon } from 'igz-controls/images/circled-r.svg'
 
 import './metricsSelector.scss'
 

--- a/src/elements/MetricsSelector/metricsSelector.scss
+++ b/src/elements/MetricsSelector/metricsSelector.scss
@@ -63,6 +63,10 @@
             font-size: 15px;
             white-space: nowrap;
             text-overflow: ellipsis;
+
+            svg {
+              margin-left: auto;
+            }
           }
 
           .metrics-selector-color-indicator {
@@ -73,6 +77,20 @@
             margin: 0 5px 0 10px;
             background-color: transparent;
             border-radius: 50%;
+          }
+
+          &.disabled {
+            label {
+              .metrics-selector-color-indicator {
+                opacity: 0.3;
+              }
+
+              svg {
+                path {
+                  fill: $spunPearl;
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
- **UI**: Add metric type icons to Metrics Selector dropdown
   depends on: https://github.com/iguazio/dashboard-react-controls/pull/283
   Jira: https://iguazio.atlassian.net/browse/ML-6530

   note: limit for 2 options just for demo purposes to show disabled options, it is not included in PR
   ![image](https://github.com/mlrun/ui/assets/155433425/cff111ae-1d47-4ad3-8454-ce49a468c8df)
