### PR TITLE
Fix [UI] function remains in UI after it was deleted `1.8.x`

### DIFF
--- a/src/components/FunctionsPageOld/FunctionsOld.js
+++ b/src/components/FunctionsPageOld/FunctionsOld.js
@@ -178,6 +178,8 @@ const Functions = ({
             })
           }
           setFunctions([])
+        } else {
+          setFunctions([])
         }
       })
     },


### PR DESCRIPTION
- **UI**: Function remains in UI after it was deleted `1.8.x`
   Backported to `1.8.x` from #3223 
   Jira: https://iguazio.atlassian.net/browse/ML-9794