### PR TITLE
[FIX] Scroll active sidebar item into view when sidebar opens

### DIFF
--- a/src/components/Sidebar/SidebarItem.jsx
+++ b/src/components/Sidebar/SidebarItem.jsx
@@ -20,7 +20,7 @@ such restriction.
 import { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useMatch } from 'react-router-dom'
-import { SidebarMenuButton, SidebarMenuItem } from './ui/sidebar'
+import { SidebarMenuButton, SidebarMenuItem, useSidebar } from './ui/sidebar'
 import { toTestId } from '../../utils/toTestId'
 
 const SidebarItem = ({
@@ -32,18 +32,19 @@ const SidebarItem = ({
   externalLink
 }) => {
   const ref = useRef(null)
+  const { open: sidebarOpen } = useSidebar()
 
   const match = useMatch(link ? `${link}/*` : null)
   const isActive = Boolean(match)
 
   useEffect(() => {
-    if (isActive) {
-      ref.current?.scrollIntoView({
-        block: 'nearest',
-        behavior: 'smooth'
-      })
+    if (isActive && sidebarOpen) {
+      const timer = setTimeout(() => {
+        ref.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      }, 300)
+      return () => clearTimeout(timer)
     }
-  }, [isActive])
+  }, [isActive, sidebarOpen])
 
   return (
     <SidebarMenuItem


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->
  
When the sidebar opens, the active navigation item was not brought into view. Users navigating to items below the fold (e.g. "ML functions" when collapsible sections are expanded) would see the sidebar open at the top with no scroll to the active item.

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->
  
- When the sidebar opens, it now waits for the expand animation to finish (300ms) and then scrolls to the active item if it's out of view
- Previously the scroll only happened when navigating to a new page - now it also happens when the sidebar itself opens
---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ML-12665
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->
  
block: 'nearest' is used so the scroll only triggers if the item is actually out of view - if it's already visible, nothing moves.

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
