### PR TITLE
[Workflow] Add workflow_call trigger for cross-repo reusable builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,19 +44,51 @@ on:
         required: false
         default: 'ubuntu-latest'
 
+  workflow_call:
+    inputs:
+      docker_registries:
+        description: 'Comma separated list of docker registries to push images to'
+        required: true
+        type: string
+        default: 'ghcr.io/'
+      docker_repo:
+        description: 'Docker repo to push images to'
+        required: false
+        type: string
+        default: ''
+      version:
+        description: 'The version to build, without prefix v'
+        required: false
+        type: string
+        default: ''
+      runner:
+        description: 'The runner label to use for the workflow'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      ref:
+        description: 'The branch or tag to checkout and build'
+        required: false
+        type: string
+        default: ''
+    secrets: inherit
+
 jobs:
   build-images:
     name: Build and push ui image
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/ui' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'mlrun/ui' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event_name == 'workflow_call' && 'mlrun/ui' || github.repository }}
+        ref: ${{ inputs.ref || github.ref }}
 
     - name: Install curl and jq
-      if: ${{ !github.event.inputs.runner || github.event.inputs.runner == 'ubuntu-latest' }}
+      if: ${{ !inputs.runner || inputs.runner == 'ubuntu-latest' }}
       run: sudo apt-get install curl jq
 
     - name: Extract git hashes and latest version
@@ -69,15 +101,15 @@ jobs:
       id: computed_params
       run: |
         echo "mlrun_version=$( \
-          input_mlrun_version=${{ github.event.inputs.version }} && \
+          input_mlrun_version=${{ inputs.version }} && \
           default_mlrun_version=$(echo ${{ steps.git_info.outputs.unstable_version_prefix }}-${{ steps.git_info.outputs.mlrun_commit_hash }}) && \
           echo ${input_mlrun_version:-`echo $default_mlrun_version`})" >> $GITHUB_OUTPUT
         echo "mlrun_docker_repo=$( \
-          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
+          input_docker_repo=${{ inputs.docker_repo }} && \
           default_docker_repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') && \
           echo ${input_docker_repo:-`echo $default_docker_repo`})" >> $GITHUB_OUTPUT
         echo "mlrun_docker_registries=$( \
-          input_docker_registries=${{ github.event.inputs.docker_registries }} && \
+          input_docker_registries=${{ inputs.docker_registries }} && \
           echo ${input_docker_registries:-ghcr.io/})" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
@@ -93,7 +125,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Docker login (quay.io)
-      if: ${{ !github.event.inputs.runner || github.event.inputs.runner == 'ubuntu-latest' }}
+      if: ${{ !inputs.runner || inputs.runner == 'ubuntu-latest' }}
       continue-on-error: true
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
@@ -102,7 +134,7 @@ jobs:
         password: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_PASSWORD }}
 
     - name: Docker login (docker.com)
-      if: ${{ !github.event.inputs.runner || github.event.inputs.runner == 'ubuntu-latest' }}
+      if: ${{ !inputs.runner || inputs.runner == 'ubuntu-latest' }}
       continue-on-error: true
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,9 +48,14 @@ on:
     inputs:
       docker_registries:
         description: 'Comma separated list of docker registries to push images to'
-        required: true
+        required: false
         type: string
         default: 'ghcr.io/'
+      artifactory_docker_repo:
+        description: 'Artifactory docker repo name (e.g. mlrun_ce). When set, overrides docker_registries with the Artifactory URL from secrets.'
+        required: false
+        type: string
+        default: ''
       docker_repo:
         description: 'Docker repo to push images to'
         required: false
@@ -107,9 +112,16 @@ jobs:
           input_docker_repo=${{ inputs.docker_repo }} && \
           default_docker_repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') && \
           echo ${input_docker_repo:-`echo $default_docker_repo`})" >> $GITHUB_OUTPUT
-        echo "mlrun_docker_registries=$( \
-          input_docker_registries=${{ inputs.docker_registries }} && \
-          echo ${input_docker_registries:-ghcr.io/})" >> $GITHUB_OUTPUT
+        if [[ -n "$ARTIFACTORY_DOCKER_REPO_INPUT" && -n "$ARTIFACTORY_URL" ]]; then
+          echo "mlrun_docker_registries=${ARTIFACTORY_URL}/${ARTIFACTORY_DOCKER_REPO_INPUT}/" >> $GITHUB_OUTPUT
+        else
+          echo "mlrun_docker_registries=$( \
+            input_docker_registries=${{ inputs.docker_registries }} && \
+            echo ${input_docker_registries:-ghcr.io/})" >> $GITHUB_OUTPUT
+        fi
+      env:
+        ARTIFACTORY_DOCKER_REPO_INPUT: ${{ inputs.artifactory_docker_repo }}
+        ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -142,7 +154,7 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_PASSWORD }}
 
     - name: Docker login (Private Artifactory)
-      if: contains(inputs.docker_registries, 'artifactory.iguazeng.com')
+      if: contains(inputs.docker_registries, 'artifactory.iguazeng.com') || inputs.artifactory_docker_repo != ''
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
       with:
         registry: ${{ secrets.ARTIFACTORY_URL }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,13 +77,13 @@ jobs:
     name: Build and push ui image
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
 
-    # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/ui' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    # Run on mlrun/ui or when explicitly triggered (workflow_dispatch covers both direct and cross-repo calls)
+    if: github.repository == 'mlrun/ui' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v3
       with:
-        repository: ${{ github.event_name == 'workflow_call' && 'mlrun/ui' || github.repository }}
+        repository: mlrun/ui
         ref: ${{ inputs.ref || github.ref }}
 
     - name: Install curl and jq

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets: inherit
 
 jobs:
   build-images:


### PR DESCRIPTION
## Summary
- Adds `workflow_call` trigger to `build.yaml` so it can be called as a reusable workflow from `mlrun/mlrun` (e.g. `private-release.yaml`)
- Adds `artifactory_docker_repo` input that constructs the Artifactory registry URL from inherited secrets, avoiding GitHub's secret masking on job outputs
- Explicitly checks out `mlrun/ui` in the checkout step (required when called cross-repo, as `github.repository` refers to the caller)

## Related
- mlrun/mlrun#9605

## Test plan
- [x] Tested via `private-release.yaml` on `mlrun/mlrun:fix/githubapp-token-refresh-test`
- [x] Verify direct `push` and `workflow_dispatch` triggers still work as before


Made with [Cursor](https://cursor.com)