### PR TITLE
Fix [Project monitoring] Consumer Group button leads to home page

### DIFF
--- a/src/elements/ProjectFunctions/ProjectFunctions.jsx
+++ b/src/elements/ProjectFunctions/ProjectFunctions.jsx
@@ -110,7 +110,7 @@ const ProjectFunctions = ({ nuclioStreamsAreEnabled }) => {
           label: 'Consumer groups',
           className:
             Object.keys(nuclioStore.v3ioStreams.data ?? {}).length > 0 ? 'running' : 'default',
-          href: `/projects/${params.projectName}/monitor${
+          link: `/projects/${params.projectName}/monitor${
             !isNuclioModeDisabled ? '/consumer-groups' : ''
           }`
         }


### PR DESCRIPTION
- **Project monitoring**: Consumer Group button leads to home page   
   Jira*: [ML-10205](https://iguazio.atlassian.net/browse/ML-10205)

   [ML-10205]: https://iguazio.atlassian.net/browse/ML-10205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ