### PR TITLE
Fix [Jobs monitoring] failed to load job artifact preview `1.9.x`

### DIFF
--- a/src/components/DetailsPreview/DetailsPreview.js
+++ b/src/components/DetailsPreview/DetailsPreview.js
@@ -64,7 +64,7 @@ const DetailsPreview = ({ artifact, handlePreview }) => {
       previewAbortControllerRef.current = new AbortController()
 
       getArtifactPreview(
-        params.projectName,
+        artifact.project || params.projectName,
         artifact,
         noData,
         setNoData,


### PR DESCRIPTION
- **Jobs monitoring**: Failed to load job artifact preview
   Backported to `1.9.x` from #3190
   Jira: https://iguazio.atlassian.net/browse/ML-9727