### PR TITLE
Fix [Jobs monitoring, cross-project] 'Date-picker', 'Filter by' pop-ups don't close on back/forward navigation 

### DIFF
--- a/src/components/ProjectsJobsMonitoring/ProjectsJobsMonitoring.js
+++ b/src/components/ProjectsJobsMonitoring/ProjectsJobsMonitoring.js
@@ -363,6 +363,7 @@ const ProjectsJobsMonitoring = ({ fetchAllJobRuns, fetchJobFunction, fetchJobs }
                   page={JOBS_MONITORING_PAGE}
                   tab={selectedTab}
                   withRefreshButton={false}
+                  key={selectedTab}
                 >
                   {tabData[selectedTab].modalFilters}
                 </ActionBar>


### PR DESCRIPTION
- **Jobs monitoring, cross-project]**: 'Date-picker', 'Filter by' pop-ups don't close on back/forward navigatio
   Jira: https://iguazio.atlassian.net/browse/ML-6656