### PR TITLE
Fix [UI] When showing lists of jobs and workflows, time frame of "any time" should not be considered a filter

### DIFF
--- a/src/utils/getNoDataMessage.js
+++ b/src/utils/getNoDataMessage.js
@@ -179,7 +179,7 @@ const getChangedFiltersList = (filters, filtersStore, filtersStoreKey) => {
       ((type === NAME_FILTER || type === LABELS_FILTER || type === ENTITIES_FILTER) &&
         filtersStore[type].length > 0) ||
       (type === STATUS_FILTER && filtersStore.state !== FILTER_ALL_ITEMS) ||
-      type === DATE_RANGE_TIME_FILTER ||
+      (type === DATE_RANGE_TIME_FILTER && !isEqual(filtersStore.dates.value, DATE_FILTER_ANY_TIME)) ||
       (type === ITERATIONS_FILTER && isIterChanged) ||
       (type === SHOW_UNTAGGED_FILTER && filtersStore.showUntagged === SHOW_UNTAGGED_ITEMS) ||
       (type === GROUP_BY_FILTER && filtersStore.groupBy !== GROUP_BY_NONE)


### PR DESCRIPTION
- **UI**: When showing lists of jobs and workflows, time frame of "any time" should not be considered a filter
   Jira: https://iguazio.atlassian.net/browse/ML-6208

   Before:
   ![image](https://github.com/mlrun/ui/assets/155433425/f1879d31-04b7-412e-a934-05ac5aa472ea)

   After:
   ![image](https://github.com/mlrun/ui/assets/155433425/6ed0be4a-8648-4a38-b880-1de668d73ffd)
