### PR TITLE
Fix [Projects Setting] Redundant request for empty label data and invalid empty-key in Node Selector params

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "final-form-arrays": "^3.1.0",
     "fs-extra": "^10.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "iguazio.dashboard-react-controls": "3.1.6",
+    "iguazio.dashboard-react-controls": "3.1.7",
     "is-wsl": "^1.1.0",
     "js-base64": "^2.6.4",
     "js-yaml": "^4.1.0",

--- a/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneral.jsx
+++ b/src/elements/ProjectSettingsGeneral/ProjectSettingsGeneral.jsx
@@ -55,7 +55,8 @@ import {
   areFormValuesChanged,
   generateObjectFromKeyValue,
   parseObjectToKeyValue,
-  setFieldState
+  setFieldState,
+  clearArrayFromEmptyObjectElements
 } from 'igz-controls/utils/form.util'
 import { FORBIDDEN_ERROR_STATUS_CODE } from 'igz-controls/constants'
 import { getChipOptions } from 'igz-controls/utils/chips.util'
@@ -214,7 +215,9 @@ const ProjectSettingsGeneral = ({
             [DEFAULT_IMAGE]: formStateLocal.values[DEFAULT_IMAGE] ?? '',
             [DESCRIPTION]: formStateLocal.values[DESCRIPTION] ?? '',
             [GOALS]: formStateLocal.values[GOALS] ?? '',
-            [PARAMS]: generateObjectFromKeyValue(formStateLocal.values[PARAMS])
+            [PARAMS]: generateObjectFromKeyValue(
+              clearArrayFromEmptyObjectElements(formStateLocal.values[PARAMS])
+            )
           },
           metadata: {
             ...newProjectData.metadata,
@@ -224,7 +227,7 @@ const ProjectSettingsGeneral = ({
 
         if (areNodeSelectorsSupported) {
           newProjectData.spec[NODE_SELECTORS] = generateObjectFromKeyValue(
-            formStateLocal.values[NODE_SELECTORS]
+            clearArrayFromEmptyObjectElements(formStateLocal.values[NODE_SELECTORS])
           )
         }
 


### PR DESCRIPTION
- **Projects Setting**: Redundant request for empty label data and invalid empty-key in Node Selector params
   Depends On: https://github.com/iguazio/dashboard-react-controls/pull/431
   Jira: https://iguazio.atlassian.net/browse/ML-10416