### PR TITLE
[FIX] [UI] Missing loader on project monitor page navigation

### DIFF
--- a/src/layout/Page/Page.jsx
+++ b/src/layout/Page/Page.jsx
@@ -102,7 +102,7 @@ const Page = () => {
       {projectName && <Sidebar projectName={projectName} />}
       <SidebarInset>
         <>
-          <Suspense>
+          <Suspense fallback={<Loader />}>
             <main id="main" ref={mainRef}>
               <div id="main-wrapper">{isProjectsFetched ? <Outlet /> : <Loader />}</div>
             </main>


### PR DESCRIPTION
## 📝 Description
After the navbar redesign, navigating to a project page for the first time showed blank content with no visible loader. On repeated visits the loader also wasn't shown while data was loading. Both issues were introduced by the navbar refactor PR

---

## 🛠️ Changes Made
- Added `fallback={<Loader />}` to `<Suspense>` in `Page.jsx`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

---
 ## 🔗 References
 - [Link](https://ecliptos.atlassian.net/browse/ML-12802)
---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

---

Includes DRC change
- [ ] Yes
- [x] No
