### PR TITLE
Fix [Workflows] Once the button is pressed, the UI should disable the button for 5 seconds, and then re-query the workflow status

### DIFF
--- a/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
+++ b/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
@@ -80,7 +80,8 @@ export const generateActionsMenu = (
   handleConfirmAbortJob,
   handleConfirmDeleteJob,
   toggleConvertedYaml,
-  handleRerun
+  handleRerun,
+  rerunIsDisabled
 ) => {
   if (job?.uid) {
     const jobKindIsAbortable = isJobKindAbortable(job, abortable_function_kinds)
@@ -143,6 +144,7 @@ export const generateActionsMenu = (
           onClick: toggleConvertedYaml
         },
         {
+          disabled: rerunIsDisabled,
           hidden: runningStates.includes(job?.state?.value),
           icon: <Rerun />,
           label: 'Retry',

--- a/src/elements/WorkflowsTable/WorkflowsTable.js
+++ b/src/elements/WorkflowsTable/WorkflowsTable.js
@@ -96,6 +96,7 @@ const WorkflowsTable = React.forwardRef(
     abortJobRef
   ) => {
     const [dataIsLoading, setDataIsLoading] = useState(false)
+    const [rerunIsDisabled, setRerunIsDisabled] = useState(false)
     const [workflowsViewMode, setWorkflowsViewMode] = useState(WORKFLOW_GRAPH_VIEW)
     const workflowsStore = useSelector(state => state.workflowsStore)
     const filtersStore = useSelector(state => state.filtersStore)
@@ -399,7 +400,9 @@ const WorkflowsTable = React.forwardRef(
         dispatch(rerunWorkflow({ project: workflow.project, workflowId: workflow.id }))
           .unwrap()
           .then(() => {
-            handleRetry()
+            setTimeout(() => {
+              handleRetry()
+            }, 5000)
             dispatch(
               setNotification({
                 status: 200,
@@ -428,7 +431,8 @@ const WorkflowsTable = React.forwardRef(
           handleConfirmAbortJob,
           handleConfirmDeleteJob,
           toggleConvertedYaml,
-          handleRerun
+          handleRerun,
+          rerunIsDisabled
         )
     }, [
       handleRerunJob,
@@ -438,7 +442,8 @@ const WorkflowsTable = React.forwardRef(
       handleConfirmAbortJob,
       handleConfirmDeleteJob,
       toggleConvertedYaml,
-      handleRerun
+      handleRerun,
+      rerunIsDisabled
     ])
 
     const handleCancel = useCallback(() => {
@@ -672,6 +677,15 @@ const WorkflowsTable = React.forwardRef(
         setSelectedFunction({})
       }
     }, [params.functionHash, params.jobId, setItemIsSelected, setSelectedFunction, setSelectedJob])
+
+    useEffect(() => {
+      if (workflowsStore.workflows.rerunInProgress) {
+        setRerunIsDisabled(true)
+        setTimeout(() => {
+          setRerunIsDisabled(false)
+        }, 5000)
+      }
+    }, [workflowsStore.workflows.rerunInProgress])
 
     const virtualizationConfig = useVirtualization({
       rowsData: {

--- a/src/reducers/workflowReducer.js
+++ b/src/reducers/workflowReducer.js
@@ -29,7 +29,8 @@ const initialState = {
   workflows: {
     data: [],
     loading: false,
-    error: null
+    error: null,
+    rerunInProgress: false
   },
   activeWorkflow: {
     data: {},
@@ -150,6 +151,15 @@ const workflowsSlice = createSlice({
         loading: false,
         error: action.payload
       }
+    })
+    builder.addCase(rerunWorkflow.fulfilled, state => {
+      state.workflows.rerunInProgress = true
+    })
+    builder.addCase(rerunWorkflow.pending, state => {
+      state.workflows.rerunInProgress = false
+    })
+    builder.addCase(rerunWorkflow.rejected, state => {
+      state.workflows.rerunInProgress = false
     })
   }
 })


### PR DESCRIPTION
- **Workflows**: Once the button is pressed, the UI should disable the button for 5 seconds, and then re-query the workflow status
Jira: https://iguazio.atlassian.net/browse/ML-9168