### PR TITLE
Fix [Feature Sets Panel] Tooltip warning icon displays over the input text

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/featureSetsPanelDataSource.scss
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelDataSource/featureSetsPanelDataSource.scss
@@ -27,6 +27,12 @@
           padding: 15px 5px 15px 0;
         }
       }
+
+      &.combobox_invalid {
+        .combobox-input {
+          padding-right: 30px;
+        }
+      }
     }
 
     .select {


### PR DESCRIPTION
- **Feature Sets Panel**: Tooltip warning icon displays over the input text
   Jira: https://iguazio.atlassian.net/browse/ML-5838