### PR TITLE
Fix [ML functions] "This function either does not exist or was deleted" notification after applying filter `1.8.x`

### DIFF
--- a/src/components/FunctionsPageOld/FunctionsOld.js
+++ b/src/components/FunctionsPageOld/FunctionsOld.js
@@ -161,7 +161,7 @@ const Functions = ({
           setFunctions(newFunctions)
 
           return newFunctions
-        } else {
+        } else if ((params.funcName && params.tag) || params.hash) {
           const paramsFunction = searchFunctionItem(
             params.hash,
             params.funcName,
@@ -615,7 +615,7 @@ const Functions = ({
             `/projects/${params.projectName}/functions/${currentItem.hash}/${tab}${window.location.search}`
           )
         }
-        
+
         dispatch(
           setNotification({
             status: 200,


### PR DESCRIPTION
- **ML functions**: "This function either does not exist or was deleted" notification after applying filter
   Backported to `1.8.x` from. #3205 
   Jira: https://iguazio.atlassian.net/browse/ML-9751