### PR TITLE
Fix [UI] Move analyses tabs to Demo mode in `1.8.0`

### DIFF
--- a/src/components/Datasets/Datasets.js
+++ b/src/components/Datasets/Datasets.js
@@ -56,6 +56,7 @@ import { toggleYaml } from '../../reducers/appReducer'
 import { transformSearchParams } from '../../utils/filter.util'
 import { useFiltersFromSearchParams } from '../../hooks/useFiltersFromSearchParams.hook'
 import { usePagination } from '../../hooks/usePagination.hook'
+import { useMode } from '../../hooks/mode.hook'
 
 import './datasets.scss'
 
@@ -72,6 +73,7 @@ const Datasets = ({ isAllVersions = false }) => {
   const dispatch = useDispatch()
   const location = useLocation()
   const navigate = useNavigate()
+  const { isDemoMode } = useMode()
   const params = useParams()
   const paginationConfigDatasetsRef = useRef({})
   const paginationConfigDatasetVersionsRef = useRef({})
@@ -83,8 +85,8 @@ const Datasets = ({ isAllVersions = false }) => {
   const datasetsFilters = useFiltersFromSearchParams(filtersConfig)
 
   const pageData = useMemo(
-    () => generatePageData(selectedDataset, viewMode, params),
-    [selectedDataset, viewMode, params]
+    () => generatePageData(selectedDataset, viewMode, params, false, isDemoMode),
+    [isDemoMode, selectedDataset, viewMode, params]
   )
 
   const detailsFormInitialValues = useMemo(

--- a/src/components/Datasets/datasets.util.js
+++ b/src/components/Datasets/datasets.util.js
@@ -96,7 +96,7 @@ export const getFiltersConfig = isAllVersions => ({
 
 export const registerDatasetTitle = 'Register dataset'
 
-export const generateDataSetsDetailsMenu = selectedItem => [
+export const generateDataSetsDetailsMenu = (selectedItem, isDemoMode) => [
   {
     label: 'overview',
     id: 'overview'
@@ -113,14 +113,20 @@ export const generateDataSetsDetailsMenu = selectedItem => [
   {
     label: 'analysis',
     id: 'analysis',
-    hidden: !selectedItem.extra_data
+    hidden: !isDemoMode || !selectedItem.extra_data
   }
 ]
 
-export const generatePageData = (selectedItem, viewMode, params, isDetailsPopUp = false) => ({
+export const generatePageData = (
+  selectedItem,
+  viewMode,
+  params,
+  isDetailsPopUp = false,
+  isDemoMode
+) => ({
   page: DATASETS_PAGE,
   details: {
-    menu: generateDataSetsDetailsMenu(selectedItem),
+    menu: generateDataSetsDetailsMenu(selectedItem, isDemoMode),
     infoHeaders,
     type: DATASETS_TAB,
     hideBackBtn: viewMode === FULL_VIEW_MODE,

--- a/src/components/FeatureStore/FeatureSets/FeatureSets.js
+++ b/src/components/FeatureStore/FeatureSets/FeatureSets.js
@@ -58,6 +58,7 @@ import { useVirtualization } from '../../../hooks/useVirtualization.hook'
 import { useInitialTableFetch } from '../../../hooks/useInitialTableFetch.hook'
 import { filtersConfig } from './featureSets.util'
 import { useFiltersFromSearchParams } from '../../../hooks/useFiltersFromSearchParams.hook'
+import { useMode } from '../../../hooks/mode.hook'
 
 import cssVariables from './featureSets.scss'
 
@@ -86,6 +87,7 @@ const FeatureSets = ({
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch = useDispatch()
+  const { isDemoMode } = useMode()
   const frontendSpec = useSelector(store => store.appStore.frontendSpec)
   const detailsFormInitialValues = useMemo(
     () => ({
@@ -99,7 +101,10 @@ const FeatureSets = ({
   const { featureSetsPanelIsOpen, setFeatureSetsPanelIsOpen, toggleConvertedYaml } =
     React.useContext(FeatureStoreContext)
 
-  const pageData = useMemo(() => generatePageData(selectedFeatureSet), [selectedFeatureSet])
+  const pageData = useMemo(
+    () => generatePageData(selectedFeatureSet, isDemoMode),
+    [isDemoMode, selectedFeatureSet]
+  )
 
   const actionsMenu = useMemo(
     () => generateActionsMenu(dispatch, selectedFeatureSet, toggleConvertedYaml),

--- a/src/components/FeatureStore/FeatureSets/featureSets.util.js
+++ b/src/components/FeatureStore/FeatureSets/featureSets.util.js
@@ -33,7 +33,7 @@ import { showErrorNotification } from '../../../utils/notifications.util'
 
 import { ReactComponent as Yaml } from 'igz-controls/images/yaml.svg'
 
-export const generateFeatureSetsDetailsMenu = selectedItem => [
+export const generateFeatureSetsDetailsMenu = (selectedItem, isDemoMode) => [
   {
     label: 'overview',
     id: 'overview'
@@ -59,7 +59,8 @@ export const generateFeatureSetsDetailsMenu = selectedItem => [
   },
   {
     label: 'analysis',
-    id: 'analysis'
+    id: 'analysis',
+    hidden: !isDemoMode
   }
 ]
 
@@ -83,12 +84,12 @@ export const filtersConfig = {
   [LABELS_FILTER]: { label: 'Labels:', initialValue: '', isModal: true }
 }
 
-export const generatePageData = selectedFeatureSet => {
+export const generatePageData = (selectedFeatureSet, isDemoMode) => {
   return {
     page: FEATURE_STORE_PAGE,
     details: {
       type: FEATURE_SETS_TAB,
-      menu: generateFeatureSetsDetailsMenu(selectedFeatureSet),
+      menu: generateFeatureSetsDetailsMenu(selectedFeatureSet, isDemoMode),
       infoHeaders: featureSetsInfoHeaders
     }
   }

--- a/src/components/FeatureStore/FeatureVectors/FeatureVectors.js
+++ b/src/components/FeatureStore/FeatureVectors/FeatureVectors.js
@@ -59,6 +59,7 @@ import { sortListByDate } from '../../../utils'
 import { isDetailsTabExists } from '../../../utils/link-helper.util'
 import { filtersConfig } from './featureVectors.util'
 import { useFiltersFromSearchParams } from '../../../hooks/useFiltersFromSearchParams.hook'
+import { useMode } from '../../../hooks/mode.hook'
 
 import cssVariables from './featureVectors.scss'
 
@@ -87,6 +88,7 @@ const FeatureVectors = ({
   const navigate = useNavigate()
   const location = useLocation()
   const dispatch = useDispatch()
+  const { isDemoMode } = useMode()
 
   const {
     createVectorPopUpIsOpen,
@@ -95,7 +97,10 @@ const FeatureVectors = ({
     toggleConvertedYaml
   } = React.useContext(FeatureStoreContext)
   const frontendSpec = useSelector(store => store.appStore.frontendSpec)
-  const pageData = useMemo(() => generatePageData(selectedFeatureVector), [selectedFeatureVector])
+  const pageData = useMemo(
+    () => generatePageData(selectedFeatureVector, isDemoMode),
+    [isDemoMode, selectedFeatureVector]
+  )
 
   const detailsFormInitialValues = useMemo(
     () => generateDetailsFormInitialValue(selectedFeatureVector, frontendSpec.internal_labels),

--- a/src/components/FeatureStore/FeatureVectors/featureVectors.util.js
+++ b/src/components/FeatureStore/FeatureVectors/featureVectors.util.js
@@ -34,7 +34,7 @@ import { parseChipsData } from '../../../utils/convertChipsData'
 import { ReactComponent as Delete } from 'igz-controls/images/delete.svg'
 import { ReactComponent as Yaml } from 'igz-controls/images/yaml.svg'
 
-export const generateFeatureVectorsDetailsMenu = selectedItem => [
+export const generateFeatureVectorsDetailsMenu = (selectedItem, isDemoMode) => [
   {
     label: 'overview',
     id: 'overview'
@@ -60,7 +60,8 @@ export const generateFeatureVectorsDetailsMenu = selectedItem => [
   },
   {
     label: 'analysis',
-    id: 'analysis'
+    id: 'analysis',
+    hidden: !isDemoMode
   }
 ]
 
@@ -83,12 +84,12 @@ export const filtersConfig = {
   [LABELS_FILTER]: { label: 'Labels:', initialValue: '', isModal: true }
 }
 
-export const generatePageData = selectedFeatureSet => {
+export const generatePageData = (selectedFeatureSet, isDemoMode) => {
   return {
     page: FEATURE_STORE_PAGE,
     details: {
       type: FEATURE_VECTORS_TAB,
-      menu: generateFeatureVectorsDetailsMenu(selectedFeatureSet),
+      menu: generateFeatureVectorsDetailsMenu(selectedFeatureSet, isDemoMode),
       infoHeaders: featureSetsInfoHeaders
     }
   }


### PR DESCRIPTION
- **UI**: Move analyses tabs to Demo mode in `1.8.0`
   Jira: [ML-9059](https://iguazio.atlassian.net/browse/ML-9059)

[ML-9059]: https://iguazio.atlassian.net/browse/ML-9059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ