### PR TITLE
Fix [Workflows] The "Retry" button doesn't work the second time for a "completed" workflow without using 'Refresh' button

### DIFF
--- a/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
+++ b/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.js
@@ -20,7 +20,14 @@ such restriction.
 import React from 'react'
 import { debounce } from 'lodash'
 
-import { FUNCTIONS_PAGE, GROUP_BY_NONE, GROUP_BY_WORKFLOW, JOBS_PAGE } from '../../../constants'
+import {
+  FUNCTIONS_PAGE,
+  GROUP_BY_NONE,
+  GROUP_BY_WORKFLOW,
+  JOBS_PAGE,
+  PENDING_STATE,
+  UNKNOWN_STATE
+} from '../../../constants'
 import {
   getJobsDetailsMenu,
   getInfoHeaders,
@@ -144,11 +151,14 @@ export const generateActionsMenu = (
           onClick: toggleConvertedYaml
         },
         {
-          disabled: rerunIsDisabled,
+          disabled: rerunIsDisabled || [PENDING_STATE, UNKNOWN_STATE].includes(job?.state?.value),
           hidden: runningStates.includes(job?.state?.value),
           icon: <Rerun />,
           label: 'Retry',
-          onClick: () => handleRerun(job)
+          onClick: () => handleRerun(job),
+          tooltip:
+            [PENDING_STATE, UNKNOWN_STATE].includes(job?.state?.value) &&
+            'Status pending: refresh the display to check for update.'
         }
       ]
     ]

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,8 @@ export const PROJECT_ONLINE_STATUS = 'online'
 export const ERROR_STATE = 'error'
 export const FAIL_STATE = 'fail'
 export const FAILED_STATE = 'failed'
+export const PENDING_STATE = 'pending'
+export const UNKNOWN_STATE = 'unknown'
 
 export const VIEW_SEARCH_PARAMETER = 'view'
 


### PR DESCRIPTION
- **Workflows**: The "Retry" button doesn't work the second time for a "completed" workflow without using 'Refresh' button
   Jira: https://iguazio.atlassian.net/browse/ML-9243
   
   