### PR TITLE
Fix [Filters] scrollbar and fields padding

### DIFF
--- a/src/components/FilterMenuModal/filterMenuModal.scss
+++ b/src/components/FilterMenuModal/filterMenuModal.scss
@@ -21,8 +21,8 @@
   }
 
   &__list {
-    padding-right: 20px;
-    margin: 0;
+    padding-right: 15px;
+    margin: 0 -15px 0 0;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
- **Filters**: Scrollbar and fields padding

   Before:
   <img width="302" alt="Screenshot 2024-12-13 at 14 02 13" src="https://github.com/user-attachments/assets/b9b5edef-864a-4e30-9473-b4c3fbbf66d4" />
   <img width="286" alt="Screenshot 2024-12-13 at 14 02 01" src="https://github.com/user-attachments/assets/0f1b7393-9f34-456b-9cf1-8991d2d2588f" />
   <img width="275" alt="Screenshot 2024-12-13 at 14 01 50" src="https://github.com/user-attachments/assets/fdf43b33-358a-4879-97e5-0da60582d6a8" />

   After:
   <img width="286" alt="Screenshot 2024-12-13 at 14 00 53" src="https://github.com/user-attachments/assets/34f0fdd7-e258-4e5a-b94c-1f4e04bd54f3" />
   <img width="262" alt="Screenshot 2024-12-13 at 14 01 12" src="https://github.com/user-attachments/assets/4f94f88a-a931-4b46-8bc0-08b26ba81ac3" />
   <img width="271" alt="Screenshot 2024-12-13 at 14 01 32" src="https://github.com/user-attachments/assets/37d393be-9921-41e1-a556-63f71ff4cc9a" />

   