### PR TITLE
Fix [Real-time pipelines] `input_path` and `result_path` are not presented

### DIFF
--- a/src/components/Pipeline/Pipeline.jsx
+++ b/src/components/Pipeline/Pipeline.jsx
@@ -101,11 +101,11 @@ const Pipeline = ({ content }) => {
         },
         {
           label: 'Input path:',
-          value: ''
+          value: selectedStepData.input_path
         },
         {
           label: 'Result path:',
-          value: ''
+          value: selectedStepData.result_path
         }
       ])
     }


### PR DESCRIPTION
- **Real-time pipelines**: `input_path` and `result_path` are not presented
   Jira: https://iguazio.atlassian.net/browse/ML-10924