### PR TITLE
Fix [Feature vectors] project name is missing from the request for tags `1.7.x`

### DIFF
--- a/src/components/AddToFeatureVectorPage/AddToFeatureVectorPage.js
+++ b/src/components/AddToFeatureVectorPage/AddToFeatureVectorPage.js
@@ -180,10 +180,10 @@ const AddToFeatureVectorPage = ({
   )
 
   const fetchTags = useCallback(
-    (project = params.project) => {
+    (project = params.projectName) => {
       return dispatch(getFilterTagOptions({ fetchTags: fetchFeatureSetsTags, project }))
     },
-    [dispatch, fetchFeatureSetsTags, params.project]
+    [dispatch, fetchFeatureSetsTags, params.projectName]
   )
 
   const handleRefresh = filters => {


### PR DESCRIPTION
- **Feature vectors**: project name is missing from the request for tags
   Backported to `1.7.x` from #2766 
   Jira: https://iguazio.atlassian.net/browse/ML-7839