### PR TITLE
Fix [Model Endpoints] take ~35 second to fetch data `1.7.x`

### DIFF
--- a/src/components/ModelsPage/ModelEndpoints/ModelEndpoints.js
+++ b/src/components/ModelsPage/ModelEndpoints/ModelEndpoints.js
@@ -117,7 +117,6 @@ const ModelEndpoints = () => {
             }
           },
           params: {
-            metric: 'latency_avg_1h',
             start: 'now-10m'
           }
         })

--- a/src/utils/createArtifactsContent.js
+++ b/src/utils/createArtifactsContent.js
@@ -424,8 +424,6 @@ export const createModelEndpointsRowData = (artifact, project) => {
     ? `store://functions/${artifact.spec.function_uri}`
     : ''
   const { key: functionName } = parseUri(functionUri)
-  const averageLatency = artifact.status?.metrics?.real_time?.latency_avg_1h?.[0]?.[1]
-
   const isEndpointTypeRouter = artifact?.status?.endpoint_type === 2
 
   return {
@@ -503,13 +501,6 @@ export const createModelEndpointsRowData = (artifact, project) => {
         headerId: 'lastprediction',
         headerLabel: 'Last prediction',
         value: formatDatetime(artifact.status?.last_request, '-'),
-        className: 'table-cell-1'
-      },
-      {
-        id: `averageLatency.${artifact.ui.identifierUnique}`,
-        headerId: 'averagelatency',
-        headerLabel: 'Average latency',
-        value: averageLatency ? `${(averageLatency / 1000).toFixed(2)}ms` : '-',
         className: 'table-cell-1'
       },
       {


### PR DESCRIPTION
- **Model Endpoints**: It takes ~35 second to fetch data `1.7.x`
   Backported to `1.7.x` from #2830 
   Jira: https://iguazio.atlassian.net/browse/ML-8070
   
   After:
   ![image](https://github.com/user-attachments/assets/6cdfaa31-d9d2-4a62-afd1-2f380bb080d8)

