### PR TITLE
Fix [Cross project] Runs of type 'Job' displayed in the runs list of type 'mpijob' `1.7.x`

### DIFF
--- a/src/components/ProjectsJobsMonitoring/ProjectsJobsMonitoring.js
+++ b/src/components/ProjectsJobsMonitoring/ProjectsJobsMonitoring.js
@@ -180,7 +180,7 @@ const ProjectsJobsMonitoring = ({ fetchAllJobRuns, fetchJobFunction, fetchJobs }
                 JOB_KIND_LOCAL
 
               return (
-                !filters.type || filters.type === FILTER_ALL_ITEMS || filters.type.includes(type)
+                !filters.type || filters.type === FILTER_ALL_ITEMS || filters.type.split(',').includes(type)
               )
             })
           const responseAbortingJobs = parsedJobs.reduce((acc, job) => {


### PR DESCRIPTION
- **Cross project**: Runs of type 'Job' displayed in the runs list of type 'mpijob' `1.7.x`
   Backported to `1.7.x` from #2818 
   Jira: https://iguazio.atlassian.net/browse/ML-8037
   