### PR TITLE
Fix [CE] link to "Real time functions" (nuclio) is broken when accessing mlrun UI via http

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -582,3 +582,7 @@ export const NOTIFICATION_DURATION = 500
 /*========= DEFAULT PROPS =============*/
 export const EMPTY_ARRAY = []
 export const EMPTY_OBJECT = {}
+
+/*========= PROTOCOLS =============*/
+export const HTTP = 'http://'
+export const HTTPS = 'https://'

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary'
 import * as serviceWorker from './serviceWorker'
 import { Provider } from 'react-redux'
 import toolkitStore from './store/toolkitStore'
+import { HTTP, HTTPS } from './constants'
 
 if (!window.location.pathname.includes(process.env.PUBLIC_URL)) {
   window.location.href = process.env.PUBLIC_URL
@@ -35,7 +36,10 @@ fetch(`${process.env.PUBLIC_URL}/config.json`, { cache: 'no-store' })
   .then(response => response.json())
   .then(config => {
     if (config.nuclioUiUrl) {
-      const mlrunProtocol = config.nuclioUiUrl.startsWith(`${window.location.protocol}//`) ? '' : `${window.location.protocol}//`
+      const mlrunProtocol =
+        config.nuclioUiUrl.startsWith(HTTP) || config.nuclioUiUrl.startsWith(HTTPS)
+          ? ''
+          : `${window.location.protocol}//`
 
       window.mlrunConfig = {
         ...config,


### PR DESCRIPTION
- **CE**: link to "Real time functions" (nuclio) is broken when accessing mlrun UI via http
   Jira: https://iguazio.atlassian.net/browse/CEML-334