### PR TITLE
Fix [Monitoring] missing tooltips on counters `1.7.1`

### DIFF
--- a/src/elements/ProjectsMonitoringCounters/JobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/JobsCounters.js
@@ -74,7 +74,7 @@ const JobsCounters = () => {
                   {projectStore.projectsSummary.loading ? (
                     <Loader section small secondary />
                   ) : (
-                    <Tooltip template={<TextTooltipTemplate text={tooltip} />}>
+                    <Tooltip textShow template={<TextTooltipTemplate text={tooltip} />}>
                       <span>
                         {counter}
                         <i className={`state-${statusClass}`} />

--- a/src/elements/ProjectsMonitoringCounters/WorkflowsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/WorkflowsCounters.js
@@ -83,7 +83,7 @@ const WorkflowsCounters = () => {
                 {projectStore.projectsSummary.loading ? (
                   <Loader section small secondary />
                 ) : (
-                  <Tooltip template={<TextTooltipTemplate text={tooltip} />}>
+                  <Tooltip textShow template={<TextTooltipTemplate text={tooltip} />}>
                     <span>
                       {counter}
                       <i className={`state-${statusClass}`} />


### PR DESCRIPTION
- **Monitoring] missing tooltips on counters `1.7.1`
   Backported to `1.7.1` from #2865 
   Jira: https://iguazio.atlassian.net/browse/ML-8217
   