### PR TITLE
Fix [Feature store] overlay error pop up is not displayed upon 403 for "Save and Ingest"

### DIFF
--- a/src/actions/featureStore.js
+++ b/src/actions/featureStore.js
@@ -458,6 +458,7 @@ const featureStoreActions = {
               ? 'You do not have permission to create a new feature set.'
               : error.message
 
+        showErrorNotification(dispatch, error, '', message)
         dispatch(featureStoreActions.createNewFeatureSetFailure(message))
 
         throw error


### PR DESCRIPTION
- **Feature store**: Overlay error pop up is not displayed upon 403 for "Save and Ingest"
   Jira: https://iguazio.atlassian.net/browse/ML-6751