### PR TITLE
[FIX] [Cooldown period] [UI] All alert activation has the latest Cooldown period value

### DIFF
--- a/src/components/DetailsInfo/DetailsInfoView.jsx
+++ b/src/components/DetailsInfo/DetailsInfoView.jsx
@@ -218,9 +218,15 @@ const DetailsInfoView = React.forwardRef(
               )}
               {!isEveryObjectValueEmpty(additionalInfo?.alerts?.resetPolicyDetailsInfo) && (
                 <>
-                  <h3 className="item-info__header" data-testid="reset-policy-header">
-                    Reset policy
-                  </h3>
+                  <div className="item-info__header-wrapper">
+                    <h3 className="item-info__header" data-testid="reset-policy-header">
+                      Reset policy
+                    </h3>
+                    <Tip
+                      className="item-info__header-tip"
+                      text="The displayed reset policy reflects the currently configured policy, which may differ from the policy that was in effect at the time of the alert activation."
+                    />
+                  </div>
                   <ul className="item-info__details">
                     {additionalInfo?.alerts?.resetPolicyDetailsInfo}
                   </ul>

--- a/src/components/DetailsInfo/detailsInfo.scss
+++ b/src/components/DetailsInfo/detailsInfo.scss
@@ -3,6 +3,7 @@
 @use 'igz-controls/scss/mixins';
 
 $itemInfoWithoutPadding: item-info-without-padding;
+$header-padding: 10px 0 7.5px 0;
 
 :root {
   --itemInfoWithoutPadding: #{$itemInfoWithoutPadding};
@@ -26,8 +27,21 @@ $itemInfoWithoutPadding: item-info-without-padding;
 
   &__header {
     margin: 0;
-    padding: 10px 0 7.5px 0;
+    padding: $header-padding;
     font-size: 18px;
+
+    &-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+    }
+
+    &-tip {
+      display: flex;
+      align-items: center;
+      padding: $header-padding;
+    }
   }
 
   &__details {


### PR DESCRIPTION
 ## 📝 Description
- Added an informative tooltip to the "Reset policy" header to clarify that the displayed policy reflects current configurations, which may differ from the time of alert activation.
---

## 🛠️ Changes Made
- Added `<Tip>` component to the "Reset policy" header in `DetailsInfoView`.
---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status
---

## 🔗 References
- Related ticket / issue: [Link](https://ecliptos.atlassian.net/browse/ML-12595)
---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No
---

Includes DRC change
- [ ] Yes
- [x] No
---

## 📸 Screenshots / Demos
<details>
<summary><b>Click to expand</b></summary>
  <img src="https://github.com/user-attachments/assets/cda35910-cfb3-4913-b4b7-e4c3d02b3d4b" width="45%" alt="After" style="border: 1px solid #ddd; border-radius: 4px; padding: 5px; margin: 5px;"/>
---
