### PR TITLE
[FIX] uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5080,20 +5080,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@cucumber/html-formatter": {
       "version": "22.3.0",
       "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-22.3.0.tgz",
@@ -7034,20 +7020,6 @@
         "storybook": "^8.6.15"
       }
     },
-    "node_modules/@storybook/addon-actions/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@storybook/addon-backgrounds": {
       "version": "8.6.14",
       "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.14.tgz",
@@ -7154,20 +7126,6 @@
       },
       "peerDependencies": {
         "storybook": "^8.6.14"
-      }
-    },
-    "node_modules/@storybook/addon-essentials/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-highlight": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     "uuid": "^14.0.0"
   },
   "overrides": {
+    "uuid": "^14.0.0",
+    "cucumber-html-reporter": {
+      "uuid": "^3.4.0"
+    },
     "dompurify": "^3.4.0",
     "jsonpath": "^1.2.0",
     "minimist": "^1.2.8",


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

**Situation**
The app already depended on uuid@^14.0.0, which includes the [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) fix (buffer bounds for v3/v5/v6).
Transitive copies were still older: Storybook on 9.x, Cucumber on 11.x, and cucumber-html-reporter on the legacy 3.x line.

**Change**
1. overrides.uuid: "^14.0.0" so every consumer of the modern uuid package resolves to ≥ 14.0.0 (aligned with the patched release).

2. overrides.cucumber-html-reporter.uuid: "^3.4.0" so that package keeps npm uuid@3.x. A flat override to 14 breaks it: it loads uuid/v4, which is not in the exports of uuid@14 (ERR_PACKAGE_PATH_NOT_EXPORTED). That old major is a different implementation than the one in the advisory (src/v35.ts / v6.ts on the current package).

**Checks**
- npm ls uuid: app + Storybook + Cucumber → 14.0.0; cucumber-html-reporter → 3.4.0 nested.
- require('cucumber-html-reporter') succeeds.
- On 14.0.0, v4 / v5 / v6 with an 8-byte buffer and offset 4 all throw RangeError (matches the intended fix).

```
package.json
Lines 58-62
  "overrides": {
    "uuid": "^14.0.0",
    "cucumber-html-reporter": {
      "uuid": "^3.4.0"
    },
```
Note: scanners may still report uuid@3.4.0 under cucumber-html-reporter. If you need a clean audit there too, the durable approach is to move off cucumber-html-reporter or use a fork/release that depends on modern uuid and updated imports.

---

## ✅ Checklist

- [ ] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: [ML-12483](https://iguazio.atlassian.net/browse/ML-12483)
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---


[ML-12483]: https://iguazio.atlassian.net/browse/ML-12483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ