### PR TITLE
Fix [UI] Remove "Default handler" from app runtime function overview `1.7.x`

### DIFF
--- a/src/components/FunctionsPage/functions.util.js
+++ b/src/components/FunctionsPage/functions.util.js
@@ -146,7 +146,7 @@ const generateFunctionsInfoHeaders = selectedFunction => {
       id: 'internalUrl',
       hidden: selectedFunction.type !== FUNCTION_TYPE_APPLICATION
     },
-    { label: 'Image', id: 'image' },
+    { label: 'Image', id: 'image', hidden: selectedFunction.type === FUNCTION_TYPE_APPLICATION },
     {
       label: 'Application image',
       id: 'applicationImage',
@@ -159,9 +159,17 @@ const generateFunctionsInfoHeaders = selectedFunction => {
       id: 'internalPort',
       hidden: selectedFunction.type !== FUNCTION_TYPE_APPLICATION
     },
-    { label: 'Code origin', id: 'codeOrigin' },
+    {
+      label: 'Code origin',
+      id: 'codeOrigin',
+      hidden: selectedFunction.type === FUNCTION_TYPE_APPLICATION
+    },
     { label: 'Updated', id: 'updated' },
-    { label: 'Default handler', id: 'defaultHandler' },
+    {
+      label: 'Default handler',
+      id: 'defaultHandler',
+      hidden: selectedFunction.type === FUNCTION_TYPE_APPLICATION
+    },
     { label: 'Description', id: 'description' }
   ]
 }


### PR DESCRIPTION
- **Functions**: Remove "Default handler" from app runtime function overview `1.7.x`
   Backported to `1.7.x` from #2801 
   Jira: https://iguazio.atlassian.net/browse/ML-7988, https://iguazio.atlassian.net/browse/ML-8014
   