### PR TITLE
Fix [Workflows] Once the button is pressed, the UI should disable the button for 5 seconds, and then re-query the workflow status

### DIFF
--- a/src/elements/WorkflowsTable/WorkflowsTable.js
+++ b/src/elements/WorkflowsTable/WorkflowsTable.js
@@ -400,9 +400,7 @@ const WorkflowsTable = React.forwardRef(
         dispatch(rerunWorkflow({ project: workflow.project, workflowId: workflow.id }))
           .unwrap()
           .then(() => {
-            setTimeout(() => {
-              handleRetry()
-            }, 5000)
+            handleRetry()
             dispatch(
               setNotification({
                 status: 200,


### PR DESCRIPTION
- **Workflows**: Once the button is pressed, the UI should disable the button for 5 seconds, and then re-query the workflow status
   Jira: https://iguazio.atlassian.net/browse/ML-9168