### PR TITLE
Fix [Project monitoring] 'Pending retry' status missing in tooltip

### DIFF
--- a/src/elements/ProjectJobs/projectJobs.utils.js
+++ b/src/elements/ProjectJobs/projectJobs.utils.js
@@ -28,7 +28,7 @@ export const getJobsStatistics = (projectCounter, projectName) => {
   return {
     running: {
       value: projectCounter.error ? 'N/A' : projectCounter.data.runs_running_count,
-      label: 'In Progress',
+      label: 'In Process',
       className:
         projectCounter.error || projectCounter.data.runs_running_count === 0
           ? 'default'


### PR DESCRIPTION
- **Project monitoring**: 'Pending retry' status missing in tooltip
   Jira: [ML-10597](https://iguazio.atlassian.net/browse/ML-10597)

   <img width="570" height="216" alt="Screenshot 2025-07-21 at 11 08 41" src="https://github.com/user-attachments/assets/34fcb303-17a0-4958-adff-6f2e76adb38a" />


[ML-10597]: https://iguazio.atlassian.net/browse/ML-10597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ