### PR TITLE
Fix [Cross projects]  The "MLRunAccessDeniedError('Not allowed to read resource /projects/undefined')" on the  Jobs / Workflows  Overview tab

### DIFF
--- a/src/hooks/usePods.hook.js
+++ b/src/hooks/usePods.hook.js
@@ -31,7 +31,7 @@ export const usePods = (dispatch, fetchJobPods, removePods, selectedJob) => {
     if (!isEmpty(selectedJob) && !arePodsHidden(selectedJob?.labels)) {
       dispatch(
         fetchJobPods(
-          params.projectName,
+          params.projectName || selectedJob?.project,
           selectedJob.uid,
           get(selectedJob, 'ui.originalContent.metadata.labels.kind', JOB_KIND_JOB)
         )
@@ -40,7 +40,7 @@ export const usePods = (dispatch, fetchJobPods, removePods, selectedJob) => {
       const interval = setInterval(() => {
         dispatch(
           fetchJobPods(
-            params.projectName,
+            params.projectName || selectedJob?.project,
             selectedJob.uid,
             get(selectedJob, 'ui.originalContent.metadata.labels.kind', JOB_KIND_JOB)
           )


### PR DESCRIPTION
- **Cross projects**: The "MLRunAccessDeniedError('Not allowed to read resource /projects/undefined')" on the  Jobs / Workflows  Overview tab
   Jira: https://iguazio.atlassian.net/browse/ML-6680
