### PR TITLE
Fix [Jobs and workflows] Hide “node selector” from details view when the function is of type “Dask”

### DIFF
--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -52,7 +52,7 @@ export const getInfoHeaders = (isSpark, selectedJob) => {
     {
       label: 'Node selector',
       id: 'nodeSelectorChips',
-      hidden: isJobKindDask(selectedJob?.labels) || !selectedJob?.nodeSelectorChips?.length
+      hidden: isJobKindDask(selectedJob?.labels)
     },
     { label: 'Priority', id: 'priority' },
     { label: 'Parameters', id: 'parameters' },

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -43,13 +43,17 @@ import { showErrorNotification } from '../../utils/notifications.util'
 
 export const page = JOBS_PAGE
 const LOG_LEVEL_ID = 'logLevel'
-export const getInfoHeaders = isSpark => {
+export const getInfoHeaders = (isSpark, selectedJob) => {
   const infoHeaders = [
     { label: 'UID', id: 'uid' },
     { label: 'Start time', id: 'startTime' },
     { label: 'Last Updated', id: 'updated' },
     { label: 'Run on spot', id: 'runOnSpot' },
-    { label: 'Node selector', id: 'nodeSelectorChips' },
+    {
+      label: 'Node selector',
+      id: 'nodeSelectorChips',
+      hidden: isJobKindDask(selectedJob?.labels) || !selectedJob?.nodeSelectorChips?.length
+    },
     { label: 'Priority', id: 'priority' },
     { label: 'Parameters', id: 'parameters' },
     { label: 'Function', id: 'function' },

--- a/src/elements/JobsTable/jobsTable.util.js
+++ b/src/elements/JobsTable/jobsTable.util.js
@@ -34,7 +34,7 @@ export const generatePageData = (
     details: {
       menu: getJobsDetailsMenu(selectedJob?.labels),
       type: JOBS_PAGE,
-      infoHeaders: getInfoHeaders(!isNil(selectedJob.ui_run)),
+      infoHeaders: getInfoHeaders(!isNil(selectedJob.ui_run), selectedJob),
       refreshLogs: handleFetchJobLogs,
       removeLogs: () => {},
       withLogsRefreshBtn: true,


### PR DESCRIPTION
- **Jobs and workflows**: Hide “node selector”from details view when the function is of type “Dask”
   Jira: [ML-7794](https://iguazio.atlassian.net/browse/ML-7794)

[ML-7794]: https://iguazio.atlassian.net/browse/ML-7794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ