### PR TITLE
Fix [Workflows] Remove the Retry and Terminate options from the Action Bar in Workflow

### DIFF
--- a/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.jsx
+++ b/src/components/Jobs/MonitorWorkflows/monitorWorkflows.util.jsx
@@ -98,6 +98,7 @@ export const generateActionsMenu = (
     const jobKindIsAbortable = isJobKindAbortable(job, abortable_function_kinds)
     const jobIsAborting = isJobAborting(job)
     const jobKindIsDask = isJobKindDask(job?.labels)
+
     return [
       [
         {


### PR DESCRIPTION
- **Workflows**: Remove the Retry and Terminate options from the Action Bar in Workflow
   Jira: [ML-11021](https://iguazio.atlassian.net/browse/ML-11021)

   <img width="585" height="332" alt="Screenshot 2025-09-08 at 16 01 33" src="https://github.com/user-attachments/assets/97804e5c-7337-4328-86bb-4c0cbfff9004" />


[ML-11021]: https://iguazio.atlassian.net/browse/ML-11021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ