### PR TITLE
[CI] Point UI build & promotion at new JFrog Artifactory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
 
     # secrets can't be referenced in step `if:`, so expose the Artifactory host via env
     env:
-      ARTIFACTORY_HOST: ${{ secrets.PRI_ARTIFACTORY_URL }}
+      ARTIFACTORY_HOST: ${{ secrets.PRIVATE_ARTIFACTORY_DOCKER_URL }}
 
     steps:
     - uses: actions/checkout@v3
@@ -125,7 +125,7 @@ jobs:
         fi
       env:
         ARTIFACTORY_DOCKER_REPO_INPUT: ${{ inputs.artifactory_docker_repo }}
-        ARTIFACTORY_URL: ${{ secrets.PRI_ARTIFACTORY_URL }}
+        ARTIFACTORY_URL: ${{ secrets.PRIVATE_ARTIFACTORY_DOCKER_URL }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -161,9 +161,9 @@ jobs:
       if: (env.ARTIFACTORY_HOST != '' && contains(inputs.docker_registries, env.ARTIFACTORY_HOST)) || inputs.artifactory_docker_repo != ''
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
       with:
-        registry: ${{ secrets.PRI_ARTIFACTORY_URL }}
-        username: ${{ secrets.PRI_ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.PRI_ARTIFACTORY_PASSWORD }}
+        registry: ${{ secrets.PRIVATE_ARTIFACTORY_DOCKER_URL }}
+        username: ${{ secrets.PRIVATE_ARTIFACTORY_USERNAME }}
+        password: ${{ secrets.PRIVATE_ARTIFACTORY_PASSWORD }}
 
     - name: Build & push image
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,6 +85,10 @@ jobs:
     # Run on mlrun/ui or when explicitly triggered (workflow_dispatch covers both direct and cross-repo calls)
     if: github.repository == 'mlrun/ui' || github.event_name == 'workflow_dispatch'
 
+    # secrets can't be referenced in step `if:`, so expose the Artifactory host via env
+    env:
+      ARTIFACTORY_HOST: ${{ secrets.PRI_ARTIFACTORY_URL }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -121,7 +125,7 @@ jobs:
         fi
       env:
         ARTIFACTORY_DOCKER_REPO_INPUT: ${{ inputs.artifactory_docker_repo }}
-        ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+        ARTIFACTORY_URL: ${{ secrets.PRI_ARTIFACTORY_URL }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -154,12 +158,12 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_PASSWORD }}
 
     - name: Docker login (Private Artifactory)
-      if: contains(inputs.docker_registries, 'artifactory.iguazeng.com') || inputs.artifactory_docker_repo != ''
+      if: (env.ARTIFACTORY_HOST != '' && contains(inputs.docker_registries, env.ARTIFACTORY_HOST)) || inputs.artifactory_docker_repo != ''
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
       with:
-        registry: ${{ secrets.ARTIFACTORY_URL }}
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        registry: ${{ secrets.PRI_ARTIFACTORY_URL }}
+        username: ${{ secrets.PRI_ARTIFACTORY_USERNAME }}
+        password: ${{ secrets.PRI_ARTIFACTORY_PASSWORD }}
 
     - name: Build & push image
       run: |

--- a/.github/workflows/ui-promotion.yaml
+++ b/.github/workflows/ui-promotion.yaml
@@ -34,7 +34,7 @@ on:
       source_artifactory_docker_repo:
         description: 'Source Artifactory Docker repository name'
         required: false
-        default: 'mlrun-staging'
+        default: 'mlrun-docker-local/mlrun-staging'
         type: string
       target_docker_registries:
         description: 'Comma separated list of target docker registries to push promoted images to (e.g., ghcr.io/,quay.io/,registry.hub.docker.com/)'
@@ -79,13 +79,13 @@ jobs:
       - name: Docker login (Source Artifactory)
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
         with:
-          registry: ${{ secrets.ARTIFACTORY_URL }}
-          username: ${{ secrets.ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          registry: ${{ secrets.PRI_ARTIFACTORY_URL }}
+          username: ${{ secrets.PRI_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.PRI_ARTIFACTORY_PASSWORD }}
 
       - name: Pull, retag and push UI Docker image
         run: |
-          SOURCE_IMAGE="${{ secrets.ARTIFACTORY_URL }}/${{ github.event.inputs.source_artifactory_docker_repo }}/mlrun/mlrun-ui:${{ github.event.inputs.version }}"
+          SOURCE_IMAGE="${{ secrets.PRI_ARTIFACTORY_URL }}/${{ github.event.inputs.source_artifactory_docker_repo }}/mlrun/mlrun-ui:${{ github.event.inputs.version }}"
           
           echo "Pulling image: $SOURCE_IMAGE"
           docker pull "$SOURCE_IMAGE"

--- a/.github/workflows/ui-promotion.yaml
+++ b/.github/workflows/ui-promotion.yaml
@@ -34,7 +34,7 @@ on:
       source_artifactory_docker_repo:
         description: 'Source Artifactory Docker repository name'
         required: false
-        default: 'mlrun-docker-local/mlrun-staging'
+        default: 'mlrun-staging'
         type: string
       target_docker_registries:
         description: 'Comma separated list of target docker registries to push promoted images to (e.g., ghcr.io/,quay.io/,registry.hub.docker.com/)'
@@ -79,13 +79,13 @@ jobs:
       - name: Docker login (Source Artifactory)
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # 3.6.0
         with:
-          registry: ${{ secrets.PRI_ARTIFACTORY_URL }}
-          username: ${{ secrets.PRI_ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.PRI_ARTIFACTORY_PASSWORD }}
+          registry: ${{ secrets.PRIVATE_ARTIFACTORY_DOCKER_URL }}
+          username: ${{ secrets.PRIVATE_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.PRIVATE_ARTIFACTORY_PASSWORD }}
 
       - name: Pull, retag and push UI Docker image
         run: |
-          SOURCE_IMAGE="${{ secrets.PRI_ARTIFACTORY_URL }}/${{ github.event.inputs.source_artifactory_docker_repo }}/mlrun/mlrun-ui:${{ github.event.inputs.version }}"
+          SOURCE_IMAGE="${{ secrets.PRIVATE_ARTIFACTORY_DOCKER_URL }}/${{ github.event.inputs.source_artifactory_docker_repo }}/mlrun/mlrun-ui:${{ github.event.inputs.version }}"
           
           echo "Pulling image: $SOURCE_IMAGE"
           docker pull "$SOURCE_IMAGE"


### PR DESCRIPTION
## 📝 Description

Migrates the UI build and promotion workflows off the legacy Iguazio Artifactory (`artifactory.iguazeng.com`) and onto the new McKinsey JFrog Artifactory. The private Artifactory host is now driven entirely by secrets so no private URL is hardcoded in this public repo. New `PRIVATE_ARTIFACTORY_*` secrets are introduced (rather than reusing the existing `ARTIFACTORY_*` ones) so workflows on un-migrated branches keep working during the migration period. Because JFrog SaaS serves Docker on per-repo subdomains rather than the bare host, Docker uses `PRIVATE_ARTIFACTORY_DOCKER_URL`.

Part of the MLRun release-process migration to JFrog (paired with the corresponding `mlrun/mlrun` change).

---

## 🛠️ Changes Made

- `build.yaml`: rewired Artifactory login/credentials from `ARTIFACTORY_*` to `PRIVATE_ARTIFACTORY_*` secrets.
- `build.yaml`: replaced the hardcoded `artifactory.iguazeng.com` host in the "Docker login (Private Artifactory)" condition with a secret-backed `ARTIFACTORY_HOST` env var (with an empty-host guard), so no private URL lives in the repo.
- `ui-promotion.yaml`: rewired source Artifactory login/credentials to `PRIVATE_ARTIFACTORY_*` secrets.
- Docker login and image refs use the JFrog per-repo subdomain host (`PRIVATE_ARTIFACTORY_DOCKER_URL`); the `source_artifactory_docker_repo` default stays `mlrun-staging` (the repo key lives in the subdomain host, not the path).

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status

---

## 🔗 References
- Related ticket / issue: ML-12716

---

## 🚨 Potentially Breaking Changes
- [x] No

Requires the `PRIVATE_ARTIFACTORY_URL` (PyPI host), `PRIVATE_ARTIFACTORY_DOCKER_URL` (Docker subdomain host), `PRIVATE_ARTIFACTORY_USERNAME`, and `PRIVATE_ARTIFACTORY_PASSWORD` secrets to be set on the repo (already configured).

---

Includes DRC change
- [x] No

---

## 🧪 Testing
Validated against the new JFrog endpoints (test version `1.12.0-rc98`):

- The UI image built and pushed to the private JFrog Docker registry (per-repo subdomain) via the cross-repo `build.yaml` trigger from `private-release`.
- Confirmed the image is pullable from the subdomain.
- Ran `ui-promotion` on this branch: pulled the UI image from the private JFrog repo and promoted it (digest preserved) to the public container registry (GHCR).

All test artifacts were cleaned up afterward.

---

## 🔍 Additional Notes

The legacy `ARTIFACTORY_*` secrets are intentionally left in place so existing workflows on other branches don't break during the migration window.

