### PR TITLE
Fix [UI] Notification duration line resets when navigating between pages `1.8.x`

### DIFF
--- a/src/common/Loader/LoaderForSuspenseFallback.js
+++ b/src/common/Loader/LoaderForSuspenseFallback.js
@@ -23,12 +23,12 @@ import Loader from './Loader'
 const LoaderForSuspenseFallback = () => {
   useLayoutEffect(() => {
     const overlayContainer = document.getElementById('overlay_container')
-    const savedDisplayStyle = overlayContainer ? overlayContainer.style.display : 'flex'
+    const savedVisibilityStyle = overlayContainer ? overlayContainer.style.visibility : 'visible'
 
-    if (overlayContainer) overlayContainer.style.display = 'none'
+    if (overlayContainer) overlayContainer.style.visibility = 'hidden'
 
     return () => {
-      if (overlayContainer) overlayContainer.style.display = savedDisplayStyle
+      if (overlayContainer) overlayContainer.style.visibility = savedVisibilityStyle
     }
   }, [])
 


### PR DESCRIPTION
- **UI**: Notification duration line resets when navigating between pages `1.8.x`
   Backported to `1.8.x` from #3253 
   Jira: https://iguazio.atlassian.net/browse/ML-9862