### PR TITLE
[BUILD] Stamp org.opencontainers.image.revision label on UI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN echo ${COMMIT_HASH} > ./build/COMMIT_HASH && \
 
 FROM gcr.io/iguazio/nginx-unprivileged:1.31.1-alpine AS production-stage
 
+ARG GIT_COMMIT_SHA
+LABEL org.opencontainers.image.revision=$GIT_COMMIT_SHA
+
 # align UID & GID with nginx-unprivileged image UID & GID
 ARG UID=101
 ARG GID=101

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "preview": "vite preview",
     "preinstall": "npx force-resolutions",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
-    "docker": "docker build -t ${MLRUN_DOCKER_REGISTRY}${MLRUN_DOCKER_REPO:-mlrun}/mlrun-ui:${MLRUN_DOCKER_TAG:-latest} --build-arg COMMIT_HASH=\"`git rev-parse --short HEAD`\" --build-arg DATE=\"`date -u`\" -f Dockerfile .",
+    "docker": "docker build -t ${MLRUN_DOCKER_REGISTRY}${MLRUN_DOCKER_REPO:-mlrun}/mlrun-ui:${MLRUN_DOCKER_TAG:-latest} --build-arg COMMIT_HASH=\"`git rev-parse --short HEAD`\" --build-arg GIT_COMMIT_SHA=\"`git rev-parse HEAD`\" --build-arg DATE=\"`date -u`\" -f Dockerfile .",
     "generate-rn": "./generate-release-notes.js ${MLRUN_OLD_VERSION} ${MLRUN_VERSION} ${MLRUN_RELEASE_BRANCH} ${MLRUN_RELEASE_TYPE}",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
## 📝 Description

Adds the standard OCI revision label (`org.opencontainers.image.revision`) to the production UI image so the full UI commit SHA travels with the published image. This lets the MLRun `release-promotion` workflow derive the UI commit to tag straight from the image, instead of requiring an operator to paste it by hand.

---

## 🛠️ Changes Made
- `Dockerfile`: declare `ARG GIT_COMMIT_SHA` and set `LABEL org.opencontainers.image.revision=$GIT_COMMIT_SHA` on the production stage.
- `package.json`: pass `--build-arg GIT_COMMIT_SHA="$(git rev-parse HEAD)"` (the full SHA) from the `docker` build script.

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: DEVOPS-1976
- Figma / design spec:
- Documentation: Companion PR — mlrun/mlrun#9868 (reads this label via `skopeo inspect` to derive `ui_commit_sha`)

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

Metadata only — no behavior change to the running image. Images built before this change have no label; the consumer handles that by failing loud and asking for an explicit `ui_commit_sha`.

---

Includes DRC change
- [ ] Yes
- [x] No

---

## 🔍 Additional Notes
- Companion to the MLRun `release-promotion` generalization; that workflow consumes this label.

---

## 📸 Screenshots / Demos
N/A — no UI change.
