### PR TITLE
[FIX] [UI] Truncate long project names in sidebar project dropdown

### DIFF
--- a/src/nextGenComponents/shared/Sidebar/ProjectDropdown/ProjectDropdown.jsx
+++ b/src/nextGenComponents/shared/Sidebar/ProjectDropdown/ProjectDropdown.jsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  EllipsisTooltip,
   Input,
   Tooltip,
   TooltipContent,
@@ -140,7 +141,9 @@ const ProjectDropdown = ({ projectName }) => {
                         to={project.link}
                         className={itemClassName}
                       >
-                        <span>{project.label}</span>
+                        <EllipsisTooltip className="min-w-0 flex-1 whitespace-nowrap">
+                          {project.label}
+                        </EllipsisTooltip>
                         {project.isCurrent && (
                           <Check className="h-4 w-4 shrink-0 text-green-600" aria-hidden="true" />
                         )}


### PR DESCRIPTION
## 📝 Description
Long project names in the sidebar project dropdown were wrapping to multiple lines instead of being truncated. This fix replaces the wrapping behavior with `EllipsisTooltip`, showing `...` for overflowing names and a tooltip with the full name on hover.

---

## 🛠️ Changes Made
- Replaced plain `<span>` with `EllipsisTooltip`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

---

 ## 🔗 References
 - [Link](https://ecliptos.atlassian.net/browse/ML-12803)
---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

---

Includes DRC change
- [ ] Yes
- [x] No

---

