### PR TITLE
Fix [Monitoring app UI] test_id for go_back for Application not correct `1.10.x`

### DIFF
--- a/src/elements/FormEnvironmentVariablesTable/FormEnvironmentVariablesRow/FormEnvironmentVariablesRow.jsx
+++ b/src/elements/FormEnvironmentVariablesTable/FormEnvironmentVariablesRow/FormEnvironmentVariablesRow.jsx
@@ -56,7 +56,7 @@ const FormEnvironmentVariablesRow = ({
   uniquenessValidator
 }) => {
   const [fieldData, setFieldData] = useState(fields.value[index])
-  const { projectName }  = useParams()
+  const { projectName } = useParams()
 
   const tableRowClassNames = classnames(
     'form-table__row',
@@ -133,10 +133,9 @@ const FormEnvironmentVariablesRow = ({
                   name={`${rowPath}.data.secretName`}
                   placeholder="Secret Name"
                   required
-                  validationRules={
-                    (getValidationRules('environmentVariables.secretName'),
-                    [getSecretNameValidator(projectName, editingItem?.data?.typeName) ])
-                  }
+                  validationRules={getValidationRules('environmentVariables.secretName', [
+                    getSecretNameValidator(projectName, editingItem?.data?.typeName)
+                  ])}
                 />
                 <FormInput
                   density="normal"

--- a/src/elements/TableTop/TableTop.jsx
+++ b/src/elements/TableTop/TableTop.jsx
@@ -32,7 +32,7 @@ const TableTop = ({ children = null, link, text = '' }) => {
     <div className="table-top">
       <div className="link-back">
         <Link to={link} className="link-back__icon">
-          <RoundedIcon id="refresh" tooltipText="Back">
+          <RoundedIcon id="back" tooltipText="Back">
             <Back />
           </RoundedIcon>
         </Link>


### PR DESCRIPTION
- **Monitoring app UI**: test_id for go_back for Application not correct
   Backported to `1.10.x` from #3493 
   Jira: https://iguazio.atlassian.net/browse/ML-11394