### PR TITLE
Fix [Artifacts] Path dropdown doesn't close when clicking outside the field

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "3.0.0",
+    "iguazio.dashboard-react-controls": "3.0.1",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.6.4",
     "js-yaml": "^4.1.0",

--- a/src/common/ChipForm/ChipForm.jsx
+++ b/src/common/ChipForm/ChipForm.jsx
@@ -265,7 +265,7 @@ const ChipForm = React.forwardRef(
           />
         </div>
         {validationRules.length > 0 && (
-          <OptionsMenu show={validationRules.length > 0} ref={refInputContainer}>
+          <OptionsMenu show={validationRules.length > 0} ref={{ refInputContainer }}>
             {getValidationRules()}
           </OptionsMenu>
         )}

--- a/src/common/Input/Input.jsx
+++ b/src/common/Input/Input.jsx
@@ -328,7 +328,7 @@ const Input = React.forwardRef(
           </ul>
         )}
         {isInvalid && !isEmpty(validationRules) && (
-          <OptionsMenu show={showValidationRules} ref={ref}>
+          <OptionsMenu show={showValidationRules} ref={{ refInputContainer: ref }}>
             {renderValidationRules}
           </OptionsMenu>
         )}

--- a/src/common/SplitButton/SplitButton.jsx
+++ b/src/common/SplitButton/SplitButton.jsx
@@ -92,7 +92,7 @@ const SplitButton = ({
         </div>
       </div>
       {!isEmpty(options) && (
-        <OptionsMenu show={isBodyOpen} ref={mainRef}>
+        <OptionsMenu show={isBodyOpen} ref={{ refInputContainer: mainRef }}>
           {options.map(option => {
             return (
               <SelectOption

--- a/src/common/TextArea/TextArea.jsx
+++ b/src/common/TextArea/TextArea.jsx
@@ -253,7 +253,7 @@ const TextArea = React.forwardRef(
           </span>
         )}
         {!isEmpty(validationRules) && (
-          <OptionsMenu show={showValidationRules} ref={ref}>
+          <OptionsMenu show={showValidationRules} ref={{ refInputContainer: ref }}>
             {renderValidationRules}
           </OptionsMenu>
         )}


### PR DESCRIPTION
- **Artifacts**: Path dropdown doesn't close when clicking outside the field
   Jira: https://iguazio.atlassian.net/browse/ML-9861