### PR TITLE
Fix [Project Settings, Projects] The second 'confirm message' is missing when deleting a non-empty project

### DIFF
--- a/src/api/projects-api.js
+++ b/src/api/projects-api.js
@@ -26,14 +26,11 @@ const projectsApi = {
     }),
   createProject: postData => mainHttpClient.post('/projects', postData),
   deleteProject: (project, deleteNonEmpty) =>
-    mainHttpClientV2.delete(
-      `/projects/${project}`,
-      deleteNonEmpty && {
-        headers: {
-          'x-mlrun-deletion-strategy': 'cascade'
-        }
+    mainHttpClientV2.delete(`/projects/${project}`, {
+      headers: {
+        'x-mlrun-deletion-strategy': deleteNonEmpty ? 'cascade' : 'restricted'
       }
-    ),
+    }),
   deleteSecret: (project, key) =>
     mainHttpClient.delete(`/projects/${project}/secrets?provider=kubernetes&secret=${key}`),
   editProject: (project, data) => mainHttpClient.put(`/projects/${project}`, data),
@@ -84,7 +81,7 @@ const projectsApi = {
       signal
     }),
   getProjectSummary: (project, signal) => {
-    return mainHttpClient.get(`/project-summaries/${project}`, {signal})
+    return mainHttpClient.get(`/project-summaries/${project}`, { signal })
   },
   getProjectWorkflows: project => {
     return mainHttpClient.get(`/projects/${project}/pipelines`)

--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -274,7 +274,7 @@ const ProjectSettings = () => {
           }}
           closePopUp={confirmData.rejectHandler}
           confirmButton={{
-            handler: confirmData.confirmHandler,
+            handler: () => confirmData.confirmHandler(confirmData.item),
             label: confirmData.btnConfirmLabel,
             variant: confirmData.btnConfirmType
           }}
@@ -284,7 +284,7 @@ const ProjectSettings = () => {
         />
       )}
 
-      { projectStore.projectsToDelete.includes(params.projectName) && <Loader />}
+      {projectStore.projectsToDelete.includes(params.projectName) && <Loader />}
 
       <div className="settings">
         <div className="settings__header">

--- a/src/components/ProjectSettings/ProjectSettings.js
+++ b/src/components/ProjectSettings/ProjectSettings.js
@@ -274,7 +274,7 @@ const ProjectSettings = () => {
           }}
           closePopUp={confirmData.rejectHandler}
           confirmButton={{
-            handler: () => confirmData.confirmHandler(confirmData.item),
+            handler: confirmData.confirmHandler,
             label: confirmData.btnConfirmLabel,
             variant: confirmData.btnConfirmType
           }}

--- a/src/components/ProjectsPage/ProjectsView.js
+++ b/src/components/ProjectsPage/ProjectsView.js
@@ -97,7 +97,7 @@ const ProjectsView = ({
           }}
           closePopUp={confirmData.rejectHandler}
           confirmButton={{
-            handler: () => confirmData.confirmHandler(confirmData.item),
+            handler: confirmData.confirmHandler,
             label: confirmData.btnConfirmLabel,
             variant: confirmData.btnConfirmType
           }}

--- a/src/components/ProjectsPage/projects.util.js
+++ b/src/components/ProjectsPage/projects.util.js
@@ -161,7 +161,7 @@ export const handleDeleteProjectError = (
       rejectHandler: () => {
         setConfirmData(null)
       },
-      confirmHandler: project => {
+      confirmHandler: () => {
         handleDeleteProject(
           project,
           true,
@@ -328,7 +328,7 @@ export const generateMonitoringCounters = (data, dispatch) => {
 
 export const onDeleteProject = (project, setConfirmData, ...args) => {
   setConfirmData({
-    item: null,
+    item: project,
     header: 'Delete project?',
     message: `You are trying to delete the project "${project.metadata.name}". Deleted projects cannot be restored`,
     btnConfirmLabel: 'Delete',
@@ -336,8 +336,7 @@ export const onDeleteProject = (project, setConfirmData, ...args) => {
     rejectHandler: () => {
       setConfirmData(null)
     },
-    confirmHandler: deleteNonEmpty =>
-      handleDeleteProject(project, deleteNonEmpty, setConfirmData, ...args)
+    confirmHandler: () => handleDeleteProject(project, false, setConfirmData, ...args)
   })
 }
 

--- a/src/components/ProjectsPage/projects.util.js
+++ b/src/components/ProjectsPage/projects.util.js
@@ -328,7 +328,7 @@ export const generateMonitoringCounters = (data, dispatch) => {
 
 export const onDeleteProject = (project, setConfirmData, ...args) => {
   setConfirmData({
-    item: project,
+    item: null,
     header: 'Delete project?',
     message: `You are trying to delete the project "${project.metadata.name}". Deleted projects cannot be restored`,
     btnConfirmLabel: 'Delete',


### PR DESCRIPTION
- **Project Settings, Projects**: The second 'confirm message' is missing when deleting a non-empty project
   Jira: [ML-8295](https://iguazio.atlassian.net/browse/ML-8295)

[ML-8295]: https://iguazio.atlassian.net/browse/ML-8295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ