### PR TITLE
Fix [UI] Limit number of artifacts shown in the artifact screen `1.6.x`

### DIFF
--- a/src/api/artifacts-api.js
+++ b/src/api/artifacts-api.js
@@ -27,8 +27,12 @@ import {
   TAG_FILTER_LATEST
 } from '../constants'
 
+const MAX_ARTIFACTS_LIMIT = 1000
+
 const fetchArtifacts = (project, filters, config = {}, withLatestTag) => {
-  const params = {}
+  const params = {
+    limit: MAX_ARTIFACTS_LIMIT
+  }
 
   if (filters?.labels) {
     params.label = filters.labels?.split(',')


### PR DESCRIPTION
- **UI**: Limit number of artifacts shown in the artifact screen
  - In `1.7.0` UI + BE will Implement a different solution
  
   Jira: https://iguazio.atlassian.net/browse/ML-6866
   