### PR TITLE
 [FIX] Support IPv6 nameservers in nginx resolver config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ ENV MLRUN_API_PROXY_URL="${MLRUN_API_PROXY_URL:-http://localhost:8090}" \
     MLRUN_NUCLIO_UI_URL="${MLRUN_NUCLIO_UI_URL:-http://localhost:8070}" \
     MLRUN_V3IO_ACCESS_KEY="${MLRUN_V3IO_ACCESS_KEY:-\"\"}"
 
-CMD echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf && /etc/nginx/run_nginx
+CMD echo resolver $(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ /:/) print "["$2"]"; else print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf && /etc/nginx/run_nginx


### PR DESCRIPTION
  ## 📝 Description
  In IPv6 Kubernetes clusters, the mlrun-ui pod fails to start with `invalid port in resolver` because nginx requires IPv6 addresses to be wrapped in square brackets. The `awk` command in the Dockerfile `CMD` writes bare IPv6 addresses (e.g. `fd00::10`) into `/etc/nginx/resolvers.conf`, and nginx misinterprets the colons as port separators.

  ---
  ## 🛠️ Changes Made
  - Updated the `awk` command in the Dockerfile `CMD` to detect IPv6 nameservers (containing `:`) and wrap them in square brackets (`[address]`)
  - IPv4 addresses are unaffected — fully backward-compatible
  ---
  ## ✅ Checklist
  - [x] I have given the PR a well-structured title describing the domain and the specific change that was made
  - [x] I tested the changes in the browser (locally or via preview build)
  - [x] I confirmed that existing tests pass
  - [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
  - [x] I updated the relevant Jira ticket with the appropriate details and status
  ---
  ## 🔗 References
  - Related ticket / issue:https://ecliptos.atlassian.net/browse/ML-12498
  - Figma / design spec: N/A
  - Documentation:
  ---
  ## 🚨 Potentially Breaking Changes
  - [ ] Yes
  - [x] No
  ---
  Includes DRC change
  - [ ] Yes
  - [x] No
  ---
  ## 🔍 Additional Notes
  - The fix handles all three scenarios: IPv4-only, IPv6-only, and dual-stack clusters
  - Example outputs:
    - IPv4: `resolver 10.96.0.10 ;`
    - IPv6: `resolver [fd00::10] ;`
    - Dual-stack: `resolver 10.96.0.10 [fd00::10] ;`
  ---
  ## 📸 Screenshots / Demos
  N/A - no UI changes; infrastructure/config fix only.

  ---
