### PR TITLE
Fix [ML Functions] There is no redirection to function overview pane `1.7.x`

### DIFF
--- a/src/components/FunctionsPage/Functions.js
+++ b/src/components/FunctionsPage/Functions.js
@@ -589,10 +589,10 @@ const Functions = ({
   }, [params.projectName])
 
   useEffect(() => {
-    if (params.hash && pageData.details.menu.length > 0) {
+    if ((params.funcName || params.hash) && pageData.details.menu.length > 0) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, pageData.details.menu, location, params.hash, params.tab])
+  }, [navigate, pageData.details.menu, location, params.hash, params.funcName, params.tab])
 
   useEffect(() => {
     checkForSelectedFunction(


### PR DESCRIPTION
- **ML Functions**: There is no redirection to function overview pane `1.7.x`
   Backported to `1.7.x` from #2797 
   Jira: https://iguazio.atlassian.net/browse/ML-8016
   