### PR TITLE
Fix [Project monitoring] UI failure when navigating to "Project monitoring" page - TypeError: e[a].value.startsWith is not a function

### DIFF
--- a/src/elements/ProjectTable/ProjectTable.js
+++ b/src/elements/ProjectTable/ProjectTable.js
@@ -47,10 +47,9 @@ const ProjectTable = ({ params, table }) => {
         </thead>
         <tbody className="project-data-card__table-body">
           {table.body.map((body, index) => {
-            const extractedItemName =
-              body['name'].value && body['name'].value.startsWith(params.projectName)
-                ? body['name'].value.slice(params.projectName.length + 1)
-                : body['name'].value
+            const extractedItemName = body['name'].value.startsWith(params.projectName)
+              ? body['name'].value.slice(params.projectName.length + 1)
+              : body['name'].value
 
             return (
               <tr key={index} className="project-data-card__table-row">

--- a/src/elements/ProjectTable/ProjectTable.js
+++ b/src/elements/ProjectTable/ProjectTable.js
@@ -58,9 +58,11 @@ const ProjectTable = ({ params, table }) => {
                       !Array.isArray(body[key].value) &&
                       `status_${body[key].value.toLowerCase()} capitalize`
                   )
-                  const name = body[key].value.startsWith(params.projectName)
-                    ? body[key].value.slice(params.projectName.length + 1)
-                    : body[key].value
+
+                  const name =
+                    key === 'name' && body[key].value.startsWith(params.projectName)
+                      ? body[key].value.slice(params.projectName.length + 1)
+                      : body[key].value
 
                   return key === 'type' ? (
                     <TableTypeCell key={body[key].value + index} data={body[key]} />

--- a/src/elements/ProjectTable/ProjectTable.js
+++ b/src/elements/ProjectTable/ProjectTable.js
@@ -59,7 +59,7 @@ const ProjectTable = ({ params, table }) => {
                       `status_${body[key].value.toLowerCase()} capitalize`
                   )
 
-                  const name =
+                  const extractedProjectName =
                     key === 'name' && body[key].value.startsWith(params.projectName)
                       ? body[key].value.slice(params.projectName.length + 1)
                       : body[key].value
@@ -75,8 +75,11 @@ const ProjectTable = ({ params, table }) => {
                             target="_top"
                             className="link project-data-card__table-link"
                           >
-                            <Tooltip template={<TextTooltipTemplate text={name} />} textShow={true}>
-                              {name}
+                            <Tooltip
+                              template={<TextTooltipTemplate text={extractedProjectName} />}
+                              textShow={true}
+                            >
+                              {extractedProjectName}
                             </Tooltip>
                           </a>
                         ) : (

--- a/src/elements/ProjectTable/ProjectTable.js
+++ b/src/elements/ProjectTable/ProjectTable.js
@@ -47,6 +47,11 @@ const ProjectTable = ({ params, table }) => {
         </thead>
         <tbody className="project-data-card__table-body">
           {table.body.map((body, index) => {
+            const extractedItemName =
+              body['name'].value && body['name'].value.startsWith(params.projectName)
+                ? body['name'].value.slice(params.projectName.length + 1)
+                : body['name'].value
+
             return (
               <tr key={index} className="project-data-card__table-row">
                 {Object.keys(body).map((key, index) => {
@@ -58,11 +63,6 @@ const ProjectTable = ({ params, table }) => {
                       !Array.isArray(body[key].value) &&
                       `status_${body[key].value.toLowerCase()} capitalize`
                   )
-
-                  const extractedProjectName =
-                    key === 'name' && body[key].value.startsWith(params.projectName)
-                      ? body[key].value.slice(params.projectName.length + 1)
-                      : body[key].value
 
                   return key === 'type' ? (
                     <TableTypeCell key={body[key].value + index} data={body[key]} />
@@ -76,10 +76,10 @@ const ProjectTable = ({ params, table }) => {
                             className="link project-data-card__table-link"
                           >
                             <Tooltip
-                              template={<TextTooltipTemplate text={extractedProjectName} />}
+                              template={<TextTooltipTemplate text={extractedItemName} />}
                               textShow={true}
                             >
-                              {extractedProjectName}
+                              {extractedItemName}
                             </Tooltip>
                           </a>
                         ) : (


### PR DESCRIPTION
- **Project monitoring**: UI failure when navigating to "Project monitoring" page - TypeError: e[a].value.startsWith is not a function
   Related to: https://github.com/mlrun/ui/pull/2517
   Jira: https://iguazio.atlassian.net/browse/ML-6810