### PR TITLE
[mlrun-ui] Align Module Federation dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@dagrejs/dagre": "^1.1.5",
-        "@module-federation/runtime": "^0.23.0",
-        "@module-federation/vite": "^1.2.6",
+        "@module-federation/runtime": "0.23.0",
+        "@module-federation/vite": "1.11.0",
         "@monaco-editor/react": "^4.7.0",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "homepage": "/mlrun",
   "dependencies": {
     "@dagrejs/dagre": "^1.1.5",
-    "@module-federation/runtime": "^0.23.0",
-    "@module-federation/vite": "^1.2.6",
+    "@module-federation/runtime": "0.23.0",
+    "@module-federation/vite": "1.11.0",
     "@monaco-editor/react": "^4.7.0",
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.16.0",
@@ -62,7 +62,7 @@
   "overrides": {
     "uuid": "^14.0.0",
     "cucumber-html-reporter": {
-      "uuid": "^11.1.1" 
+      "uuid": "^11.1.1"
     },
     "dompurify": "^3.4.0",
     "jsonpath": "^1.2.0",


### PR DESCRIPTION
Align Module Federation dependency versions


## 📝 Description
Align Module Federation packages in oris-ui with the approved versions used across MLRun UI applications.

---

## 🛠️ Changes Made
- add dts property to the federation.
- update version in the package.json

```
@module-federation/vite is pinned to 1.11.0.
@module-federation/runtime is pinned to 0.23.0.
```
---

## ✅ Checklist

- [ ] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/IG4-2882
- Related PR: https://github.com/McK-Private/oris-ui/pull/331
- Related PR: https://github.com/McK-Private/nuclio-ui/pull/189



---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [ ] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
