### PR TITLE
Fix [Models endpoints monitoring, metrics] metric histogram chart does not display 100% of values

### DIFF
--- a/src/components/DetailsMetrics/DetailsMetrics.js
+++ b/src/components/DetailsMetrics/DetailsMetrics.js
@@ -95,7 +95,7 @@ const DetailsMetrics = ({ selectedItem }) => {
     const bins = Array(numberOfBins)
       .fill()
       .map(() => ({ count: 0, minBinValue: null, maxBinValue: null }))
-    const roundValue = value => Math.round(value * 100) / 100
+    const roundValue = (value, fraction = 100) => Math.round(value * fraction) / fraction
 
     points.forEach(value => {
       const binIndex = Math.min(Math.floor((value - minPointValue) / binSize), numberOfBins - 1)
@@ -110,7 +110,7 @@ const DetailsMetrics = ({ selectedItem }) => {
 
     const totalCount = points.length
 
-    const binPercentages = bins.map(bin => ((bin.count / totalCount) * 100).toFixed(1))
+    const binPercentages = bins.map(bin => roundValue((bin.count / totalCount) * 100, 1000))
 
     const binLabels = Array.from({ length: numberOfBins }, (_, i) => {
       if (parseFloat(binPercentages[i]) === 0) return ''


### PR DESCRIPTION
- **Models endpoints monitoring, metrics**: metric histogram chart does not display 100% of values
   Jira: https://iguazio.atlassian.net/browse/ML-7181