### PR TITLE
Fix [Pagination] blank white space around page numbers

### DIFF
--- a/src/common/Pagination/Pagination.js
+++ b/src/common/Pagination/Pagination.js
@@ -21,7 +21,7 @@ import React, { useCallback, useMemo, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
-import { max, min } from 'lodash'
+import { max } from 'lodash'
 
 import { RoundedIcon } from 'igz-controls/components'
 
@@ -208,18 +208,6 @@ const Pagination = ({
     return { width: paginationItemWidth }
   }, [])
 
-  const getPaginationPagesStyle = useCallback(
-    (paginationItems, paginationItem, index) => {
-      const maxFePages = paginationConfig[BE_PAGE_SIZE] / paginationConfig[FE_PAGE_SIZE]
-      const maxPage = max(paginationItems)
-      const maxPageCount = min([7, maxPage, maxFePages])
-      const paginationPagesWidth = `${maxPageCount * 40}px`
-
-      return { minWidth: paginationPagesWidth }
-    },
-    [paginationConfig]
-  )
-
   return (
     <div className="pagination">
       {paginationConfig.isNewResponse && (
@@ -247,11 +235,7 @@ const Pagination = ({
               <Arrow />
             </RoundedIcon>
 
-            <div
-              className="pagination-pages"
-              ref={paginationPagesRef}
-              style={getPaginationPagesStyle(paginationItems)}
-            >
+            <div className="pagination-pages" ref={paginationPagesRef}>
               {paginationItems.map(
                 (pageItem, index) =>
                   pageItem && (

--- a/src/common/Pagination/pagination.scss
+++ b/src/common/Pagination/pagination.scss
@@ -26,7 +26,9 @@
 
   .pagination-pages {
     display: flex;
+    align-items: center;
     justify-content: center;
+    margin: 0 5px;
   }
 
   .pagination-btn {
@@ -36,7 +38,7 @@
     display: flex;
     justify-content: center;
     border: none;
-    padding: 4px 5px;
+    padding: 4px 8px;
     margin: 0 2px;
     font-size: 14px;
     font-weight: normal;
@@ -56,7 +58,6 @@
     }
 
     .pagination-page-number {
-      padding: 2px 3px;
       box-sizing: content-box;
       border-bottom: 2px solid transparent;
       border-top: 2px solid transparent;


### PR DESCRIPTION
- **Pagination**: Blank white space around page numbers
   Jira: [ML-8928](https://iguazio.atlassian.net/browse/ML-8928)

   Before:
   <img width="1355" alt="Screenshot 2024-12-29 at 15 55 46" src="https://github.com/user-attachments/assets/5f7fbb0e-c67a-4ecc-8a6f-cd27da4f0525" />

   After: 
   <img width="1401" alt="Screenshot 2024-12-29 at 15 55 10" src="https://github.com/user-attachments/assets/cf6ebdf7-cb62-474f-8df5-a7b92726f165" />

[ML-8928]: https://iguazio.atlassian.net/browse/ML-8928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ