### PR TITLE
[FEAT] Show project sync status (creating/deleting) with tooltip

### DIFF
--- a/src/api/events-api.js
+++ b/src/api/events-api.js
@@ -17,37 +17,13 @@ illegal under applicable law, and the grant of the foregoing license
 under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
-import { mainHttpClient } from '../httpClient'
+import { iguazioHttpClient } from '../httpClient'
 
-const tasksApi = {
-  getBackgroundTasks: kind => {
-    const config = {}
-
-    if (kind) {
-      config.params = {
-        kind
-      }
-    }
-
-    return mainHttpClient.get('/background-tasks', config)
-  },
-  getProjectBackgroundTask: (project, id) => {
-    return mainHttpClient.get(`/projects/${project}/background-tasks/${id}`)
-  },
-  getBackgroundTask: id => {
-    return mainHttpClient.get(`/background-tasks/${id}`)
-  },
-  getProjectBackgroundTasks: (project, state) => {
-    const config = {}
-
-    if (state) {
-      config.params = {
-        state
-      }
-    }
-
-    return mainHttpClient.get(`/projects/${project}/background-tasks`, config)
-  }
+const eventsApi = {
+  getProjectSyncIssues: () =>
+    iguazioHttpClient.get('/v1/events/activations', {
+      params: { class: 'Software.ProjectSync', severity: 'major,critical' }
+    })
 }
 
-export default tasksApi
+export default eventsApi

--- a/src/components/ProjectsPage/Projects.jsx
+++ b/src/components/ProjectsPage/Projects.jsx
@@ -61,6 +61,7 @@ import {
   setDeletingProjects
 } from '../../reducers/projectReducer'
 import { fetchAllNuclioFunctions } from '../../reducers/nuclioReducer'
+import { useProjectsSyncStatus } from '../../hooks/useProjectsSyncStatus.hook'
 
 const Projects = () => {
   const [actionsMenu, setActionsMenu] = useState({})
@@ -91,14 +92,22 @@ const Projects = () => {
     deletingProjectsRef.current = projectStore.deletingProjects
   }, [projectStore.deletingProjects])
 
-  const fetchMinimalProjects = useCallback(() => {
-    dispatch(
-      fetchProjects({
-        params: { format: 'minimal' },
-        setRequestErrorMessage: setProjectsRequestErrorMessage
-      })
-    )
-  }, [dispatch])
+  const fetchMinimalProjects = useCallback(
+    (silent = false) => {
+      dispatch(
+        fetchProjects({
+          params: { format: 'minimal' },
+          setRequestErrorMessage: setProjectsRequestErrorMessage,
+          silent
+        })
+      )
+    },
+    [dispatch]
+  )
+
+  const fetchMinimalProjectsSilently = useCallback(() => {
+    fetchMinimalProjects(true)
+  }, [fetchMinimalProjects])
 
   const isValidProjectState = useCallback(
     project => {
@@ -184,6 +193,11 @@ const Projects = () => {
         })
     }
   }, [isNuclioModeDisabled, dispatch, fetchMinimalProjects])
+
+  const { projectSyncStatusMap } = useProjectsSyncStatus(
+    projectStore.projects,
+    fetchMinimalProjectsSilently
+  )
 
   const handleSearchOnChange = useCallback(
     name => {
@@ -457,6 +471,7 @@ const Projects = () => {
       isDescendingOrder={isDescendingOrder}
       projectsRequestErrorMessage={projectsRequestErrorMessage}
       projectStore={projectStore}
+      projectSyncStatusMap={projectSyncStatusMap}
       refreshProjects={refreshProjects}
       selectedProjectsState={selectedProjectsState}
       setCreateProject={setCreateProject}

--- a/src/components/ProjectsPage/Projects.jsx
+++ b/src/components/ProjectsPage/Projects.jsx
@@ -138,15 +138,17 @@ const Projects = () => {
     [isDescendingOrder, sortProjectId]
   )
 
-  const refreshProjects = useCallback(() => {
+  const refreshProjects = useCallback((silent = false) => {
     abortControllerRef.current = new AbortController()
 
     if (!isNuclioModeDisabled) {
       dispatch(fetchAllNuclioFunctions())
     }
 
-    dispatch(removeProjects())
-    fetchMinimalProjects()
+    if (!silent) {
+      dispatch(removeProjects())
+    }
+    fetchMinimalProjects(silent)
     dispatch(
       fetchProjectsSummary({ signal: abortControllerRef.current.signal, refresh: refreshProjects })
     )
@@ -439,7 +441,7 @@ const Projects = () => {
       .then(result => {
         if (result) {
           setCreateProject(false)
-          refreshProjects()
+          refreshProjects(true)
           dispatch(fetchProjectsNames())
           dispatch(
             setNotification({

--- a/src/components/ProjectsPage/ProjectsView.jsx
+++ b/src/components/ProjectsPage/ProjectsView.jsx
@@ -57,6 +57,7 @@ const ProjectsView = ({
   isDescendingOrder,
   projectsRequestErrorMessage,
   projectStore,
+  projectSyncStatusMap,
   refreshProjects,
   selectedProjectsState,
   setCreateProject,
@@ -176,6 +177,7 @@ const ProjectsView = ({
                     projectSummary={projectStore.projectsSummary.data.find(
                       item => item.name === project.metadata.name
                     )}
+                    syncStatusTooltip={projectSyncStatusMap[project.metadata.name]}
                   />
                 )
               })}
@@ -215,6 +217,7 @@ ProjectsView.propTypes = {
   isDescendingOrder: PropTypes.bool.isRequired,
   projectStore: PropTypes.object.isRequired,
   projectsRequestErrorMessage: PropTypes.string.isRequired,
+  projectSyncStatusMap: PropTypes.object.isRequired,
   refreshProjects: PropTypes.func.isRequired,
   selectedProjectsState: PropTypes.string.isRequired,
   setCreateProject: PropTypes.func.isRequired,

--- a/src/components/ProjectsPage/projects.util.jsx
+++ b/src/components/ProjectsPage/projects.util.jsx
@@ -443,10 +443,7 @@ export const handleDeleteProject = (
 
         dispatch(setDeletingProjects(newDeletingProjects))
 
-        // Refetch immediately so `status.state: deleting` is picked up right away and
-        // the sync-status polling (see useProjectsSyncStatus.hook.js) starts covering this
-        // project even if no other project was already in a transitional state.
-        fetchMinimalProjects()
+        fetchMinimalProjects(true)
 
         if (refreshProjects) {
           pollDeletingProjects(terminatePollRef, newDeletingProjects, refreshProjects, dispatch)

--- a/src/components/ProjectsPage/projects.util.jsx
+++ b/src/components/ProjectsPage/projects.util.jsx
@@ -39,7 +39,13 @@ import {
 } from '../../reducers/projectReducer'
 import tasksApi from '../../api/tasks-api'
 import { DANGER_BUTTON, FORBIDDEN_ERROR_STATUS_CODE } from 'igz-controls/constants'
-import { PROJECT_ONLINE_STATUS } from '../../constants'
+import {
+  PROJECT_CREATING_STATUS,
+  PROJECT_DELETING_STATUS,
+  PROJECT_ONLINE_STATUS,
+  PROJECT_SYNC_ISSUE_TOOLTIP,
+  PROJECT_TRANSITIONAL_STATUSES
+} from '../../constants'
 import { setNotification } from 'igz-controls/reducers/notificationReducer'
 import { showErrorNotification } from 'igz-controls/utils/notification.util'
 
@@ -255,6 +261,31 @@ export const pollDeletingProjects = (terminatePollRef, deletingProjects, refresh
   })
 }
 
+const projectSyncStateWords = {
+  [PROJECT_CREATING_STATUS]: { noun: 'creation', gerund: 'creating' },
+  [PROJECT_DELETING_STATUS]: { noun: 'deletion', gerund: 'deleting' }
+}
+
+export const getProjectSyncTooltip = (project, backgroundTaskState, hasSystemSyncIssue) => {
+  const state = project.status?.state
+
+  if (!PROJECT_TRANSITIONAL_STATUSES.includes(state)) {
+    return null
+  }
+
+  if (hasSystemSyncIssue) {
+    return PROJECT_SYNC_ISSUE_TOOLTIP
+  }
+
+  const { noun, gerund } = projectSyncStateWords[state]
+
+  if (backgroundTaskState === BG_TASK_FAILED) {
+    return `Issues were detected while ${gerund} the project. The system will automatically retry: no manual action is needed.`
+  }
+
+  return `The project is in ${noun} process.`
+}
+
 export const generateAlerts = (data, dispatch) => {
   const projectAlerts = {}
   data.forEach(project => {
@@ -411,6 +442,11 @@ export const handleDeleteProject = (
         }
 
         dispatch(setDeletingProjects(newDeletingProjects))
+
+        // Refetch immediately so `status.state: deleting` is picked up right away and
+        // the sync-status polling (see useProjectsSyncStatus.hook.js) starts covering this
+        // project even if no other project was already in a transitional state.
+        fetchMinimalProjects()
 
         if (refreshProjects) {
           pollDeletingProjects(terminatePollRef, newDeletingProjects, refreshProjects, dispatch)

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,12 @@ export const NAVBAR_WIDTH_OPENED = 245
 export const CANCEL_REQUEST_TIMEOUT = 120000
 
 export const PROJECT_ONLINE_STATUS = 'online'
+export const PROJECT_CREATING_STATUS = 'creating'
+export const PROJECT_DELETING_STATUS = 'deleting'
+export const PROJECT_TRANSITIONAL_STATUSES = [PROJECT_CREATING_STATUS, PROJECT_DELETING_STATUS]
+export const PROJECT_SYNC_POLL_INTERVAL_MS = 10000
+export const PROJECT_SYNC_ISSUE_TOOLTIP =
+  'Project synchronization issues were detected. Contact the system admin.'
 
 export const ABORTED_STATE = 'aborted'
 export const ABORTING_STATE = 'aborting'

--- a/src/elements/ProjectCard/ProjectCard.jsx
+++ b/src/elements/ProjectCard/ProjectCard.jsx
@@ -25,7 +25,7 @@ import ProjectCardView from './ProjectCardView'
 
 import { generateProjectStatistic } from './projectCard.util'
 
-const ProjectCard = ({ actionsMenu, alert, project, projectSummary }) => {
+const ProjectCard = ({ actionsMenu, alert, project, projectSummary, syncStatusTooltip }) => {
   const [fetchNuclioFunctionsFailure, setFetchNuclioFunctionsFailure] = useState(false)
   const projectStore = useSelector(store => store.projectStore)
   const nuclioStore = useSelector(store => store.nuclioStore)
@@ -62,6 +62,7 @@ const ProjectCard = ({ actionsMenu, alert, project, projectSummary }) => {
       alert={alert}
       project={project}
       statistics={statistics}
+      syncStatusTooltip={syncStatusTooltip}
       ref={actionsMenuRef}
     />
   )
@@ -71,7 +72,8 @@ ProjectCard.propTypes = {
   actionsMenu: PropTypes.object.isRequired,
   alert: PropTypes.number.isRequired,
   project: PropTypes.object.isRequired,
-  projectSummary: PropTypes.object
+  projectSummary: PropTypes.object,
+  syncStatusTooltip: PropTypes.string
 }
 
 export default ProjectCard

--- a/src/elements/ProjectCard/ProjectCardView.jsx
+++ b/src/elements/ProjectCard/ProjectCardView.jsx
@@ -20,6 +20,7 @@ such restriction.
 import React, { useRef } from 'react'
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
+import classnames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import ProjectStatistics from '../ProjectStatistics/ProjectStatistics'
@@ -38,92 +39,109 @@ import ClockIcon from 'igz-controls/images/clock.svg?react'
 
 import './projectCard.scss'
 
-const ProjectCardView = React.forwardRef(({ actionsMenu, alert, project, statistics }, ref) => {
-  const cardRef = useRef()
-  const chipRef = useRef()
-  const navigate = useNavigate()
+const ProjectCardView = React.forwardRef(
+  ({ actionsMenu, alert, project, statistics, syncStatusTooltip }, ref) => {
+    const cardRef = useRef()
+    const chipRef = useRef()
+    const navigate = useNavigate()
 
-  const { deletingProjects, projectsToDelete } = useSelector(state => state.projectStore)
+    const { deletingProjects, projectsToDelete } = useSelector(state => state.projectStore)
 
-  return (
-    <div className="project-card">
-      {(Object.values(deletingProjects).includes(project.metadata.name) ||
-        projectsToDelete.includes(project.metadata.name)) && <Loader section />}
-      <div
-        onClick={event => {
-          if (
-            event.target.tagName !== 'A' &&
-            !ref.current.contains(event.target) &&
-            !chipRef.current?.contains(event.target) &&
-            !event.target.closest('#overlay_container')
-          ) {
-            navigate(`/projects/${project.metadata.name}/monitor`)
-          }
-        }}
-        ref={cardRef}
+    const projectCardClassNames = classnames(
+      'project-card',
+      syncStatusTooltip && 'project-card--dimmed'
+    )
+
+    return (
+      <Tooltip
+        hidden={!syncStatusTooltip}
+        template={<TextTooltipTemplate text={syncStatusTooltip} />}
       >
-        <div className="project-card__general-info">
-          <div className="project-card__header">
-            <div className="project-card__header-title">
-              <Tooltip
-                className="project-card__title"
-                template={<TextTooltipTemplate text={project.metadata.name} />}
-              >
-                {project.metadata.name}
-              </Tooltip>
+        <div className={projectCardClassNames}>
+          {!syncStatusTooltip &&
+            (Object.values(deletingProjects).includes(project.metadata.name) ||
+              projectsToDelete.includes(project.metadata.name)) && <Loader section />}
+          <div
+            onClick={event => {
+              if (
+                event.target.tagName !== 'A' &&
+                !ref.current.contains(event.target) &&
+                !chipRef.current?.contains(event.target) &&
+                !event.target.closest('#overlay_container')
+              ) {
+                navigate(`/projects/${project.metadata.name}/monitor`)
+              }
+            }}
+            ref={cardRef}
+          >
+            <div className="project-card__general-info">
+              <div className="project-card__header">
+                <div className="project-card__header-title">
+                  <Tooltip
+                    className="project-card__title"
+                    template={<TextTooltipTemplate text={project.metadata.name} />}
+                  >
+                    {project.metadata.name}
+                  </Tooltip>
 
-              {alert ? (
-                <div className="project-card__alert">
-                  <Alerts className="project-card__alert-icon" />
-                  <div className="project-card__alert-text">{alert.toLocaleString()}</div>
+                  {alert ? (
+                    <div className="project-card__alert">
+                      <Alerts className="project-card__alert-icon" />
+                      <div className="project-card__alert-text">{alert.toLocaleString()}</div>
+                    </div>
+                  ) : null}
+                  <div className="project-card__info" data-testid="project-card__created">
+                    <ClockIcon className="project-card__info-icon" />
+                    <span>Created {getTimeElapsedByDate(project.metadata.created)}</span>
+                  </div>
                 </div>
-              ) : null}
-              <div className="project-card__info" data-testid="project-card__created">
-                <ClockIcon className="project-card__info-icon" />
-                <span>Created {getTimeElapsedByDate(project.metadata.created)}</span>
+
+                <div
+                  className={`project-card__header-sub-title project-card__info ${
+                    !project.spec.owner ? 'visibility-hidden' : ''
+                  } `}
+                  data-testid="project-card__owner"
+                >
+                  <span>Owner:</span>
+                  <span>{project.spec.owner}</span>
+                </div>
               </div>
-            </div>
 
-            <div
-              className={`project-card__header-sub-title project-card__info ${
-                !project.spec.owner ? 'visibility-hidden' : ''
-              } `}
-              data-testid="project-card__owner"
-            >
-              <span>Owner:</span>
-              <span>{project.spec.owner}</span>
-            </div>
-          </div>
+              <div className="project-card__content">
+                <div className="project-card__description" data-testid="project-card__description">
+                  {project?.spec.description && (
+                    <Tooltip template={<TextTooltipTemplate text={project.spec.description} />}>
+                      {project.spec.description}
+                    </Tooltip>
+                  )}
+                </div>
 
-          <div className="project-card__content">
-            <div className="project-card__description" data-testid="project-card__description">
-              {project?.spec.description && (
-                <Tooltip template={<TextTooltipTemplate text={project.spec.description} />}>
-                  {project.spec.description}
-                </Tooltip>
+                <div className="project-card__statistic">
+                  <ProjectStatistics statistics={statistics} />
+                </div>
+              </div>
+
+              {project.metadata.labels && (
+                <div
+                  className="project-card__info"
+                  ref={chipRef}
+                  data-testid="project-card__labels"
+                >
+                  <span>Labels:</span>
+                  <ReadOnlyChips labels={project.metadata.labels} shortChips />
+                </div>
               )}
             </div>
 
-            <div className="project-card__statistic">
-              <ProjectStatistics statistics={statistics} />
+            <div className="project-card__actions-menu" ref={ref}>
+              <ActionsMenu dataItem={project} menu={actionsMenu[project.metadata.name]} />
             </div>
           </div>
-
-          {project.metadata.labels && (
-            <div className="project-card__info" ref={chipRef} data-testid="project-card__labels">
-              <span>Labels:</span>
-              <ReadOnlyChips labels={project.metadata.labels} shortChips />
-            </div>
-          )}
         </div>
-
-        <div className="project-card__actions-menu" ref={ref}>
-          <ActionsMenu dataItem={project} menu={actionsMenu[project.metadata.name]} />
-        </div>
-      </div>
-    </div>
-  )
-})
+      </Tooltip>
+    )
+  }
+)
 
 ProjectCardView.displayName = 'ProjectCardView'
 
@@ -131,7 +149,8 @@ ProjectCardView.propTypes = {
   actionsMenu: PropTypes.object.isRequired,
   alert: PropTypes.number.isRequired,
   project: PropTypes.object.isRequired,
-  statistics: PropTypes.object.isRequired
+  statistics: PropTypes.object.isRequired,
+  syncStatusTooltip: PropTypes.string
 }
 
 export default ProjectCardView

--- a/src/elements/ProjectCard/ProjectCardView.jsx
+++ b/src/elements/ProjectCard/ProjectCardView.jsx
@@ -18,19 +18,12 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 import React, { useRef } from 'react'
-import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import ProjectStatistics from '../ProjectStatistics/ProjectStatistics'
-import {
-  Tooltip,
-  TextTooltipTemplate,
-  Loader,
-  ActionsMenu,
-  ReadOnlyChips
-} from 'igz-controls/components'
+import { Tooltip, TextTooltipTemplate, ActionsMenu, ReadOnlyChips } from 'igz-controls/components'
 
 import { getTimeElapsedByDate } from 'igz-controls/utils/datetime.util'
 
@@ -45,8 +38,6 @@ const ProjectCardView = React.forwardRef(
     const chipRef = useRef()
     const navigate = useNavigate()
 
-    const { deletingProjects, projectsToDelete } = useSelector(state => state.projectStore)
-
     const projectCardClassNames = classnames(
       'project-card',
       syncStatusTooltip && 'project-card--dimmed'
@@ -58,9 +49,6 @@ const ProjectCardView = React.forwardRef(
         template={<TextTooltipTemplate text={syncStatusTooltip} />}
       >
         <div className={projectCardClassNames}>
-          {!syncStatusTooltip &&
-            (Object.values(deletingProjects).includes(project.metadata.name) ||
-              projectsToDelete.includes(project.metadata.name)) && <Loader section />}
           <div
             onClick={event => {
               if (

--- a/src/elements/ProjectCard/projectCard.scss
+++ b/src/elements/ProjectCard/projectCard.scss
@@ -6,6 +6,7 @@
 .project-card {
   position: relative;
   min-height: 240px;
+  height: 100%;
   color: colors.$topaz;
   background-color: colors.$white;
   border-radius: 8px;
@@ -129,6 +130,13 @@
 
   &:hover {
     box-shadow: shadows.$previewBoxShadow;
+  }
+
+  &--dimmed {
+    opacity: 0.6;
+    filter: grayscale(100%);
+    cursor: default;
+    pointer-events: none;
   }
 
   .project-data-card__statistics {

--- a/src/hooks/useProjectsSyncStatus.hook.js
+++ b/src/hooks/useProjectsSyncStatus.hook.js
@@ -39,68 +39,82 @@ const fetchBackgroundTaskState = async opId => {
 
     return data?.status?.state ?? null
   } catch (error) {
-    if (error.response?.status === NOTFOUND_ERROR_STATUS_CODE) {
-      return BG_TASK_FAILED
-    }
-    console.error('Failed to fetch project background task status', error)
-
-    return null
+    return error.response?.status === NOTFOUND_ERROR_STATUS_CODE ? BG_TASK_FAILED : null
   }
 }
 
-const fetchProjectNamesWithSyncIssues = async () => {
+const fetchProjectSyncIssueNames = async () => {
   try {
     const { data } = await eventsApi.getProjectSyncIssues()
 
-    return new Set(data?.activations?.map(a => a.parameters?.project).filter(Boolean) ?? [])
-  } catch (error) {
-    console.error('Failed to fetch project sync events', error)
-
+    return new Set(
+      data?.activations?.map(activation => activation.parameters?.project).filter(Boolean)
+    )
+  } catch {
     return new Set()
   }
 }
 
-const fetchProjectSyncTooltipEntry = async (project, syncIssuesPromise) => {
-  const [backgroundTaskState, syncIssues] = await Promise.all([
+const toSyncStatusMap = entries =>
+  Object.fromEntries(entries.filter(([, tooltip]) => Boolean(tooltip)))
+
+const fetchProjectSyncTooltipEntry = async (project, syncIssueNamesPromise) => {
+  const [backgroundTaskState, syncIssueNames] = await Promise.all([
     fetchBackgroundTaskState(project.status?.op_id),
-    syncIssuesPromise
+    syncIssueNamesPromise
   ])
 
   const tooltip = getProjectSyncTooltip(
     project,
     backgroundTaskState,
-    syncIssues.has(project.metadata?.name)
+    syncIssueNames.has(project.metadata?.name)
   )
 
   return [project.metadata?.name, tooltip]
 }
 
-const fetchProjectSyncStatusMap = async transitionalProjects => {
-  const syncIssuesPromise = fetchProjectNamesWithSyncIssues()
+const fetchSyncStatusMap = async transitionalProjects => {
+  const syncIssueNamesPromise = fetchProjectSyncIssueNames()
 
-  const tooltipEntries = await Promise.all(
-    transitionalProjects.map(project => fetchProjectSyncTooltipEntry(project, syncIssuesPromise))
+  const entries = await Promise.all(
+    transitionalProjects.map(project => fetchProjectSyncTooltipEntry(project, syncIssueNamesPromise))
   )
 
-  return Object.fromEntries(tooltipEntries.filter(([, tooltip]) => Boolean(tooltip)))
+  return toSyncStatusMap(entries)
 }
 
+const getBaselineSyncStatusMap = transitionalProjects =>
+  toSyncStatusMap(
+    transitionalProjects.map(project => [
+      project.metadata?.name,
+      getProjectSyncTooltip(project, null, false)
+    ])
+  )
+
+const mergeSyncStatusMaps = (baselineMap, polledMap) =>
+  Object.fromEntries(
+    Object.keys(baselineMap).map(name => [name, polledMap[name] ?? baselineMap[name]])
+  )
+
 export const useProjectsSyncStatus = (projects, refreshProjects) => {
-  const [projectSyncStatusMap, setProjectSyncStatusMap] = useState({})
+  const [polledSyncStatusMap, setPolledSyncStatusMap] = useState({})
   const latestProjectsRef = useRef(projects)
 
   useEffect(() => {
     latestProjectsRef.current = projects
   }, [projects])
 
-  const hasTransitionalProjects = useMemo(
-    () => selectTransitionalProjects(projects).length > 0,
-    [projects]
+  const transitionalProjects = useMemo(() => selectTransitionalProjects(projects), [projects])
+  const hasTransitionalProjects = transitionalProjects.length > 0
+
+  const baselineSyncStatusMap = useMemo(
+    () => getBaselineSyncStatusMap(transitionalProjects),
+    [transitionalProjects]
   )
 
   useEffect(() => {
     if (!hasTransitionalProjects) {
-      setProjectSyncStatusMap({})
+      setPolledSyncStatusMap({})
 
       return
     }
@@ -109,18 +123,18 @@ export const useProjectsSyncStatus = (projects, refreshProjects) => {
     const terminatePollRef = { current: null }
 
     const pollProjectSyncStatus = async () => {
-      const transitionalProjects = selectTransitionalProjects(latestProjectsRef.current)
+      const currentTransitionalProjects = selectTransitionalProjects(latestProjectsRef.current)
 
-      if (!transitionalProjects.length) {
+      if (!currentTransitionalProjects.length) {
         return null
       }
 
       refreshProjects()
 
-      const syncStatusMap = await fetchProjectSyncStatusMap(transitionalProjects)
+      const syncStatusMap = await fetchSyncStatusMap(currentTransitionalProjects)
 
       if (isActive) {
-        setProjectSyncStatusMap(syncStatusMap)
+        setPolledSyncStatusMap(syncStatusMap)
       }
 
       return syncStatusMap
@@ -136,6 +150,11 @@ export const useProjectsSyncStatus = (projects, refreshProjects) => {
       terminatePollRef.current?.()
     }
   }, [hasTransitionalProjects, refreshProjects])
+
+  const projectSyncStatusMap = useMemo(
+    () => mergeSyncStatusMaps(baselineSyncStatusMap, polledSyncStatusMap),
+    [baselineSyncStatusMap, polledSyncStatusMap]
+  )
 
   return { projectSyncStatusMap }
 }

--- a/src/hooks/useProjectsSyncStatus.hook.js
+++ b/src/hooks/useProjectsSyncStatus.hook.js
@@ -1,0 +1,141 @@
+/*
+Copyright 2019 Iguazio Systems Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License") with
+an addition restriction as set forth herein. You may not use this
+file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+In addition, you may not use the software for any purposes that are
+illegal under applicable law, and the grant of the foregoing license
+under the Apache 2.0 license is conditioned upon your compliance with
+such restriction.
+*/
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import tasksApi from '../api/tasks-api'
+import eventsApi from '../api/events-api'
+import { getProjectSyncTooltip } from '../components/ProjectsPage/projects.util'
+import { pollTask, BG_TASK_FAILED } from '../utils/poll.util'
+import { NOTFOUND_ERROR_STATUS_CODE } from 'igz-controls/constants'
+import { PROJECT_SYNC_POLL_INTERVAL_MS, PROJECT_TRANSITIONAL_STATUSES } from '../constants'
+
+const selectTransitionalProjects = projects =>
+  projects.filter(project => PROJECT_TRANSITIONAL_STATUSES.includes(project.status?.state))
+
+const fetchBackgroundTaskState = async opId => {
+  if (!opId) {
+    return null
+  }
+
+  try {
+    const { data } = await tasksApi.getBackgroundTask(opId)
+
+    return data?.status?.state ?? null
+  } catch (error) {
+    if (error.response?.status === NOTFOUND_ERROR_STATUS_CODE) {
+      return BG_TASK_FAILED
+    }
+    console.error('Failed to fetch project background task status', error)
+
+    return null
+  }
+}
+
+const fetchProjectNamesWithSyncIssues = async () => {
+  try {
+    const { data } = await eventsApi.getProjectSyncIssues()
+
+    return new Set(data?.activations?.map(a => a.parameters?.project).filter(Boolean) ?? [])
+  } catch (error) {
+    console.error('Failed to fetch project sync events', error)
+
+    return new Set()
+  }
+}
+
+const fetchProjectSyncTooltipEntry = async (project, syncIssuesPromise) => {
+  const [backgroundTaskState, syncIssues] = await Promise.all([
+    fetchBackgroundTaskState(project.status?.op_id),
+    syncIssuesPromise
+  ])
+
+  const tooltip = getProjectSyncTooltip(
+    project,
+    backgroundTaskState,
+    syncIssues.has(project.metadata?.name)
+  )
+
+  return [project.metadata?.name, tooltip]
+}
+
+const fetchProjectSyncStatusMap = async transitionalProjects => {
+  const syncIssuesPromise = fetchProjectNamesWithSyncIssues()
+
+  const tooltipEntries = await Promise.all(
+    transitionalProjects.map(project => fetchProjectSyncTooltipEntry(project, syncIssuesPromise))
+  )
+
+  return Object.fromEntries(tooltipEntries.filter(([, tooltip]) => Boolean(tooltip)))
+}
+
+export const useProjectsSyncStatus = (projects, refreshProjects) => {
+  const [projectSyncStatusMap, setProjectSyncStatusMap] = useState({})
+  const latestProjectsRef = useRef(projects)
+
+  useEffect(() => {
+    latestProjectsRef.current = projects
+  }, [projects])
+
+  const hasTransitionalProjects = useMemo(
+    () => selectTransitionalProjects(projects).length > 0,
+    [projects]
+  )
+
+  useEffect(() => {
+    if (!hasTransitionalProjects) {
+      setProjectSyncStatusMap({})
+
+      return
+    }
+
+    let isActive = true
+    const terminatePollRef = { current: null }
+
+    const pollProjectSyncStatus = async () => {
+      const transitionalProjects = selectTransitionalProjects(latestProjectsRef.current)
+
+      if (!transitionalProjects.length) {
+        return null
+      }
+
+      refreshProjects()
+
+      const syncStatusMap = await fetchProjectSyncStatusMap(transitionalProjects)
+
+      if (isActive) {
+        setProjectSyncStatusMap(syncStatusMap)
+      }
+
+      return syncStatusMap
+    }
+
+    pollTask(pollProjectSyncStatus, result => result === null, {
+      delay: PROJECT_SYNC_POLL_INTERVAL_MS,
+      terminatePollRef
+    }).catch(() => {})
+
+    return () => {
+      isActive = false
+      terminatePollRef.current?.()
+    }
+  }, [hasTransitionalProjects, refreshProjects])
+
+  return { projectSyncStatusMap }
+}

--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -546,7 +546,11 @@ const projectStoreSlice = createSlice({
         loading: false
       }
     })
-    builder.addCase(fetchProjects.pending, showLoading)
+    builder.addCase(fetchProjects.pending, (state, action) => {
+      if (!action.meta.arg?.silent) {
+        showLoading(state)
+      }
+    })
     builder.addCase(fetchProjects.fulfilled, (state, action) => {
       state.projects = action.payload
       state.loading = false

--- a/tests/mockServer/data/projectSyncEvents.json
+++ b/tests/mockServer/data/projectSyncEvents.json
@@ -1,0 +1,15 @@
+{
+  "activations": [
+    {
+      "id": "sync-test-activation-1",
+      "class": "Software.ProjectSync",
+      "severity": "critical",
+      "kind": "project_stuck_after_retries",
+      "description": "Project stuck in transitional state after multiple retries",
+      "parameters": {
+        "project": "sync-test-issue"
+      },
+      "created_at": "2026-07-08T00:00:00.000Z"
+    }
+  ]
+}

--- a/tests/mockServer/data/projects.json
+++ b/tests/mockServer/data/projects.json
@@ -1703,6 +1703,90 @@
       "status": {
         "state": "online"
       }
+    },
+    {
+      "kind": "project",
+      "metadata": {
+        "name": "sync-test-creating",
+        "created": "2026-07-08T00:00:00.000000",
+        "labels": {},
+        "annotations": {}
+      },
+      "spec": {
+        "description": "Manual test fixture: creation in progress (background task running)",
+        "owner": "admin",
+        "goals": null,
+        "params": {},
+        "functions": null,
+        "workflows": null,
+        "artifacts": null,
+        "artifact_path": null,
+        "conda": "",
+        "source": "",
+        "subpath": null,
+        "origin_url": null,
+        "desired_state": "online"
+      },
+      "status": {
+        "state": "creating",
+        "op_id": "sync-test-task-creating"
+      }
+    },
+    {
+      "kind": "project",
+      "metadata": {
+        "name": "sync-test-retrying",
+        "created": "2026-07-08T00:00:00.000000",
+        "labels": {},
+        "annotations": {}
+      },
+      "spec": {
+        "description": "Manual test fixture: background task lost/failed, system auto-retries",
+        "owner": "admin",
+        "goals": null,
+        "params": {},
+        "functions": null,
+        "workflows": null,
+        "artifacts": null,
+        "artifact_path": null,
+        "conda": "",
+        "source": "",
+        "subpath": null,
+        "origin_url": null,
+        "desired_state": "archived"
+      },
+      "status": {
+        "state": "deleting",
+        "op_id": "sync-test-task-retrying"
+      }
+    },
+    {
+      "kind": "project",
+      "metadata": {
+        "name": "sync-test-issue",
+        "created": "2026-07-08T00:00:00.000000",
+        "labels": {},
+        "annotations": {}
+      },
+      "spec": {
+        "description": "Manual test fixture: system-level Orca ProjectSync issue",
+        "owner": "admin",
+        "goals": null,
+        "params": {},
+        "functions": null,
+        "workflows": null,
+        "artifacts": null,
+        "artifact_path": null,
+        "conda": "",
+        "source": "",
+        "subpath": null,
+        "origin_url": null,
+        "desired_state": "online"
+      },
+      "status": {
+        "state": "creating",
+        "op_id": "sync-test-task-issue"
+      }
     }
   ]
 }

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -71,6 +71,8 @@ import logs from './data/logs.json'
 import modelEndpoints from './data/modelEndpoints.json'
 import metricsData from './data/metrics.json'
 
+import projectSyncEvents from './data/projectSyncEvents.json'
+
 import iguazioProjects from './data/iguazioProjects.json'
 import iguazioUserGrops from './data/iguazioUserGroups.json'
 import iguazioProjectAuthorizationRoles from './data/iguazioProjectAuthorizationRoles.json'
@@ -145,6 +147,25 @@ const backgroundTaskTemplate = {
     error: null
   }
 }
+
+;['sync-test-creating', 'sync-test-issue'].forEach(projectName => {
+  const now = new Date().toISOString()
+  const taskId = `sync-test-task-${projectName.replace('sync-test-', '')}`
+
+  set(backgroundTasks, taskId, {
+    ...cloneDeep(backgroundTaskTemplate),
+    metadata: {
+      ...backgroundTaskTemplate.metadata,
+      name: taskId,
+      project: projectName,
+      kind: 'project.creation',
+      created: now,
+      updated: now
+    },
+    status: { state: 'running', error: null }
+  })
+})
+
 const projectTemplate = {
   kind: 'project',
   metadata: { name: '', created: '', labels: null, annotations: null },
@@ -420,7 +441,19 @@ function getProjectTasks(req, res) {
 }
 
 function getTask(req, res) {
-  res.send(get(backgroundTasks, req.params.taskId, {}))
+  const task = get(backgroundTasks, req.params.taskId)
+
+  if (!task) {
+    res.statusCode = 404
+    res.send({})
+    return
+  }
+
+  res.send(task)
+}
+
+function getProjectSyncEvents(req, res) {
+  res.send(projectSyncEvents)
 }
 
 function getTasks(req, res) {
@@ -3224,6 +3257,7 @@ app.get(`${iguazioApiUrl}/api/users`, getIguazioUsers)
 app.get(`${iguazioApiUrl}/api/scrubbed_users`, getIguazioUsers)
 
 app.get(`${iguazioApiUrl}/api/jobs/:id`, getIguazioJob)
+app.get(`${iguazioApiUrl}/api/v1/events/activations`, getProjectSyncEvents)
 
 app.listen(port, () => {
   console.log(`Example app listening at http://localhost:${port}`)

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -589,7 +589,21 @@ function createNewProject(req, res) {
     project.metadata.labels = req.body.metadata.labels
     project.metadata.created = currentDate.toISOString()
     project.spec.description = req.body.spec.description
+    project.status.state = 'creating'
     projects.projects.push(project)
+
+    const creationTask = createTask(null, {
+      kind: `project.creation.${project.metadata.name}`,
+      taskFunc: () =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            project.status.state = 'online'
+            resolve()
+          }, random(5000, 10000))
+        })
+    })
+    project.status.op_id = creationTask.metadata.name
+
     const summary = cloneDeep(summuryTemplate)
     summary.name = req.body.metadata.name
     projectsSummary.project_summaries.push(summary)
@@ -628,6 +642,15 @@ function deleteProjectV2(req, res) {
       taskFunc,
       kind: `project.deletion.wrapper.${req.params.project}`
     })
+
+    const deletingProject = projects.projects.find(
+      project => project.metadata.name === req.params['project']
+    )
+
+    if (deletingProject) {
+      deletingProject.status.state = 'deleting'
+      deletingProject.status.op_id = task.metadata.name
+    }
 
     res.status = 202
     res.send(task)


### PR DESCRIPTION
## 📝 Description
Dim project cards while `status.state` is `creating`/`deleting` and show a tooltip: in progress, auto-retrying (failed background task), or system sync issue (admin action needed).

## 🛠️ Changes Made
- `useProjectsSyncStatus` hook: polls background-task (`op_id`) + Orca events API every 10s while any project is transitional
- New `events-api.js`, `getBackgroundTask` in `tasks-api.js`
- `ProjectCard`: dim + tooltip, replaces old session-local delete spinner
- New constants for transitional states / tooltip text / poll interval
- `fetchProjects`: added `silent` flag so background polling doesn't show the full-page loader
- Delete flow: refetch project list immediately after delete request (was only refreshing on task completion)
- Mock server: sync test fixtures + events endpoint

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally, using the mock server fixtures)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

## 🔗 References
- [Ticket](https://ecliptos.atlassian.net/browse/ML-12526)

## 🚨 Breaking Changes
- [x] No

## Includes DRC change
- [x] No
