### PR TITLE
[FIX] Dashboard side menu duplication after redirection

### DIFF
--- a/src/components/Details/details.util.js
+++ b/src/components/Details/details.util.js
@@ -314,7 +314,8 @@ export const generateRealTimePipelinesContent = selectedItem => {
     rootFunction: {
       value: selectedItem.name,
       status: selectedItem.state.value,
-      link: generateNuclioLink(`/projects/${selectedItem.project}/functions/${nuclioFunctionName}`)
+      link: generateNuclioLink(`/projects/${selectedItem.project}/functions/${nuclioFunctionName}`),
+      linkIsExternal: true
     },
     childFunction: {
       value: selectedItem.childFunctions ?? selectedItem.function_refs ?? [],

--- a/src/components/ModelsPage/RealTimePipelines/RealTimePipelines.jsx
+++ b/src/components/ModelsPage/RealTimePipelines/RealTimePipelines.jsx
@@ -198,7 +198,9 @@ const RealTimePipelines = () => {
 
             totalPipelines += 1
 
-            const nuclioFuncState = (getNuclioFuncState(nuclioFunc) || '').toLocaleLowerCase()
+            const nuclioFuncState = !isEmpty(nuclioFunc)
+              ? (getNuclioFuncState(nuclioFunc) || '').toLocaleLowerCase()
+              : ''
 
             const state = nuclioFuncState || func.state?.value || func.status?.state
 

--- a/src/components/ModelsPage/RealTimePipelines/realTimePipelines.scss
+++ b/src/components/ModelsPage/RealTimePipelines/realTimePipelines.scss
@@ -63,6 +63,14 @@ $pipelinesRowHeightExtended: variables.$rowHeight;
         $pipelinesRowHeight,
         $pipelinesRowHeightExtended
       );
+
+      .table-body__cell a.link {
+        display: flex;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
   }
 }

--- a/src/elements/DetailsInfoItem/DetailsInfoItem.jsx
+++ b/src/elements/DetailsInfoItem/DetailsInfoItem.jsx
@@ -217,16 +217,29 @@ const DetailsInfoItem = React.forwardRef(
             if (!infoItem) return null
 
             return item.link ? (
-              <Link className="details-item__data details-item__link" to={item.link} key={index}>
-                <Tooltip template={<TextTooltipTemplate text={infoItem} />}>{infoItem}</Tooltip>
-                {item.status && (
-                  <div className="details-item__data details-item__status">
-                    <Tooltip template={<TextTooltipTemplate text={item.status} />}>
-                      <i className={`state-${item.status}-function status-icon`} />
-                    </Tooltip>
-                  </div>
-                )}
-              </Link>
+              item.linkIsExternal ? (
+                <a href={item.link} className="details-item__data details-item__link" target="_top">
+                  <Tooltip template={<TextTooltipTemplate text={infoItem} />}>{infoItem}</Tooltip>
+                  {item.status && (
+                    <div className="details-item__data details-item__status">
+                      <Tooltip template={<TextTooltipTemplate text={item.status} />}>
+                        <i className={`state-${item.status}-function status-icon`} />
+                      </Tooltip>
+                    </div>
+                  )}
+                </a>
+              ) : (
+                <Link className="details-item__data details-item__link" to={item.link} key={index}>
+                  <Tooltip template={<TextTooltipTemplate text={infoItem} />}>{infoItem}</Tooltip>
+                  {item.status && (
+                    <div className="details-item__data details-item__status">
+                      <Tooltip template={<TextTooltipTemplate text={item.status} />}>
+                        <i className={`state-${item.status}-function status-icon`} />
+                      </Tooltip>
+                    </div>
+                  )}
+                </Link>
+              )
             ) : (
               <a
                 key={index}

--- a/src/utils/createRealTimePipelinesContent.js
+++ b/src/utils/createRealTimePipelinesContent.js
@@ -46,9 +46,10 @@ const createRealTimePipelinesContent = (pipelines, projectName) =>
           headerId: 'rootFunction',
           headerLabel: 'Root function',
           value: pipeline.name,
-          className: 'table-cell-2 link-blue',
+          className: 'table-cell-2',
           showStatus: true,
           showTag: true,
+          linkIsExternal: true,
           getLink: () =>
             generateNuclioLink(`/projects/${projectName}/functions/${nuclioFunctionName}`)
         },

--- a/src/utils/getState.js
+++ b/src/utils/getState.js
@@ -98,7 +98,8 @@ const functionStateLabels = {
   succeeded: 'Succeeded',
   standby: 'Standby',
   scaledToZero: 'Scaled to zero',
-  unhealthy: 'Unhealthy'
+  unhealthy: 'Unhealthy',
+  initialized: 'Initialized'
 }
 
 export default getState


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/ML-12236
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
