### PR TITLE
Fix [Feature Sets Panel] changing default path for online target does not take effect when creating feature set

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
@@ -304,7 +304,7 @@ const FeatureSetsPanelTargetStore = ({
       'isOnlineTargetPathEditModeClosed',
       setTargetsPathEditData,
       setDisableButtons,
-      setNewFeatureSetTarget
+      value => dispatch(setNewFeatureSetTarget(value))
     )
   }
 


### PR DESCRIPTION
- **Feature Sets Panel**: Changing default path for online target does not take effect when creating feature set
   Jira: https://iguazio.atlassian.net/browse/ML-9331