### PR TITLE
Fix [Feature sets] project name is missing from the request url when navigating between feature sets

### DIFF
--- a/src/components/FeatureStore/FeatureSets/FeatureSets.js
+++ b/src/components/FeatureStore/FeatureSets/FeatureSets.js
@@ -299,7 +299,7 @@ const FeatureSets = ({
     fetchData,
     setExpandedRowsData: setSelectedRowData,
     createRowData: rowItem =>
-      createFeatureSetsRowData(rowItem, FEATURE_SETS_TAB, params.projectName),
+      createFeatureSetsRowData(rowItem, params.projectName, FEATURE_SETS_TAB),
     fetchTags,
     filters: filtersStore
   })


### PR DESCRIPTION
- **Feature sets**: project name is missing from the request url when navigating between feature sets
   Jira: https://github.com/mlrun/ui/pull/2726