### PR TITLE
[FIX] [Navbar] Nuclio options are not highlighted after selection

### DIFF
--- a/src/nextGenComponents/shared/Sidebar/SidebarCollapseItem/SidebarCollapseItem.jsx
+++ b/src/nextGenComponents/shared/Sidebar/SidebarCollapseItem/SidebarCollapseItem.jsx
@@ -38,9 +38,14 @@ const SidebarCollapseItem = ({ icon, label, nestedLinks }) => {
   const [open, setOpen] = useState(false)
   const { open: sidebarOpen } = useSidebar()
 
-  const isAnyChildActive = nestedLinks.some(nested =>
-    nested.link ? pathname.includes(nested.link.toLowerCase()) : false
-  )
+  const isAnyChildActive = nestedLinks.some(nested => {
+    if (!nested.link) return false
+    try {
+      return pathname.toLowerCase().startsWith(new URL(nested.link).pathname.toLowerCase())
+    } catch {
+      return pathname.toLowerCase().startsWith(nested.link.toLowerCase())
+    }
+  })
 
   return (
     <Collapsible

--- a/src/nextGenComponents/shared/Sidebar/SidebarItem/SidebarItem.jsx
+++ b/src/nextGenComponents/shared/Sidebar/SidebarItem/SidebarItem.jsx
@@ -17,7 +17,7 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useMatch } from 'react-router-dom'
 import { SidebarMenuButton, SidebarMenuItem, useSidebar } from 'igz-controls/nextGenComponents'
@@ -34,7 +34,16 @@ const SidebarItem = ({
   const ref = useRef(null)
   const { open: sidebarOpen } = useSidebar()
 
-  const match = useMatch(link ? `${link}/*` : null)
+  const linkPath = useMemo(() => {
+    if (!link) return null
+    try {
+      return new URL(link).pathname
+    } catch {
+      return link
+    }
+  }, [link])
+
+  const match = useMatch(linkPath ? `${linkPath}/*` : null)
   const isActive = Boolean(match)
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/IG4-3028
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [ ] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->
@muli-cohen @pini-sh-panda Please cherry-pick and open PR to development once merged in feature branch
---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->
<img width="1436" height="1100" alt="image" src="https://github.com/user-attachments/assets/049ae781-b4a7-46f2-a8ec-367c54b49804" />

---
