### PR TITLE
[FIX] Nuclio function name missing in breadcrumbs and remount MF app on project switch

### DIFF
--- a/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
+++ b/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
@@ -19,6 +19,7 @@ such restriction.
 */
 import React, { useEffect, useState, Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
+import { useParams } from 'react-router-dom'
 import { ensureNuclioRemote, loadNuclioApp } from '../../utils/nuclio.remotes.utils'
 import NuclioRemoteError from './NuclioRemoteError'
 import { Loader } from 'igz-controls/components'
@@ -29,8 +30,11 @@ import Breadcrumbs from '../../common/Breadcrumbs/Breadcrumbs'
 const RemoteNuclioApp = React.lazy(() => loadNuclioApp())
 
 const RemoteNuclioRouteWrapper = () => {
+  const params = useParams()
   const [ready, setReady] = useState(false)
   const [error, setError] = useState(false)
+
+  const nuclioItemName = params?.['*']?.split('/').filter(Boolean)[0] ?? ''
 
   useEffect(() => {
     const origPushState = history.pushState
@@ -57,6 +61,9 @@ const RemoteNuclioRouteWrapper = () => {
   }, [])
 
   useEffect(() => {
+    setReady(false)
+    setError(false)
+
     const init = async () => {
       try {
         await ensureNuclioRemote()
@@ -66,7 +73,7 @@ const RemoteNuclioRouteWrapper = () => {
       }
     }
     void init()
-  }, [])
+  }, [params.projectName])
 
   const renderContent = () => {
     if (error) {
@@ -82,7 +89,7 @@ const RemoteNuclioRouteWrapper = () => {
     }
 
     return (
-      <ErrorBoundary fallback={<NuclioRemoteError />}>
+      <ErrorBoundary key={params.projectName} fallback={<NuclioRemoteError />}>
         <Suspense
           fallback={
             <div className="flex-center">
@@ -92,7 +99,7 @@ const RemoteNuclioRouteWrapper = () => {
         >
           <div className="nuclio-app-wrapper">
             <div className="content__header">
-              <Breadcrumbs />
+              <Breadcrumbs itemName={nuclioItemName} />
             </div>
             <RemoteNuclioApp />
           </div>


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
[FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
[STYLE] Reformat components for linting compliance
[CI] Run tests on push for all branches
[FEAT] Add dark mode toggle in header
-->

## 📝 Description
<!-- A clear, concise summary of what this PR does. -->
<!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

Two issues with the Nuclio module federation integration:

1. The breadcrumb did not show the function name when navigating into a Nuclio function - unlike datasets, models and other pages which correctly display the item name.
2. Switching projects while inside a Nuclio page did not reset the MF app - the previous function's state persisted in the new project context.

---

## 🛠️ Changes Made
<!-- List the main updates in this PR. -->
<!-- Example:
- Replaced Sass styles with CSS Modules
- Updated Button component props for accessibility
- Adjusted CI workflow to run on push for all branches
-->

- Derive the function name from the URL wildcard (`params['*']`) and pass it as `itemName` to `<Breadcrumbs />` — since Nuclio owns its own routing internally, the function name lives in the wildcard rather than a named route param
- Add `key={params.projectName}` to `<ErrorBoundary>` so the entire MF app subtree unmounts and remounts fresh when the project changes, resetting all internal Nuclio state
- Re-run the MF init effect on `params.projectName` change to reset `ready`/`error` state between projects

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ORIS-3081
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
- TODO: Migrate remaining components away from Sass
- Known issue: minor layout flicker on mobile
-->

- Stale function name in URL on project switch is resolved by [#3724](https://github.com/mlrun/ui/pull/3724)

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
