### PR TITLE
Fix [Real time pipelines] UI crash `Cannot destructure property width of e.__rf as it is undefined` when clicking on real-time pipeline name

### DIFF
--- a/src/common/ReactFlow/mlReactFlow.util.js
+++ b/src/common/ReactFlow/mlReactFlow.util.js
@@ -81,7 +81,7 @@ export const getLayoutedElements = (nodes, edges, direction = 'TB') => {
   return [layoutedNodes, layoutedEdges]
 }
 
-export const getNodeClassName = (node) => {
+export const getNodeClassName = node => {
   return classnames(
     node.className,
     node.data.subType,
@@ -99,8 +99,8 @@ const getNodeIntersection = (intersectionNode, targetNode) => {
     width: intersectionNodeWidth,
     height: intersectionNodeHeight,
     position: intersectionNodePosition
-  } = intersectionNode.__rf
-  const targetPosition = targetNode.__rf.position
+  } = intersectionNode
+  const targetPosition = targetNode.position
 
   const w = intersectionNodeWidth / 2
   const h = intersectionNodeHeight / 2
@@ -123,7 +123,7 @@ const getNodeIntersection = (intersectionNode, targetNode) => {
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
 const getEdgePosition = (node, intersectionPoint) => {
-  const n = { ...node.__rf.position, ...node.__rf }
+  const n = { ...node.position, ...node }
   const nx = Math.round(n.x)
   const ny = Math.round(n.y)
   const px = Math.round(intersectionPoint.x)

--- a/src/common/ReactFlow/mlReactFlow.util.js
+++ b/src/common/ReactFlow/mlReactFlow.util.js
@@ -99,8 +99,8 @@ const getNodeIntersection = (intersectionNode, targetNode) => {
     width: intersectionNodeWidth,
     height: intersectionNodeHeight,
     position: intersectionNodePosition
-  } = intersectionNode
-  const targetPosition = targetNode.position
+  } = intersectionNode?.__rf || intersectionNode
+  const targetPosition = targetNode?.__rf?.position || targetNode.position
 
   const w = intersectionNodeWidth / 2
   const h = intersectionNodeHeight / 2
@@ -123,7 +123,7 @@ const getNodeIntersection = (intersectionNode, targetNode) => {
 
 // returns the position (top,right,bottom or right) passed node compared to the intersection point
 const getEdgePosition = (node, intersectionPoint) => {
-  const n = { ...node.position, ...node }
+  const n = { ...(node?.__rf?.position || node.position), ...(node?.__rf || node) }
   const nx = Math.round(n.x)
   const ny = Math.round(n.y)
   const px = Math.round(intersectionPoint.x)


### PR DESCRIPTION
- **Real time pipelines**: UI crash "Cannot destructure property width of e.__rf as it is undefined." when clicking on real-time pipeline name
   Jira: https://iguazio.atlassian.net/browse/ML-7780