### PR TITLE
Fix [UI] Warning: findDOMNode is deprecated `1.7.x`

### DIFF
--- a/src/common/Download/DownloadContainer.js
+++ b/src/common/Download/DownloadContainer.js
@@ -17,7 +17,7 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import React from 'react'
+import React, { useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Transition, TransitionGroup } from 'react-transition-group'
 import { isEmpty } from 'lodash'
@@ -31,6 +31,7 @@ import { ReactComponent as CloseIcon } from 'igz-controls/images/close.svg'
 import './downloadContainer.scss'
 
 const DownloadContainer = () => {
+  const nodeRef = useRef(null)
   const downloadStore = useSelector(store => store.downloadStore)
   const dispatch = useDispatch()
   const duration = 500
@@ -60,7 +61,7 @@ const DownloadContainer = () => {
   return (
     <TransitionGroup component={null}>
       {!isEmpty(downloadStore.downloadList) && downloadStore.showDownloadsList && (
-        <Transition timeout={duration}>
+        <Transition timeout={duration} nodeRef={nodeRef}>
           {state => (
             <div
               className="download-container"

--- a/src/common/Notification/Notification.js
+++ b/src/common/Notification/Notification.js
@@ -51,8 +51,8 @@ const Notification = () => {
     <div className="notifications-wrapper">
       <TransitionGroup component={null}>
         {notificationStore.notification.map(item => {
+          const nodeRef = React.createRef()
           const isSuccessResponse = inRange(item.status, 200, 300)
-
           const transitionStyles = {
             entered: {
               transform: 'translateY(0)',
@@ -68,6 +68,7 @@ const Notification = () => {
 
           return (
             <Transition
+              nodeRef={nodeRef}
               key={`css${item.id}`}
               timeout={duration}
               onEntered={() => {


### PR DESCRIPTION
- **UI**: Warning: findDOMNode is deprecated
   Backported to `1.7.x` from #2833 
   Jira: https://iguazio.atlassian.net/browse/ML-6376