### PR TITLE
Fix [Cross projects] No data and error 403 :Not allowed to read resource/projects/undefined')" on Jobs Artifacts screen

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -149,7 +149,7 @@ const DetailsArtifacts = ({
 
       dispatch(
         fetchArtifacts({
-          project: params.projectName,
+          project: job.project || params.projectName,
           filters: {},
           config
         })


### PR DESCRIPTION
- **Cross projects**: No data and error 403 :Not allowed to read resource/projects/undefined')" on Jobs Artifacts screen
   Jira: https://iguazio.atlassian.net/browse/ML-6681
