### PR TITLE
[CHORE] Add data-testid to sidebar

### DIFF
--- a/src/components/Sidebar/ProjectDropdown.jsx
+++ b/src/components/Sidebar/ProjectDropdown.jsx
@@ -104,7 +104,8 @@ const ProjectDropdown = ({ projectName }) => {
           </DropdownMenuTrigger>
           <DropdownMenuContent
             data-testid="sidebar-project-dropdown-content"
-            className="w-[--radix-popper-anchor-width] p-2">
+            className="w-[--radix-popper-anchor-width] p-2"
+          >
             <div className="flex relative mb-2">
               <Input
                 type="text"

--- a/src/components/Sidebar/ProjectDropdown.jsx
+++ b/src/components/Sidebar/ProjectDropdown.jsx
@@ -71,6 +71,7 @@ const ProjectDropdown = ({ projectName }) => {
       </SidebarMenuItem>
       <SidebarMenuItem className="h-full group-data-[collapsible=icon]:hidden">
         <DropdownMenu
+          data-testid="sidebar-project-dropdown"
           open={open}
           onOpenChange={isOpen => {
             setOpen(isOpen)
@@ -81,6 +82,7 @@ const ProjectDropdown = ({ projectName }) => {
         >
           <DropdownMenuTrigger
             asChild
+            data-testid="sidebar-project-dropdown-trigger"
             className="h-full px-3 py-2
               data-[state=open]:bg-accent
               data-[state=open]:text-accent-foreground
@@ -100,7 +102,9 @@ const ProjectDropdown = ({ projectName }) => {
               <ChevronDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-[--radix-popper-anchor-width] p-2">
+          <DropdownMenuContent
+            data-testid="sidebar-project-dropdown-content"
+            className="w-[--radix-popper-anchor-width] p-2">
             <div className="flex relative mb-2">
               <Input
                 type="text"

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -47,6 +47,7 @@ function SidebarList({ projectName }) {
     <Sidebar
       collapsible="icon"
       className="sticky border-0 border-r border-solid border-gray-200 top-14 z-10 flex flex-col"
+      data-testid='sidebar'
     >
       <SidebarHeader className="px-3 min-h-[70px]">
         <ProjectDropdown projectName={projectName} />
@@ -64,7 +65,7 @@ function SidebarList({ projectName }) {
         </SidebarMenu>
       </SidebarContent>
       <SidebarSeparator />
-      <SidebarFooter className="pt-1 px-0 gap-y-1 group-data-[collapsible=icon]:gap-y-6">
+      <SidebarFooter data-testid='sidebar-footer' className="pt-1 px-0 gap-y-1 group-data-[collapsible=icon]:gap-y-6">
         <SidebarMenu>
           {footerLinks.map(link => (
             <SidebarItem key={link.id} {...link} />

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -47,7 +47,7 @@ function SidebarList({ projectName }) {
     <Sidebar
       collapsible="icon"
       className="sticky border-0 border-r border-solid border-gray-200 top-14 z-10 flex flex-col"
-      data-testid='sidebar'
+      data-testid="sidebar"
     >
       <SidebarHeader className="px-3 min-h-[70px]">
         <ProjectDropdown projectName={projectName} />
@@ -65,7 +65,10 @@ function SidebarList({ projectName }) {
         </SidebarMenu>
       </SidebarContent>
       <SidebarSeparator />
-      <SidebarFooter data-testid='sidebar-footer' className="pt-1 px-0 gap-y-1 group-data-[collapsible=icon]:gap-y-6">
+      <SidebarFooter
+        data-testid="sidebar-footer"
+        className="pt-1 px-0 gap-y-1 group-data-[collapsible=icon]:gap-y-6"
+      >
         <SidebarMenu>
           {footerLinks.map(link => (
             <SidebarItem key={link.id} {...link} />

--- a/src/components/Sidebar/SidebarCollapseItem.jsx
+++ b/src/components/Sidebar/SidebarCollapseItem.jsx
@@ -43,6 +43,7 @@ const SidebarCollapseItem = ({ icon, label, nestedLinks }) => {
       <SidebarMenuItem className="flex-col px-3 py-0.5">
         <CollapsibleTrigger asChild>
           <SidebarMenuButton
+            data-testid="sidebar-collapsible-menu-item"
             className="flex gap-2 pl-3 py-3 text-sidebar-foreground cursor-pointer"
             isActive={(!open && isAnyChildActive) || (!sidebarOpen && isAnyChildActive)}
           >

--- a/src/components/Sidebar/SidebarCollapseItem.jsx
+++ b/src/components/Sidebar/SidebarCollapseItem.jsx
@@ -43,7 +43,7 @@ const SidebarCollapseItem = ({ icon, label, nestedLinks }) => {
       <SidebarMenuItem className="flex-col px-3 py-0.5">
         <CollapsibleTrigger asChild>
           <SidebarMenuButton
-            data-testid="sidebar-collapsible-menu-item"
+            data-testid={`sidebar-collapsible-menu-item-${label}`}
             className="flex gap-2 pl-3 py-3 text-sidebar-foreground cursor-pointer"
             isActive={(!open && isAnyChildActive) || (!sidebarOpen && isAnyChildActive)}
           >

--- a/src/components/Sidebar/SidebarCollapseItem.jsx
+++ b/src/components/Sidebar/SidebarCollapseItem.jsx
@@ -24,6 +24,7 @@ import { ChevronRightIcon, ChevronDownIcon } from 'lucide-react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ui/collapsible'
 import { SidebarMenuButton, SidebarMenuItem, SidebarMenuSub, useSidebar } from '@/ui/sidebar'
 import SidebarItem from './SidebarItem'
+import { toTestId } from '../../utils/toTestId'
 
 const SidebarCollapseItem = ({ icon, label, nestedLinks }) => {
   const { pathname } = useLocation()
@@ -40,10 +41,12 @@ const SidebarCollapseItem = ({ icon, label, nestedLinks }) => {
       open={sidebarOpen && open}
       onOpenChange={setOpen}
     >
-      <SidebarMenuItem className="flex-col px-3 py-0.5">
+      <SidebarMenuItem
+        className="flex-col px-3 py-0.5"
+        data-testid={`sidebar-collapsible-menu-item-${toTestId(label)}`}
+      >
         <CollapsibleTrigger asChild>
           <SidebarMenuButton
-            data-testid={`sidebar-collapsible-menu-item-${label}`}
             className="flex gap-2 pl-3 py-3 text-sidebar-foreground cursor-pointer"
             isActive={(!open && isAnyChildActive) || (!sidebarOpen && isAnyChildActive)}
           >

--- a/src/components/Sidebar/SidebarItem.jsx
+++ b/src/components/Sidebar/SidebarItem.jsx
@@ -21,6 +21,7 @@ import { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useMatch } from 'react-router-dom'
 import { SidebarMenuButton, SidebarMenuItem } from './ui/sidebar'
+import { toTestId } from '../../utils/toTestId'
 
 const SidebarItem = ({
   link,
@@ -46,7 +47,7 @@ const SidebarItem = ({
 
   return (
     <SidebarMenuItem
-      data-testid={`sidebar-menu-item-${label}`}
+      data-testid={`sidebar-menu-item-${toTestId(label)}`}
       ref={ref}
       className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}
     >
@@ -56,12 +57,16 @@ const SidebarItem = ({
         className={`gap-2 p-3 ${menuButtonClassName ?? ''}`}
       >
         {externalLink ? (
-          <a href={link} target="_top" data-testid={`sidebar-menu-item-${label}-external-link`}>
+          <a
+            href={link}
+            target="_top"
+            data-testid={`sidebar-menu-item-${toTestId(label)}-external-link`}
+          >
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </a>
         ) : (
-          <Link to={link} data-testid={`sidebar-menu-item-${label}-internal-link`}>
+          <Link to={link} data-testid={`sidebar-menu-item-${toTestId(label)}-internal-link`}>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </Link>

--- a/src/components/Sidebar/SidebarItem.jsx
+++ b/src/components/Sidebar/SidebarItem.jsx
@@ -45,19 +45,19 @@ const SidebarItem = ({
   }, [isActive])
 
   return (
-    <SidebarMenuItem data-testid='sidebar-menu-item' ref={ref} className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}>
+    <SidebarMenuItem data-testid={`sidebar-menu-item-${label}`} ref={ref} className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}>
       <SidebarMenuButton
         asChild
         isActive={isActive}
         className={`gap-2 p-3 ${menuButtonClassName ?? ''}`}
       >
         {externalLink ? (
-          <a href={link} target="_top" data-testid='sidebar-menu-item-external-link'>
+          <a href={link} target="_top" data-testid={`sidebar-menu-item-${label}-external-link`}>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </a>
         ) : (
-          <Link to={link}  data-testid='sidebar-menu-item-internal-link'>
+          <Link to={link}  data-testid={`sidebar-menu-item-${label}-internal-link`}>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </Link>

--- a/src/components/Sidebar/SidebarItem.jsx
+++ b/src/components/Sidebar/SidebarItem.jsx
@@ -45,7 +45,11 @@ const SidebarItem = ({
   }, [isActive])
 
   return (
-    <SidebarMenuItem data-testid={`sidebar-menu-item-${label}`} ref={ref} className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}>
+    <SidebarMenuItem
+      data-testid={`sidebar-menu-item-${label}`}
+      ref={ref}
+      className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}
+    >
       <SidebarMenuButton
         asChild
         isActive={isActive}
@@ -57,7 +61,7 @@ const SidebarItem = ({
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </a>
         ) : (
-          <Link to={link}  data-testid={`sidebar-menu-item-${label}-internal-link`}>
+          <Link to={link} data-testid={`sidebar-menu-item-${label}-internal-link`}>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </Link>

--- a/src/components/Sidebar/SidebarItem.jsx
+++ b/src/components/Sidebar/SidebarItem.jsx
@@ -45,19 +45,19 @@ const SidebarItem = ({
   }, [isActive])
 
   return (
-    <SidebarMenuItem ref={ref} className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}>
+    <SidebarMenuItem data-testid='sidebar-menu-item' ref={ref} className={`px-3 py-0.5 ${menuItemClassname ?? ''}`}>
       <SidebarMenuButton
         asChild
         isActive={isActive}
         className={`gap-2 p-3 ${menuButtonClassName ?? ''}`}
       >
         {externalLink ? (
-          <a href={link} target="_top">
+          <a href={link} target="_top" data-testid='sidebar-menu-item-external-link'>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </a>
         ) : (
-          <Link to={link}>
+          <Link to={link}  data-testid='sidebar-menu-item-internal-link'>
             {icon}
             <span className="group-data-[collapsible=icon]:hidden">{label}</span>
           </Link>

--- a/src/components/Sidebar/ui/sidebar.jsx
+++ b/src/components/Sidebar/ui/sidebar.jsx
@@ -211,6 +211,7 @@ const Sidebar = React.forwardRef(
               <Button
                 variant="outline"
                 tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+                data-testid='pin-sidebar-button'
                 side="right"
                 className="absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid
                   w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]
@@ -218,7 +219,7 @@ const Sidebar = React.forwardRef(
                   hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 onClick={togglePin}
               >
-                {pinned ? <SidebarClose /> : <SidebarOpen />}
+                {pinned ? <SidebarClose data-testid='closeed-pin' /> : <SidebarOpen data-testid='opened-pin' />}
               </Button>
             )}
           </div>

--- a/src/components/Sidebar/ui/sidebar.jsx
+++ b/src/components/Sidebar/ui/sidebar.jsx
@@ -211,7 +211,7 @@ const Sidebar = React.forwardRef(
               <Button
                 variant="outline"
                 tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-                data-testid='pin-sidebar-button'
+                data-testid="pin-sidebar-button"
                 side="right"
                 className="absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid
                   w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]
@@ -219,7 +219,11 @@ const Sidebar = React.forwardRef(
                   hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                 onClick={togglePin}
               >
-                {pinned ? <SidebarClose data-testid='closeed-pin' /> : <SidebarOpen data-testid='opened-pin' />}
+                {pinned ? (
+                  <SidebarClose data-testid="closeed-pin" />
+                ) : (
+                  <SidebarOpen data-testid="opened-pin" />
+                )}
               </Button>
             )}
           </div>

--- a/src/utils/toTestId.js
+++ b/src/utils/toTestId.js
@@ -1,3 +1,22 @@
+/*
+Copyright 2019 Iguazio Systems Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License") with
+an addition restriction as set forth herein. You may not use this
+file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+In addition, you may not use the software for any purposes that are
+illegal under applicable law, and the grant of the foregoing license
+under the Apache 2.0 license is conditioned upon your compliance with
+such restriction.
+*/
 export const toTestId = (title, suffix = '') => {
   const formattedTitle = title.replace(/\s+/g, '-').toLowerCase()
   return suffix ? formattedTitle + '-' + suffix : formattedTitle

--- a/src/utils/toTestId.js
+++ b/src/utils/toTestId.js
@@ -1,0 +1,4 @@
+export const toTestId = (title, suffix = '') => {
+  const formattedTitle = title.replace(/\s+/g, '-').toLowerCase()
+  return suffix ? formattedTitle + '-' + suffix : formattedTitle
+}


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

Adds data-testid attributes to sidebar navigation components
---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue:
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
