### PR TITLE
Fix [Wizard] batch run - back/next buttons does not look like "button"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "2.2.18",
+    "iguazio.dashboard-react-controls": "2.2.19",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
- **Wizard**: Batch run - back/next buttons does not look like "button"
   Depends On: https://github.com/iguazio/dashboard-react-controls/pull/365
   **Bump DRC version to `2.2.19`**
   Jira: https://iguazio.atlassian.net/browse/ML-9222
   
   Before:
   <img width="518" alt="Screenshot 2025-02-06 at 16 59 07" src="https://github.com/user-attachments/assets/5df2302c-c491-4757-960a-53c1b96baafc" />

   After:
   <img width="469" alt="Screenshot 2025-02-06 at 17 01 19" src="https://github.com/user-attachments/assets/f4a50cc1-aff2-489c-9b93-3bc5d37fe1dd" />


   
   