### PR TITLE
Fix [General] infinite loop when the BE endpoints return error `1.7.x`

### DIFF
--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -154,9 +154,9 @@ const responseRejectInterceptor = error => {
 
       if (
         consecutiveErrorsCount === MAX_CONSECUTIVE_ERRORS_COUNT &&
-        window.location.pathname !== `/${PROJECTS_PAGE_PATH}`
+        window.location.pathname !== `${process.env.PUBLIC_URL}/${PROJECTS_PAGE_PATH}`
       ) {
-        window.location.href = '/projects'
+        window.location.href = `${process.env.PUBLIC_URL}/${PROJECTS_PAGE_PATH}`
       }
     }
   }


### PR DESCRIPTION
- **General**: infinite loop when the BE endpoints return error `1.7.x`
   Backported to `1.7.x` from #2824 
   Jira: https://iguazio.atlassian.net/browse/ML-8034
