### PR TITLE
Fix [Jobs monitoring] "Past 24 hours" time filter is applied after click on "In process" jobs

### DIFF
--- a/src/elements/ProjectsMonitoringCounters/JobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/JobsCounters.js
@@ -61,7 +61,11 @@ const JobsCounters = () => {
             {projectStore.projectsSummary.loading ? (
               <Loader section small secondary />
             ) : (
-              <span className="stats__link" onClick={jobStats.all.link} data-testid="jobs_see_all">
+              <span
+                className="stats__link"
+                onClick={jobStats.all.link}
+                data-testid="jobs_total_counter"
+              >
                 {jobStats.all.counter}
               </span>
             )}
@@ -73,7 +77,7 @@ const JobsCounters = () => {
                   <Loader section small secondary />
                 ) : (
                   <Tooltip textShow template={<TextTooltipTemplate text={tooltip} />}>
-                    <span>
+                    <span data-testid={`jobs_${statusClass}_counter`}>
                       {counter}
                       <i className={`state-${statusClass}`} />
                     </span>

--- a/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
@@ -74,10 +74,10 @@ const ScheduledJobsCounters = () => {
             ) : (
               <span
                 className="stats__link"
-                onClick={scheduledStats.all.link}
+                onClick={scheduledStats.jobs.link}
                 data-testid="scheduled_total_see_all"
               >
-                {scheduledStats.jobs.counter}{' '}
+                {scheduledStats.jobs.counter}
               </span>
             )}
           </span>
@@ -93,14 +93,30 @@ const ScheduledJobsCounters = () => {
                 onClick={scheduledStats.workflows.link}
                 data-testid="scheduled_wf_see_all"
               >
-                {scheduledStats.workflows.counter}{' '}
+                {scheduledStats.workflows.counter}
+              </span>
+            )}
+          </span>
+        </StatsCard.Col>
+        <StatsCard.Col>
+          <h6 className="stats__subtitle">Total</h6>
+          <span className="stats__counter">
+            {projectStore.projectsSummary.loading ? (
+              <Loader section small secondary />
+            ) : (
+              <span
+                className="stats__link"
+                onClick={scheduledStats.all.link}
+                data-testid="scheduled_wf_see_all"
+              >
+                {scheduledStats.all.counter}
               </span>
             )}
           </span>
         </StatsCard.Col>
       </StatsCard.Row>
       <StatsCard.Row>
-        <StatsCard.Col/>
+        <StatsCard.Col />
       </StatsCard.Row>
     </StatsCard>
   )

--- a/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/ScheduledJobsCounters.js
@@ -75,7 +75,7 @@ const ScheduledJobsCounters = () => {
               <span
                 className="stats__link"
                 onClick={scheduledStats.jobs.link}
-                data-testid="scheduled_total_see_all"
+                data-testid="scheduled_jobs_counter"
               >
                 {scheduledStats.jobs.counter}
               </span>
@@ -91,7 +91,7 @@ const ScheduledJobsCounters = () => {
               <span
                 className="stats__link"
                 onClick={scheduledStats.workflows.link}
-                data-testid="scheduled_wf_see_all"
+                data-testid="scheduled_wf_counter"
               >
                 {scheduledStats.workflows.counter}
               </span>
@@ -107,7 +107,7 @@ const ScheduledJobsCounters = () => {
               <span
                 className="stats__link"
                 onClick={scheduledStats.all.link}
-                data-testid="scheduled_wf_see_all"
+                data-testid="scheduled_total_counter"
               >
                 {scheduledStats.all.counter}
               </span>

--- a/src/elements/ProjectsMonitoringCounters/WorkflowsCounters.js
+++ b/src/elements/ProjectsMonitoringCounters/WorkflowsCounters.js
@@ -74,7 +74,7 @@ const WorkflowsCounters = () => {
               <span
                 className="stats__link"
                 onClick={workflowsStats.all.link}
-                data-testid="workflows_see_all"
+                data-testid="workflows_total_counter"
               >
                 {workflowsStats.all.counter}
               </span>
@@ -87,7 +87,7 @@ const WorkflowsCounters = () => {
                   <Loader section small secondary />
                 ) : (
                   <Tooltip textShow template={<TextTooltipTemplate text={tooltip} />}>
-                    <span>
+                    <span data-testid={`wf_${statusClass}_counter`}>
                       {counter}
                       <i className={`state-${statusClass}`} />
                     </span>

--- a/src/utils/generateMonitoringData.js
+++ b/src/utils/generateMonitoringData.js
@@ -51,17 +51,13 @@ export const generateMonitoringStats = (data, navigate, tab) => {
           {
             counter: data.running,
             link: () =>
-              navigateToJobsMonitoringPage(
-                {
-                  [STATUS_FILTER]: ['running', 'pending', 'aborting']
-                },
-                {
-                  [DATES_FILTER]: getDatePickerFilterValue(
-                    datePickerPastOptions,
-                    ANY_TIME_DATE_OPTION
-                  )
-                }
-              ),
+              navigateToJobsMonitoringPage({
+                [STATUS_FILTER]: ['running', 'pending', 'aborting'],
+                [DATES_FILTER]: getDatePickerFilterValue(
+                  datePickerPastOptions,
+                  ANY_TIME_DATE_OPTION
+                ).initialSelectedOptionId
+              }),
             statusClass: 'running',
             tooltip: 'Aborting, Pending, Running'
           },
@@ -89,15 +85,13 @@ export const generateMonitoringStats = (data, navigate, tab) => {
             {
               counter: data.running,
               link: () =>
-                navigateToJobsMonitoringPage(
-                  { [STATUS_FILTER]: ['running'] },
-                  {
-                    [DATES_FILTER]: getDatePickerFilterValue(
-                      datePickerPastOptions,
-                      ANY_TIME_DATE_OPTION
-                    )
-                  }
-                ),
+                navigateToJobsMonitoringPage({
+                  [STATUS_FILTER]: ['running'],
+                  [DATES_FILTER]: getDatePickerFilterValue(
+                    datePickerPastOptions,
+                    ANY_TIME_DATE_OPTION
+                  ).initialSelectedOptionId
+                }),
               statusClass: 'running',
               tooltip: 'Running'
             },

--- a/src/utils/generateMonitoringData.js
+++ b/src/utils/generateMonitoringData.js
@@ -30,11 +30,7 @@ import {
   ERROR_STATE,
   FAILED_STATE
 } from '../constants'
-import {
-  ANY_TIME_DATE_OPTION,
-  datePickerPastOptions,
-  getDatePickerFilterValue
-} from './datePicker.util'
+import { ANY_TIME_DATE_OPTION } from './datePicker.util'
 
 export const generateMonitoringStats = (data, navigate, tab) => {
   const navigateToJobsMonitoringPage = (filters = {}) => {
@@ -53,10 +49,7 @@ export const generateMonitoringStats = (data, navigate, tab) => {
             link: () =>
               navigateToJobsMonitoringPage({
                 [STATUS_FILTER]: ['running', 'pending', 'aborting'],
-                [DATES_FILTER]: getDatePickerFilterValue(
-                  datePickerPastOptions,
-                  ANY_TIME_DATE_OPTION
-                ).initialSelectedOptionId
+                [DATES_FILTER]: ANY_TIME_DATE_OPTION
               }),
             statusClass: 'running',
             tooltip: 'Aborting, Pending, Running'
@@ -87,10 +80,7 @@ export const generateMonitoringStats = (data, navigate, tab) => {
               link: () =>
                 navigateToJobsMonitoringPage({
                   [STATUS_FILTER]: ['running'],
-                  [DATES_FILTER]: getDatePickerFilterValue(
-                    datePickerPastOptions,
-                    ANY_TIME_DATE_OPTION
-                  ).initialSelectedOptionId
+                  [DATES_FILTER]: ANY_TIME_DATE_OPTION
                 }),
               statusClass: 'running',
               tooltip: 'Running'


### PR DESCRIPTION
- **Jobs monitoring**: "Past 24 hours" time filter is applied after click on "In process" jobs
   Jira: [ML-8481](https://iguazio.atlassian.net/browse/ML-8481)

[ML-8481]: https://iguazio.atlassian.net/browse/ML-8481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ