### PR TITLE
[FIX] remove "Auto-generate access key" checkbox on CE setups

### DIFF
--- a/src/components/FeatureSetsPanel/FeatureSetsPanelView.jsx
+++ b/src/components/FeatureSetsPanel/FeatureSetsPanelView.jsx
@@ -118,6 +118,7 @@ const FeatureSetsPanelView = ({
           </Accordion>
           <PanelCredentialsAccessKey
             credentialsAccessKey={featureStore.newFeatureSet.credentials.access_key}
+            frontendSpec={frontendSpec}
             required={accessKeyRequired}
             setCredentialsAccessKey={value => dispatch(setNewFeatureSetCredentialsAccessKey(value))}
             setValidation={setValidation}

--- a/src/components/FunctionsPanel/FunctionsPanelView.jsx
+++ b/src/components/FunctionsPanel/FunctionsPanelView.jsx
@@ -158,6 +158,7 @@ const FunctionsPanelView = ({
             <PanelCredentialsAccessKey
               className="functions-panel__item"
               credentialsAccessKey={functionsStore.newFunction.metadata.credentials.access_key}
+              frontendSpec={frontendSpec}
               required={
                 functionsStore.newFunction.metadata.credentials.access_key !==
                 PANEL_DEFAULT_ACCESS_KEY

--- a/src/elements/PanelCredentialsAccessKey/PanelCredentialsAccessKey.jsx
+++ b/src/elements/PanelCredentialsAccessKey/PanelCredentialsAccessKey.jsx
@@ -31,6 +31,7 @@ import './panelCredentialsAccessKey.scss'
 const PanelCredentialsAccessKey = ({
   className = '',
   credentialsAccessKey,
+  frontendSpec,
   isPanelEditMode = false,
   required = false,
   setCredentialsAccessKey,
@@ -48,24 +49,26 @@ const PanelCredentialsAccessKey = ({
 
   return (
     <div className={accessKeyClassNames}>
-      <CheckBox
-        disabled={isPanelEditMode}
-        item={{
-          id: PANEL_DEFAULT_ACCESS_KEY,
-          label: 'Auto-generate access key'
-        }}
-        onChange={value => {
-          if (value !== credentialsAccessKey && inputValue.length > 0) {
-            setInputValue('')
-          }
-          setCredentialsAccessKey(value === credentialsAccessKey ? '' : value)
-          setValidation(state => ({
-            ...state,
-            isAccessKeyValid: true
-          }))
-        }}
-        selectedId={credentialsAccessKey}
-      />
+      {!frontendSpec.ce?.version && (
+        <CheckBox
+          disabled={isPanelEditMode}
+          item={{
+            id: PANEL_DEFAULT_ACCESS_KEY,
+            label: 'Auto-generate access key'
+          }}
+          onChange={value => {
+            if (value !== credentialsAccessKey && inputValue.length > 0) {
+              setInputValue('')
+            }
+            setCredentialsAccessKey(value === credentialsAccessKey ? '' : value)
+            setValidation(state => ({
+              ...state,
+              isAccessKeyValid: true
+            }))
+          }}
+          selectedId={credentialsAccessKey}
+        />
+      )}
       {credentialsAccessKey !== PANEL_DEFAULT_ACCESS_KEY && (
         <Input
           floatingLabel
@@ -95,6 +98,7 @@ const PanelCredentialsAccessKey = ({
 PanelCredentialsAccessKey.propTypes = {
   className: PropTypes.string,
   credentialsAccessKey: PropTypes.string.isRequired,
+  frontendSpec: PropTypes.object.isRequired,
   isPanelEditMode: PropTypes.bool,
   required: PropTypes.bool,
   setCredentialsAccessKey: PropTypes.func.isRequired,


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/ML-12221
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
