### PR TITLE
Fix [Application Metrics] Searching for a non-existent metric name crashes the UI

### DIFF
--- a/src/elements/MetricsSelector/MetricsSelector.jsx
+++ b/src/elements/MetricsSelector/MetricsSelector.jsx
@@ -284,7 +284,7 @@ const MetricsSelector = ({
                         return (
                           <>
                             {applicationName
-                              ? renderMetrics(filteredMetrics[0] || [])
+                              ? renderMetrics(filteredMetrics[0] || {})
                               : filteredMetrics.map(metricsGroup => {
                                   return !isEmpty(metricsGroup.metrics) ? (
                                     <Accordion

--- a/src/elements/MetricsSelector/MetricsSelector.jsx
+++ b/src/elements/MetricsSelector/MetricsSelector.jsx
@@ -261,7 +261,7 @@ const MetricsSelector = ({
                         const renderMetrics = metricsList => {
                           return (
                             <ul className="metrics-selector-options">
-                              {metricsList.metrics.map(metricItem => {
+                              {metricsList?.metrics?.map(metricItem => {
                                 return (
                                   <SelectOption
                                     key={metricItem.id}


### PR DESCRIPTION
- **Application Metrics**: Searching for a non-existent metric name crashes the UI
   Jira: https://iguazio.atlassian.net/browse/ML-10230