### PR TITLE
Fix [UI] Artifacts Fail showing html files when stored as "s3" `1.7.x`

### DIFF
--- a/src/common/Download/DownloadItem.js
+++ b/src/common/Download/DownloadItem.js
@@ -108,7 +108,7 @@ const DownloadItem = ({ downloadItem }) => {
               throw new Error('Error during loading the file')
             }
 
-            config.params.offset += chunkSize
+            config.params.offset += response.data.byteLength
           }
 
           response.data = fullFile

--- a/src/common/Download/DownloadItem.js
+++ b/src/common/Download/DownloadItem.js
@@ -103,12 +103,12 @@ const DownloadItem = ({ downloadItem }) => {
             response = await api.getArtifactPreview(downloadItem.projectName, config)
 
             if (response?.data) {
-              fullFile = new Blob([fullFile, response.data], { type: response.data.type })
+              fullFile = new Blob([fullFile, response.data])
             } else {
               throw new Error('Error during loading the file')
             }
 
-            config.params.offset += response.data.byteLength
+            config.params.offset += response.data.byteLength ?? chunkSize
           }
 
           response.data = fullFile

--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -243,7 +243,7 @@ export const fetchArtifactPreview = async (
         throw new Error('Error during loading the preview file')
       }
 
-      config.params.offset += response.data.size
+      config.params.offset += response.data.size ?? chunkSize
     }
 
     response.data = fullFile

--- a/src/utils/getArtifactPreview.js
+++ b/src/utils/getArtifactPreview.js
@@ -243,7 +243,7 @@ export const fetchArtifactPreview = async (
         throw new Error('Error during loading the preview file')
       }
 
-      config.params.offset += chunkSize
+      config.params.offset += response.data.size
     }
 
     response.data = fullFile


### PR DESCRIPTION
- **UI**: Artifacts Fail showing html files when stored as "s3" `1.7.x`
   Backport to `1.7.x` from https://github.com/mlrun/ui/pull/2964
   JIra: https://iguazio.atlassian.net/browse/ML-8974