### PR TITLE
Fix [Models] misleading "Uptime" column name in "Model Endpoints" screen

### DIFF
--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -495,7 +495,7 @@ export const createModelEndpointsRowData = (artifact, project) => {
       {
         id: `firstRequest.${artifact.ui.identifierUnique}`,
         headerId: 'uptime',
-        headerLabel: 'Uptime',
+        headerLabel: 'First prediction',
         value: formatDatetime(artifact.status?.first_request, '-'),
         className: 'table-cell-1'
       },


### PR DESCRIPTION
- **Models**: misleading "Uptime" column name in "Model Endpoints" screen
   Jira: [ML-7637](https://iguazio.atlassian.net/browse/ML-7637)

[ML-7637]: https://iguazio.atlassian.net/browse/ML-7637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ