### PR TITLE
Fix [Jobs] run UI does not present run handler `1.7.x`

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -208,6 +208,9 @@ export const generateJobsContent = selectedItem => {
     parameters: {
       value: selectedItem.parametersChips
     },
+    handler: {
+      value: selectedItem.handler
+    },
     function: {
       value: selectedItem.function
     },

--- a/src/components/Jobs/jobs.util.js
+++ b/src/components/Jobs/jobs.util.js
@@ -55,6 +55,7 @@ export const getInfoHeaders = (isSpark, selectedJob) => {
       hidden: isJobKindDask(selectedJob?.labels)
     },
     { label: 'Priority', id: 'priority' },
+    { label: 'Handler', id: 'handler' },
     { label: 'Parameters', id: 'parameters' },
     { label: 'Function', id: 'function' },
     { label: 'Function tag', id: 'functionTag' },


### PR DESCRIPTION
- **Jobs**: run UI does not present run handler
   Backported to `1.7.x` from #2796 
   Jira: https://iguazio.atlassian.net/browse/ML-8005

   After:
   ![image](https://github.com/user-attachments/assets/530d6a81-cc9e-4669-91dd-ed2d8b9778a0)
   