### PR TITLE
Impl [Projects] Jobs monitoring 'scheduled' with type=All is inaccessible without filter

### DIFF
--- a/src/components/ProjectsPage/projects.util.js
+++ b/src/components/ProjectsPage/projects.util.js
@@ -228,6 +228,7 @@ export const generateMonitoringCounters = (data, dispatch) => {
       running: 0
     },
     scheduled: {
+      all: 0,
       jobs: 0,
       workflows: 0
     }
@@ -248,6 +249,9 @@ export const generateMonitoringCounters = (data, dispatch) => {
     monitoringCounters.workflows.completed += project.pipelines_completed_recent_count
     monitoringCounters.workflows.failed += project.pipelines_failed_recent_count
     monitoringCounters.workflows.running += project.pipelines_running_count
+    monitoringCounters.scheduled.all +=
+      project.distinct_scheduled_jobs_pending_count +
+      project.distinct_scheduled_pipelines_pending_count
     monitoringCounters.scheduled.jobs += project.distinct_scheduled_jobs_pending_count
     monitoringCounters.scheduled.workflows += project.distinct_scheduled_pipelines_pending_count
   })

--- a/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
@@ -122,7 +122,7 @@ const ScheduledJobsCounters = () => {
           <span
             className="link"
             onClick={scheduledStats.all.link}
-            data-testid="scheduled_wf_see_all"
+            data-testid="scheduled_total_see_all"
           >
             See all
           </span>

--- a/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
@@ -88,6 +88,16 @@ const ScheduledJobsCounters = () => {
             )}
           </span>
         </StatsCard.Col>
+        <StatsCard.Col>
+          <h6 className="stats__subtitle">Total</h6>
+          <span className="stats__counter">
+            {projectStore.projectsSummary.loading ? (
+              <Loader section small secondary />
+            ) : (
+              scheduledStats.all.counter
+            )}
+          </span>
+        </StatsCard.Col>
       </StatsCard.Row>
       <StatsCard.Row>
         <StatsCard.Col>
@@ -103,6 +113,15 @@ const ScheduledJobsCounters = () => {
           <span
             className="link"
             onClick={scheduledStats.workflows.link}
+            data-testid="scheduled_wf_see_all"
+          >
+            See all
+          </span>
+        </StatsCard.Col>
+        <StatsCard.Col>
+          <span
+            className="link"
+            onClick={scheduledStats.all.link}
             data-testid="scheduled_wf_see_all"
           >
             See all

--- a/src/utils/generateMonitoringData.js
+++ b/src/utils/generateMonitoringData.js
@@ -116,6 +116,10 @@ export const generateMonitoringStats = (data, navigate, dispatch, tab) => {
           ]
         }
       : {
+          all: {
+            counter: data.all,
+            link: () => navigateToJobsMonitoringPage({ [TYPE_FILTER]: FILTER_ALL_ITEMS }, {})
+          },
           jobs: {
             counter: data.jobs,
             link: () => navigateToJobsMonitoringPage({ [TYPE_FILTER]: JOB_KIND_JOB }, {})


### PR DESCRIPTION
- **Projects**: Jobs monitoring 'scheduled' with type=All is inaccessible without filter
   Jira: [ML-7745](https://iguazio.atlassian.net/browse/ML-7745)
   
   Before:
   <img width="1687" alt="Screenshot 2024-09-03 at 17 01 11" src="https://github.com/user-attachments/assets/d43db397-3c6b-4c6d-ac52-2714c03fda0a">

   After:
   <img width="1688" alt="Screenshot 2024-09-03 at 17 00 34" src="https://github.com/user-attachments/assets/7af209f8-284f-4cd7-921e-4aac59d3517d">

   

[ML-7745]: https://iguazio.atlassian.net/browse/ML-7745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ