### PR TITLE
Bump DRC version `2.2.20`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "2.2.19",
+    "iguazio.dashboard-react-controls": "2.2.20",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Includes: https://github.com/iguazio/dashboard-react-controls/pull/368