### PR TITLE
Fix [Jobs] Get artifacts from the run status instead of using producer URI - updated dependency `1.6.x`

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -169,7 +169,7 @@ const DetailsArtifacts = ({
     } else if (selectedItem.iterationStats.length === 0) {
       getJobArtifacts(selectedItem, null)
     }
-  }, [fetchJob, getJobArtifacts, iteration, params.jobId, params.projectName, selectedItem])
+  }, [getJobArtifacts, iteration, params.jobId, params.projectName, selectedItem])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- **Jobs**: Get artifacts from the run status instead of using producer URI - updated dependency
Backported to `1.6.x` from #2519 
   Jira: https://iguazio.atlassian.net/browse/ML-6779
   