### PR TITLE
Fix [Jobs] Get artifacts from the run status instead of using producer URI `1.6.x`

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -32,7 +32,8 @@ import jobsActions from '../../actions/jobs'
 import { generateArtifactIndexes } from '../Details/details.util'
 import {
   generateArtifactsPreviewContent,
-  generateArtifactsTabContent
+  generateArtifactsTabContent,
+  getJobAccordingIteration
 } from './detailsArtifacts.util'
 import { useSortTable } from '../../hooks/useSortTable.hook'
 import { ALLOW_SORT_BY, DEFAULT_SORT_BY, EXCLUDE_SORT_BY } from 'igz-controls/types'
@@ -140,8 +141,13 @@ const DetailsArtifacts = ({
       }
 
       if (workflowId) {
-        config.params.tree = workflowId.trim()
-        config.params.producer_uri = `${params.projectName}/${job.uid}`
+        return fetchJob(params.projectName, params.jobId, iteration).then(job => {
+          const selectedJob = getJobAccordingIteration(job)
+
+          setArtifactsPreviewContent(
+            generateArtifactsPreviewContent(selectedJob, selectedJob.artifacts)
+          )
+        })
       }
 
       if (iteration) {
@@ -160,7 +166,7 @@ const DetailsArtifacts = ({
           setArtifactsPreviewContent(generateArtifactsPreviewContent(job, result))
         })
     },
-    [dispatch, params.projectName]
+    [dispatch, fetchJob, params.jobId, params.projectName]
   )
 
   useEffect(() => {


### PR DESCRIPTION
- **Jobs**: Get artifacts from the run status instead of using producer URI
Backported to `1.6.x` from #2519 
   Jira: https://iguazio.atlassian.net/browse/ML-6779
   