### PR TITLE
[FIX] Inconsistent tab selection after page refresh in detail views

### DIFF
--- a/src/components/Artifacts/Artifacts.jsx
+++ b/src/components/Artifacts/Artifacts.jsx
@@ -413,10 +413,10 @@ const Artifacts = ({
   const tableHeaders = useMemo(() => tableContent[0]?.content ?? [], [tableContent])
 
   useEffect(() => {
-    if (params.id && pageData.details.menu.length > 0) {
+    if (params.id && !isEmpty(selectedArtifact) && pageData.details.menu.length > 0) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, location, pageData.details.menu, params.tab, params.id])
+  }, [navigate, location, pageData.details.menu, params.tab, params.id, selectedArtifact])
 
   useEffect(() => {
     if (isEmpty(selectedArtifact)) {

--- a/src/components/FeatureStore/FeatureSets/FeatureSets.jsx
+++ b/src/components/FeatureStore/FeatureSets/FeatureSets.jsx
@@ -20,7 +20,7 @@ such restriction.
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, isEmpty } from 'lodash'
 
 import FeatureSetsView from './FeatureSetsView'
 import { FeatureStoreContext } from '../FeatureStore'
@@ -391,10 +391,23 @@ const FeatureSets = () => {
   }, [featureStore.featureSets.allData, navigate, params.name, params.projectName, params.tag])
 
   useEffect(() => {
-    if (params.name && params.tag && pageData.details.menu.length > 0) {
+    if (
+      params.name &&
+      params.tag &&
+      !isEmpty(selectedFeatureSet) &&
+      pageData.details.menu.length > 0
+    ) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, location, pageData.details.menu, params.name, params.tag, params.tab])
+  }, [
+    navigate,
+    location,
+    pageData.details.menu,
+    params.name,
+    params.tag,
+    params.tab,
+    selectedFeatureSet
+  ])
 
   useEffect(() => {
     checkTabIsValid(navigate, params, selectedFeatureSet, FEATURE_SETS_TAB)

--- a/src/components/FeatureStore/FeatureVectors/FeatureVectors.jsx
+++ b/src/components/FeatureStore/FeatureVectors/FeatureVectors.jsx
@@ -458,10 +458,23 @@ const FeatureVectors = () => {
   }, [featureStore.featureVectors?.allData, navigate, params.name, params.projectName, params.tag])
 
   useEffect(() => {
-    if (params.name && params.tag && pageData.details.menu.length > 0) {
+    if (
+      params.name &&
+      params.tag &&
+      !isEmpty(selectedFeatureVector) &&
+      pageData.details.menu.length > 0
+    ) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, location, pageData.details.menu, params.name, params.tag, params.tab])
+  }, [
+    navigate,
+    location,
+    pageData.details.menu,
+    params.name,
+    params.tag,
+    params.tab,
+    selectedFeatureVector
+  ])
 
   useEffect(() => {
     checkTabIsValid(navigate, params, setSelectedFeatureVector, FEATURE_VECTORS_TAB)

--- a/src/components/FunctionsPage/Functions.jsx
+++ b/src/components/FunctionsPage/Functions.jsx
@@ -503,10 +503,10 @@ const Functions = ({ isAllVersions = false }) => {
   }, [params.projectName])
 
   useEffect(() => {
-    if (params.id && pageData.details.menu.length > 0) {
+    if (params.id && !isEmpty(selectedFunction) && pageData.details.menu.length > 0) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, pageData.details.menu, location, params.id, params.tab])
+  }, [navigate, pageData.details.menu, location, params.id, params.tab, selectedFunction])
 
   useEffect(() => {
     dispatch(setFilters({ groupBy: GROUP_BY_NONE }))

--- a/src/components/FunctionsPageOld/FunctionsOld.jsx
+++ b/src/components/FunctionsPageOld/FunctionsOld.jsx
@@ -537,10 +537,22 @@ const Functions = () => {
   }, [params.projectName])
 
   useEffect(() => {
-    if ((params.funcName || params.hash) && pageData.details.menu.length > 0) {
+    if (
+      (params.funcName || params.hash) &&
+      !isEmpty(selectedFunction) &&
+      pageData.details.menu.length > 0
+    ) {
       isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
     }
-  }, [navigate, pageData.details.menu, location, params.hash, params.funcName, params.tab])
+  }, [
+    navigate,
+    pageData.details.menu,
+    location,
+    params.hash,
+    params.funcName,
+    params.tab,
+    selectedFunction
+  ])
 
   useEffect(() => {
     checkForSelectedFunction(

--- a/src/components/ModelsPage/ModelEndpoints/ModelEndpointsTable.jsx
+++ b/src/components/ModelsPage/ModelEndpoints/ModelEndpointsTable.jsx
@@ -21,6 +21,7 @@ import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
 
 import ActionBar from '../../ActionBar/ActionBar'
 import ArtifactsTableRow from '../../../elements/ArtifactsTableRow/ArtifactsTableRow'
@@ -205,10 +206,23 @@ const ModelEndpointsTable = React.forwardRef(
     ])
 
     useEffect(() => {
-      if (params.name && params.tag && pageData.details.menu.length > 0) {
+      if (
+        params.name &&
+        params.tag &&
+        !isEmpty(selectedModelEndpoint) &&
+        pageData.details.menu.length > 0
+      ) {
         isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
       }
-    }, [navigate, location, pageData.details.menu, params.name, params.tag, params.tab])
+    }, [
+      navigate,
+      location,
+      pageData.details.menu,
+      params.name,
+      params.tag,
+      params.tab,
+      selectedModelEndpoint
+    ])
 
     const tableContent = useMemo(() => {
       return modelEndpoints.map(contentItem =>

--- a/src/elements/JobsTable/JobsTable.jsx
+++ b/src/elements/JobsTable/JobsTable.jsx
@@ -218,10 +218,10 @@ const JobsTable = React.forwardRef(
     )
 
     useEffect(() => {
-      if (params.jobId && pageData.details.menu.length > 0) {
+      if (params.jobId && !isEmpty(selectedJob) && pageData.details.menu.length > 0) {
         isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
       }
-    }, [navigate, pageData.details.menu, location, params.jobId, params.tab])
+    }, [navigate, pageData.details.menu, location, params.jobId, params.tab, selectedJob])
 
     const handleConfirmAbortJob = useCallback(
       job => {

--- a/src/elements/WorkflowsTable/WorkflowsTable.jsx
+++ b/src/elements/WorkflowsTable/WorkflowsTable.jsx
@@ -671,10 +671,22 @@ const WorkflowsTable = React.forwardRef(
     ])
 
     useEffect(() => {
-      if ((params.jobId || params.functionHash) && pageData.details.menu.length > 0) {
+      if (
+        (params.jobId || params.functionHash) &&
+        !isEmpty(selectedJob) &&
+        pageData.details.menu.length > 0
+      ) {
         isDetailsTabExists(params.tab, pageData.details.menu, navigate, location)
       }
-    }, [navigate, pageData.details.menu, location, params.jobId, params.functionHash, params.tab])
+    }, [
+      navigate,
+      pageData.details.menu,
+      location,
+      params.jobId,
+      params.functionHash,
+      params.tab,
+      selectedJob
+    ])
 
     useEffect(() => {
       const workflow = { ...workflowsStore.activeWorkflow?.data }


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/ML-11784
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
