### PR TITLE
Fix [Cross Project] The Filter menu Apply button is hidden on Projects jobs screen

### DIFF
--- a/src/components/ProjectsJobsMonitoring/JobsMonitoring/JobsMonitoringFilters.js
+++ b/src/components/ProjectsJobsMonitoring/JobsMonitoring/JobsMonitoringFilters.js
@@ -22,11 +22,7 @@ import { useForm } from 'react-final-form'
 
 import { FormInput, FormOnChange, FormSelect } from 'igz-controls/components'
 
-import {
-  JOBS_MONITORING_JOBS_TAB,
-  LABELS_FILTER,
-  PROJECT_FILTER
-} from '../../../constants'
+import { JOBS_MONITORING_JOBS_TAB, LABELS_FILTER, PROJECT_FILTER } from '../../../constants'
 import { generateStatusFilter, generateTypeFilter } from '../../FilterMenu/filterMenu.settings'
 import { handleFilterStateChange } from '../projectsJobsMotinoring.util'
 
@@ -53,7 +49,13 @@ const JobsMonitoringFilters = () => {
         />
       </div>
       <div className="form-row">
-        <FormSelect label="Status" name="state" options={statusList} multiple />
+        <FormSelect
+          className="filter-job-status"
+          label="Status"
+          name="state"
+          options={statusList}
+          multiple
+        />
         <FormOnChange handler={(value, some) => handleStateChange(value, some)} name="state" />
       </div>
       <div className="form-row">

--- a/src/components/ProjectsJobsMonitoring/WorkflowsMonitoring/WorkflowsMonitoringFilters.js
+++ b/src/components/ProjectsJobsMonitoring/WorkflowsMonitoring/WorkflowsMonitoringFilters.js
@@ -49,7 +49,13 @@ const WorkflowsMonitoringFilters = () => {
         />
       </div>
       <div className="form-row">
-        <FormSelect label="Status" name="state" options={statusList} multiple />
+        <FormSelect
+          className="filter-scheduled-status"
+          label="Status"
+          name="state"
+          options={statusList}
+          multiple
+        />
         <FormOnChange handler={(value, some) => handleStateChange(value, some)} name="state" />
       </div>
       <div className="form-row">

--- a/src/components/ProjectsJobsMonitoring/projectsJobsMonitoring.scss
+++ b/src/components/ProjectsJobsMonitoring/projectsJobsMonitoring.scss
@@ -8,3 +8,19 @@
     padding: 0;
   }
 }
+
+.filter-job-status {
+  &.form-field-select__options-list {
+    .options-list {
+      max-height: 180px;
+    }
+  }
+}
+
+.filter-scheduled-status {
+  &.form-field-select__options-list {
+    .options-list {
+      max-height: 100px;
+    }
+  }
+}

--- a/src/components/ProjectsJobsMonitoring/projectsJobsMonitoring.scss
+++ b/src/components/ProjectsJobsMonitoring/projectsJobsMonitoring.scss
@@ -8,19 +8,3 @@
     padding: 0;
   }
 }
-
-.filter-job-status {
-  &.form-field-select__options-list {
-    .options-list {
-      max-height: 180px;
-    }
-  }
-}
-
-.filter-scheduled-status {
-  &.form-field-select__options-list {
-    .options-list {
-      max-height: 100px;
-    }
-  }
-}


### PR DESCRIPTION
- **Cross Project**: The Filter menu Apply button is hidden on Projects jobs screen
   Depends on: https://github.com/iguazio/dashboard-react-controls/pull/304 
   Jira: [ML-7152](https://iguazio.atlassian.net/browse/ML-7152)

[ML-7152]: https://iguazio.atlassian.net/browse/ML-7152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ