### PR TITLE
[FIX] Time dropdown width does not match the dropdown field

### DIFF
--- a/src/common/TimePicker/TimePicker.jsx
+++ b/src/common/TimePicker/TimePicker.jsx
@@ -144,22 +144,21 @@ const TimePicker = ({
           <Caret />
         </div>
         {isDropDownMenuOpen && (
-        <PopUpDialog
-          key={selectKey}
-          className="time-picker__dropdown"
-          headerIsHidden
-          customPosition={{
-            element: timePickerRef,
-            position: 'bottom-right'
-          }}
-          ref={dropdownRef}
-          style={{ width: `${timePickerRef.current?.clientWidth || 116}px` }}
-        >
-          <TimePickerOptions key={selectKey} handleInputChange={handleInputChange} />
-        </PopUpDialog>
-      )}
+          <PopUpDialog
+            key={selectKey}
+            className="time-picker__dropdown"
+            headerIsHidden
+            customPosition={{
+              element: timePickerRef,
+              position: 'bottom-right'
+            }}
+            ref={dropdownRef}
+            style={{ width: `${timePickerRef.current?.clientWidth || 116}px` }}
+          >
+            <TimePickerOptions key={selectKey} handleInputChange={handleInputChange} />
+          </PopUpDialog>
+        )}
       </div>
-      
     </div>
   )
 }

--- a/src/common/TimePicker/TimePicker.jsx
+++ b/src/common/TimePicker/TimePicker.jsx
@@ -143,8 +143,7 @@ const TimePicker = ({
         >
           <Caret />
         </div>
-      </div>
-      {isDropDownMenuOpen && (
+        {isDropDownMenuOpen && (
         <PopUpDialog
           key={selectKey}
           className="time-picker__dropdown"
@@ -154,11 +153,13 @@ const TimePicker = ({
             position: 'bottom-right'
           }}
           ref={dropdownRef}
-          style={{ width: '116px' }}
+          style={{ width: `${timePickerRef.current?.clientWidth || 116}px` }}
         >
           <TimePickerOptions key={selectKey} handleInputChange={handleInputChange} />
         </PopUpDialog>
       )}
+      </div>
+      
     </div>
   )
 }

--- a/src/common/TimePicker/timePicker.scss
+++ b/src/common/TimePicker/timePicker.scss
@@ -26,13 +26,13 @@
 
 .time-picker__dropdown {
   .pop-up-dialog {
-    height: 200px;
+    height: 184px;
     padding: 0;
   }
 
   &-item {
-    height: 50px;
-    padding: 16px;
+    height: 46px;
+    padding: 14px 16px;
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/ML-11975
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->
<img width="998" height="577" alt="image" src="https://github.com/user-attachments/assets/37fa998b-0157-4203-ae5d-9fa6787a7c20" />
<img width="616" height="513" alt="image" src="https://github.com/user-attachments/assets/f0c935b0-45f5-4136-a6f8-06c51eda7c80" />

---
