### PR TITLE
[FIX] Append search params to application details links to preserve filters

### DIFF
--- a/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
@@ -18,7 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { isEmpty } from 'lodash'
 import { HelpCircle, FileCode2 } from 'lucide-react'
@@ -65,6 +65,7 @@ import {
 const ApplicationsPage = () => {
   const params = useParams()
   const navigate = useNavigate()
+  const { search } = useLocation()
   const dispatch = useDispatch()
   const funcLoading = useSelector(
     store => store.functionsStore.funcLoading || store.nuclioStore.nuclioFunctionLoading
@@ -112,21 +113,21 @@ const ApplicationsPage = () => {
 
   const handleCloseDetails = useCallback(() => {
     setSelectedApplication({})
-    navigate(`/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}${window.location.search}`, {
+    navigate(`/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}${search}`, {
       replace: true
     })
-  }, [navigate, params.projectName])
+  }, [navigate, params.projectName, search])
 
   const handleTabChange = useCallback(
     tabId => {
       if (params.name && params.id) {
         navigate(
-          `/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}/${params.name}/${params.id}/${tabId}${window.location.search}`,
+          `/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}/${params.name}/${params.id}/${tabId}${search}`,
           { replace: true }
         )
       }
     },
-    [navigate, params.projectName, params.name, params.id]
+    [navigate, params.projectName, params.name, params.id, search]
   )
 
   const selectionArgs = useMemo(
@@ -187,7 +188,10 @@ const ApplicationsPage = () => {
     }
   }, [selectedApplication])
 
-  const columns = useMemo(() => getApplicationsColumns(params.projectName), [params.projectName])
+  const columns = useMemo(
+    () => getApplicationsColumns(params.projectName, search),
+    [params.projectName, search]
+  )
 
   return (
     <div

--- a/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/ApplicationsPage.jsx
@@ -18,7 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { isEmpty } from 'lodash'
 import { HelpCircle, FileCode2 } from 'lucide-react'
@@ -65,7 +65,6 @@ import {
 const ApplicationsPage = () => {
   const params = useParams()
   const navigate = useNavigate()
-  const { search } = useLocation()
   const dispatch = useDispatch()
   const funcLoading = useSelector(
     store => store.functionsStore.funcLoading || store.nuclioStore.nuclioFunctionLoading
@@ -113,21 +112,21 @@ const ApplicationsPage = () => {
 
   const handleCloseDetails = useCallback(() => {
     setSelectedApplication({})
-    navigate(`/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}${search}`, {
+    navigate(`/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}${window.location.search}`, {
       replace: true
     })
-  }, [navigate, params.projectName, search])
+  }, [navigate, params.projectName])
 
   const handleTabChange = useCallback(
     tabId => {
       if (params.name && params.id) {
         navigate(
-          `/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}/${params.name}/${params.id}/${tabId}${search}`,
+          `/projects/${params.projectName}/${APPLICATIONS_PAGE_PATH}/${params.name}/${params.id}/${tabId}${window.location.search}`,
           { replace: true }
         )
       }
     },
-    [navigate, params.projectName, params.name, params.id, search]
+    [navigate, params.projectName, params.name, params.id]
   )
 
   const selectionArgs = useMemo(
@@ -188,10 +187,7 @@ const ApplicationsPage = () => {
     }
   }, [selectedApplication])
 
-  const columns = useMemo(
-    () => getApplicationsColumns(params.projectName, search),
-    [params.projectName, search]
-  )
+  const columns = useMemo(() => getApplicationsColumns(params.projectName), [params.projectName])
 
   return (
     <div

--- a/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
@@ -29,7 +29,7 @@ import {
 } from './ApplicationDetails/applicationDetails.constants'
 import { UNKNOWN_STATE_LABEL, UNKNOWN_STATE_CLASS } from './applications.constants'
 
-export const getApplicationsColumns = projectName => [
+export const getApplicationsColumns = (projectName, searchParams = '') => [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -45,7 +45,7 @@ export const getApplicationsColumns = projectName => [
       return (
         <div className="flex items-center gap-2">
           <Link
-            to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${DEFAULT_APPLICATION_DETAILS_TAB}`}
+            to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${DEFAULT_APPLICATION_DETAILS_TAB}${searchParams}`}
             className="text-igz-primary text-body font-medium hover:underline"
             data-testid="application-name-link"
           >
@@ -96,7 +96,7 @@ export const getApplicationsColumns = projectName => [
 
       return (
         <Link
-          to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${APPLICATION_DETAILS_TAB.MONITORING_ENDPOINTS}`}
+          to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${APPLICATION_DETAILS_TAB.MONITORING_ENDPOINTS}${searchParams}`}
           className="!text-igz-link text-body hover:underline"
           data-testid="endpoints-count"
         >

--- a/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
+++ b/src/nextGenComponents/pages/ApplicationsPage/applicationsColumns.jsx
@@ -29,7 +29,7 @@ import {
 } from './ApplicationDetails/applicationDetails.constants'
 import { UNKNOWN_STATE_LABEL, UNKNOWN_STATE_CLASS } from './applications.constants'
 
-export const getApplicationsColumns = (projectName, searchParams = '') => [
+export const getApplicationsColumns = projectName => [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -45,7 +45,7 @@ export const getApplicationsColumns = (projectName, searchParams = '') => [
       return (
         <div className="flex items-center gap-2">
           <Link
-            to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${DEFAULT_APPLICATION_DETAILS_TAB}${searchParams}`}
+            to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${DEFAULT_APPLICATION_DETAILS_TAB}${window.location.search}`}
             className="text-igz-primary text-body font-medium hover:underline"
             data-testid="application-name-link"
           >
@@ -96,7 +96,7 @@ export const getApplicationsColumns = (projectName, searchParams = '') => [
 
       return (
         <Link
-          to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${APPLICATION_DETAILS_TAB.MONITORING_ENDPOINTS}${searchParams}`}
+          to={`/projects/${projectName}/${APPLICATIONS_PAGE_PATH}/${row.original.name}/${identifier}/${APPLICATION_DETAILS_TAB.MONITORING_ENDPOINTS}${window.location.search}`}
           className="!text-igz-link text-body hover:underline"
           data-testid="endpoints-count"
         >


### PR DESCRIPTION
## 📝 Description
This PR fixes an issue where user-selected filters on the Applications page were being reset to their defaults after navigating to the application details and returning via the UI close/back button. By passing the URL query parameters through the routing state, the filters remain active and the UI stays synchronized as expected

---

## 🛠️ Changes Made
- Updated `getApplicationsColumns` to accept `searchParams` and appended them to the `<Link>` URLs in the data table

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [x] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

---

Includes DRC change
- [ ] Yes
- [x] No
