### PR TITLE
[FIX] Change default sorting to updated time descending

### DIFF
--- a/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
@@ -48,6 +48,7 @@ import {
   APPLICATION_KIND,
   APPLICATIONS_ERROR_MESSAGE,
   APPLICATIONS_FILTERS_CONFIG,
+  DEFAULT_UPDATED_SORTING,
   TAG_WILDCARD
 } from './applications.constants'
 import {
@@ -58,7 +59,6 @@ import {
 import { APPLICATIONS_PAGE, APPLICATIONS_PAGE_PATH } from '../../../constants'
 import {
   DEFAULT_APPLICATION_DETAILS_TAB,
-  DEFAULT_NAME_SORTING,
   VIEW_YAML_LABEL
 } from './ApplicationDetails/applicationDetails.constants'
 
@@ -265,7 +265,7 @@ const ApplicationsPage = () => {
                     data={applications}
                     columns={columns}
                     rowActions={rowActions}
-                    initialSorting={DEFAULT_NAME_SORTING}
+                    initialSorting={DEFAULT_UPDATED_SORTING}
                   />
                 )}
               </div>

--- a/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.test.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.test.jsx
@@ -23,6 +23,8 @@ import { render, screen } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 import ApplicationsPage from './ApplicationsPage'
+import { DEFAULT_UPDATED_SORTING } from './applications.constants'
+import { DataTable } from 'igz-controls/nextGenComponents'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -46,7 +48,7 @@ vi.mock('react-redux', () => ({
 }))
 
 vi.mock('igz-controls/nextGenComponents', () => ({
-  DataTable: props => (
+  DataTable: vi.fn(props => (
     <table data-testid="data-table">
       <tbody>
         {props.data.map((row, rowIndex) => (
@@ -62,7 +64,7 @@ vi.mock('igz-controls/nextGenComponents', () => ({
         ))}
       </tbody>
     </table>
-  ),
+  )),
   Loader: () => <div data-testid="loader" />,
   Tooltip: props => <>{props.children}</>,
   TooltipTrigger: props => <>{props.children}</>,
@@ -231,6 +233,13 @@ describe('ApplicationsPage', () => {
     it('renders action bar', () => {
       renderPage()
       expect(screen.getByTestId('action-bar')).toBeInTheDocument()
+    })
+
+    it('passes default sorting by "updated" descending to DataTable', () => {
+      renderPage()
+      const dataTableCalls = DataTable.mock.calls
+      const lastCallProps = dataTableCalls[dataTableCalls.length - 1][0]
+      expect(lastCallProps.initialSorting).toEqual(DEFAULT_UPDATED_SORTING)
     })
   })
 

--- a/src/nextGenComponents/pages/ApplicationsPage/applications.constants.js
+++ b/src/nextGenComponents/pages/ApplicationsPage/applications.constants.js
@@ -107,3 +107,5 @@ export const APPLICATIONS_FILTERS_CONFIG = {
     formatFilterValue: formatStatusFilterValue
   }
 }
+
+export const DEFAULT_UPDATED_SORTING = [{ id: 'updated', desc: true }]

--- a/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
@@ -110,6 +110,7 @@ export const getApplicationsColumns = projectName => [
     id: 'updated',
     size: 15,
     header: 'Updated',
+    enableSorting: true,
     cell: ({ row }) => (
       <span className="text-igz-secondary text-body" data-testid="updated-cell">
         {formatDatetime(row.original.updated, '')}


### PR DESCRIPTION
## 📝 Description
This PR changes the default sorting of the Applications list from ascending by `Name` to descending by `Updated` time
---

## 🛠️ Changes Made
- Added `DEFAULT_UPDATED_SORTING` constant and removed the unused `DEFAULT_NAME_SORTING` constant
- Updated the `initialSorting` prop for the `DataTable` in `ApplicationsPage`
- Explicitly added `enableSorting: true` to the `updated` column definition to ensure the sorting indicator is correctly displayed in the header
- Updated unit tests in `ApplicationsPage.test.jsx` to verify the new default sorting configuration

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [x] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

---

Includes DRC change
- [ ] Yes
- [x] No