### PR TITLE
Fix [Artifacts] Path dropdown doesn't close when clicking outside the field `1.9.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "2.2.21",
+    "iguazio.dashboard-react-controls": "2.2.22-1.9.x",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.5.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
- **Artifacts**: Path dropdown doesn't close when clicking outside the field `1.9.x`
   Backported to `1.9.x` from #3238 
   Jira: https://iguazio.atlassian.net/browse/ML-9861