### PR TITLE
Fix [Job Artifacts] project name is missing from the request url after click on Artifacts tab

### DIFF
--- a/src/components/DetailsArtifacts/DetailsArtifacts.js
+++ b/src/components/DetailsArtifacts/DetailsArtifacts.js
@@ -141,9 +141,9 @@ const DetailsArtifacts = ({
       }
 
       if (workflowId) {
-        return fetchJob(params.projectName, params.jobId, iteration).then(job => {
-          if (job) {
-            const selectedJob = getJobAccordingIteration(job)
+        return fetchJob(job.project || params.projectName, params.jobId, iteration).then(responseJob => {
+          if (responseJob) {
+            const selectedJob = getJobAccordingIteration(responseJob)
 
             setArtifactsPreviewContent(
               generateArtifactsPreviewContent(selectedJob, selectedJob.artifacts)


### PR DESCRIPTION
-  **Job Artifacts**: Project name is missing from the request url after click on Artifacts tab
   Jira: https://iguazio.atlassian.net/browse/ML-7971