### PR TITLE
Fix [Alerts history] Alerts notifications icons need tooltip 

### DIFF
--- a/src/utils/createAlertsContent.js
+++ b/src/utils/createAlertsContent.js
@@ -182,7 +182,7 @@ const getNotificationData = notifications =>
         </div>
       ),
       tooltip: upperFirst(
-        `${notification.summary.succeeded} success, ${notification.summary.failed} failed`
+        `${notification.kind}: ${notification.summary.succeeded} success, ${notification.summary.failed} failed`
       ),
       kind: notification.kind,
       succeeded: notification.summary.succeeded,


### PR DESCRIPTION
- **Alerts history**: Alerts notifications icons need tooltip 
   Jira: https://iguazio.atlassian.net/browse/ML-9103

   <img width="211" alt="Screenshot 2025-01-15 at 11 24 36" src="https://github.com/user-attachments/assets/232448ea-3813-4893-95a8-9e3a9974766a" />