### PR TITLE
Fix [Cross project] Wrong redirection from the breadcrumbs menu on the Jobs monitoring `1.7.x`

### DIFF
--- a/src/common/Breadcrumbs/breadcrumbs.util.js
+++ b/src/common/Breadcrumbs/breadcrumbs.util.js
@@ -70,7 +70,7 @@ export const generateMlrunScreens = params =>
         {
           label: 'Jobs monitoring',
           id: JOBS_MONITORING_PAGE,
-          link: `/${PROJECTS_PAGE_PATH}/*/${JOBS_MONITORING_PAGE}`
+          linkTo: `/${PROJECTS_PAGE_PATH}/*/${JOBS_MONITORING_PAGE}`
         }
       ]
 

--- a/src/elements/BreadcrumbsDropdown/BreadcrumbsDropdown.js
+++ b/src/elements/BreadcrumbsDropdown/BreadcrumbsDropdown.js
@@ -85,7 +85,7 @@ const BreadcrumbsDropdown = forwardRef(
                   </a>
                 ) : (
                   <Link
-                    to={`${link}/${listItem.id}${screen ? `/${screen}` : ''}${
+                    to={listItem.linkTo || `${link}/${listItem.id}${screen ? `/${screen}` : ''}${
                       tab ? `/${tab}` : ''
                     }`}
                     onClick={onClick}


### PR DESCRIPTION
- **Cross project**: Wrong redirection from the breadcrumbs menu on the Jobs monitoring `1.7.x`
   Backported to `1.7.x` from #2811 
   Jira: https://iguazio.atlassian.net/browse/ML-8020