### PR TITLE
Fix [Feature store] validation error on Timestamp Key field remains after unchecking Offline target store

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelTargetStore/FeatureSetsPanelTargetStore.js
@@ -525,7 +525,8 @@ const FeatureSetsPanelTargetStore = ({
         }))
         setValidation(state => ({
           ...state,
-          [kindId === PARQUET ? 'isOfflineTargetPathValid' : 'isOnlineTargetPathValid']: true
+          [kindId === PARQUET ? 'isOfflineTargetPathValid' : 'isOnlineTargetPathValid']: true,
+          isTimestampKeyValid: true
         }))
 
         if (kindId === checkboxModels.externalOffline.id) {


### PR DESCRIPTION
- **Feature store**: validation error on Timestamp Key field remains after unchecking Offline target store
   Jira: https://iguazio.atlassian.net/browse/ML-9537