### PR TITLE
Fix Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "final-form-arrays": "^3.1.0",
         "fs-extra": "^10.0.0",
         "identity-obj-proxy": "^3.0.0",
-        "iguazio.dashboard-react-controls": "3.2.8",
+        "iguazio.dashboard-react-controls": "3.2.12",
         "is-wsl": "^1.1.0",
         "js-base64": "^2.6.4",
         "js-yaml": "^4.1.0",
@@ -14821,9 +14821,9 @@
       "license": "ISC"
     },
     "node_modules/iguazio.dashboard-react-controls": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/iguazio.dashboard-react-controls/-/iguazio.dashboard-react-controls-3.2.8.tgz",
-      "integrity": "sha512-n1z8nHmYE4B2/Tr7C6VkMQqnKz2csUduY03I8I0mNcWYC2Cr7HGYlW44WYv2scB91+CMOy3Hg7uzV4UAIe6ULQ==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/iguazio.dashboard-react-controls/-/iguazio.dashboard-react-controls-3.2.12.tgz",
+      "integrity": "sha512-2ioztKMtuJ9WDjAB7wogfmHB/9tGonwfavbF6jydvdUGUoVJNwR6Ci+Ep43QQ5iSOGhYBW4LQiBZznhiQ+QFIg==",
       "peerDependencies": {
         "@reduxjs/toolkit": "*",
         "classnames": "*",
@@ -19852,17 +19852,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -21411,14 +21400,14 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "minimatch": "^10.2.1",
     "postcss": "^8.4.49",
     "qs": "^6.15.0",
+    "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.5"
   },
   "scripts": {


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

Vulnerability: Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()

Impact: ### Impact

The serialize-javascript npm package (versions <= 7.0.2) contains a code injection vulnerability. It is an incomplete fix for CVE-2020-7660.

While RegExp.source is sanitized, RegExp.flags is interpolated directly into the generated output without escaping. A similar issue exists in Date.prototype.toISOString().

If an attacker can control the input object passed to serialize(), they can inject malicious JavaScript via the flags property of a RegExp object. When the serialized string is later evaluated (via eval, new Function, or <script> tags), the injected code executes.
---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->
  
Fix for serialize-javascript RCE (GHSA-5c6j-r48x-rmvq)
Issue: `serialize-javascript` ≤ 7.0.2 is vulnerable to code injection / RCE because:
- RegExp.flags is interpolated without escaping.
- Date.prototype.toISOString() is used in a way that allows injection.

Change in `package.json`: An override was added so the whole dependency tree uses a patched version:
"serialize-javascript": "^7.0.3"
Result: After npm install, the lockfile uses serialize-javascript 7.0.4 (≥ 7.0.3), so the vulnerability is addressed. The package is transitive (e.g. from html-webpack-plugin or similar); the override forces every consumer to 7.0.3+.

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: [ML-12234](https://iguazio.atlassian.net/browse/ML-12234)
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---


[ML-12234]: https://iguazio.atlassian.net/browse/ML-12234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ