### PR TITLE
Fix [Projects] Clicking on search text box in projects refreshes the screen `1.7.1`

### DIFF
--- a/src/components/ProjectsPage/ProjectsView.js
+++ b/src/components/ProjectsPage/ProjectsView.js
@@ -107,7 +107,7 @@ const ProjectsView = ({
         />
       )}
       <div className="projects__wrapper">
-        {projectStore.projects.length > 0 && <ProjectsMonitoring />}
+        <ProjectsMonitoring />
         <PageHeader title="Projects" />
         <div className="projects-content-header">
           <div className="projects-content-header__row">

--- a/src/utils/generateMonitoringData.js
+++ b/src/utils/generateMonitoringData.js
@@ -47,7 +47,7 @@ export const generateMonitoringStats = (data, navigate, dispatch, tab) => {
   return tab === JOBS_MONITORING_JOBS_TAB
     ? {
         all: {
-          counter: data.all,
+          counter: data.all || 0,
           link: () => navigateToJobsMonitoringPage({ [STATUS_FILTER]: [FILTER_ALL_ITEMS] })
         },
         counters: [
@@ -85,7 +85,7 @@ export const generateMonitoringStats = (data, navigate, dispatch, tab) => {
     : tab === JOBS_MONITORING_WORKFLOWS_TAB
       ? {
           all: {
-            counter: data.all,
+            counter: data.all || 0,
             link: () => navigateToJobsMonitoringPage({ [STATUS_FILTER]: [FILTER_ALL_ITEMS] })
           },
           counters: [
@@ -106,7 +106,8 @@ export const generateMonitoringStats = (data, navigate, dispatch, tab) => {
             },
             {
               counter: data.failed,
-              link: () => navigateToJobsMonitoringPage({ [STATUS_FILTER]: [ERROR_STATE, FAILED_STATE] }),
+              link: () =>
+                navigateToJobsMonitoringPage({ [STATUS_FILTER]: [ERROR_STATE, FAILED_STATE] }),
               statusClass: 'failed',
               tooltip: 'Error, Failed'
             },
@@ -120,7 +121,7 @@ export const generateMonitoringStats = (data, navigate, dispatch, tab) => {
         }
       : {
           all: {
-            counter: data.all,
+            counter: data.all || 0,
             link: () => navigateToJobsMonitoringPage({ [TYPE_FILTER]: FILTER_ALL_ITEMS }, {})
           },
           jobs: {


### PR DESCRIPTION
- **Projects**: Clicking on search text box in projects refreshes the screen
   Backported to `1.7.1` from #2853 
   Jira: [ML-8171](https://iguazio.atlassian.net/browse/ML-8171)

[ML-8171]: https://iguazio.atlassian.net/browse/ML-8171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ