### PR TITLE
Fix [Workflows] Retry option should not be available during "In Process" states

### DIFF
--- a/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.jsx
+++ b/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.jsx
@@ -144,7 +144,7 @@ export const generateActionsMenu = (
       ]
     ]
   } else {
-    const runningStates = ['running', 'pending']
+    const runningStates = ['running', 'pending', 'terminating']
 
     return [
       [


### PR DESCRIPTION
- **Workflows**: Retry option should not be available during "In Process" states
   Fix: Retry option disabled in terminating
   Jira: [ML10440](https://iguazio.atlassian.net/browse/ML-10440)

   <img width="1920" height="230" alt="Screenshot 2025-07-13 at 14 25 03" src="https://github.com/user-attachments/assets/ecc9979c-cd8f-4b50-b626-ee63559517d5" />