### PR TITLE
Fix [Alerts history] "Failed to retrieve data " when click on Job ID from Alert page

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -182,7 +182,7 @@ export const generateArtifactsContent = (detailsType, selectedItem, projectName)
         value: formatDatetime(selectedItem.updated, 'N/A')
       },
       framework: {
-        value: detailsType === MODELS_TAB ? (selectedItem.framework ?? '') : null
+        value: detailsType === MODELS_TAB ? selectedItem.framework ?? '' : null
       },
       algorithm: {
         value: selectedItem.algorithm
@@ -239,7 +239,7 @@ export const generateAlertsContent = selectedItem => {
       handleClick: () =>
         openPopUp(JobPopUp, {
           jobData: {
-            project: selectedItem?.job?.name,
+            project: selectedItem?.project,
             uid: selectedItem?.job?.jobUid,
             iter: 0
           }


### PR DESCRIPTION
- **Alerts history**: "Failed to retrieve data " when click on Job ID from Alert page
   Jira: https://iguazio.atlassian.net/browse/ML-8916?filter=-1

   <img width="1438" alt="ML-8916-after-fix" src="https://github.com/user-attachments/assets/433a2b23-460b-41e1-be39-3f502641b4f7" />
