### PR TITLE
Fix [Jobs] reason for job failure is not displayed `1.7.1`

### DIFF
--- a/src/utils/parseJob.js
+++ b/src/utils/parseJob.js
@@ -52,7 +52,12 @@ export const parseJob = (job, tab, customState, customError) => {
           : convertTriggerToCrontab(job.scheduled_object?.schedule)
       },
       startTime: new Date(job.last_run?.status?.start_time),
-      state: getState(job.last_run?.status?.state, JOBS_PAGE, JOB_KIND_JOB),
+      state: getState(
+        job.last_run?.status?.state,
+        JOBS_PAGE,
+        JOB_KIND_JOB,
+        job.last_run?.status?.reason ?? job.last_run?.status?.error
+      ),
       type:
         job.kind === JOB_KIND_PIPELINE || jobHasWorkflowLabel(job) ? JOB_KIND_WORKFLOW : job.kind,
       ui: {
@@ -91,7 +96,12 @@ export const parseJob = (job, tab, customState, customError) => {
       results: job.status?.results || {},
       resultsChips: parseKeyValues(job.status?.results || {}),
       startTime: new Date(job.status?.start_time),
-      state: getState(customState || job.status?.state, JOBS_PAGE, JOB_KIND_JOB, job.status?.reason),
+      state: getState(
+        customState || job.status?.state,
+        JOBS_PAGE,
+        JOB_KIND_JOB,
+        job.status?.reason ?? job.status?.error
+      ),
       ui_run: job.status?.ui_url,
       uid: job.metadata.uid,
       updated: new Date(job.status?.last_update),


### PR DESCRIPTION
- **Jobs**: Reason for job failure is not displayed
   Backported to `1.7.x` from https://github.com/mlrun/ui/pull/2870
   Jira: [ML-8241](https://iguazio.atlassian.net/browse/ML-8241)

[ML-8241]: https://iguazio.atlassian.net/browse/ML-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ