### PR TITLE
[FIX] [RemoteNuclio] Infinite request loop and wrong redirect when navigating away from function creation page

### DIFF
--- a/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
+++ b/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
@@ -28,6 +28,9 @@ import Breadcrumbs from '../../common/Breadcrumbs/Breadcrumbs'
 
 const RemoteNuclioApp = React.lazy(() => loadNuclioApp())
 
+const isNuclioPath = pathname =>
+  /^\/projects\/[^/]+\/(real-time-functions|create-function|api-gateways)(\/|$)/.test(pathname)
+
 const RemoteNuclioRouteWrapper = () => {
   const [ready, setReady] = useState(false)
   const [error, setError] = useState(false)
@@ -39,14 +42,18 @@ const RemoteNuclioRouteWrapper = () => {
     history.pushState = function (...args) {
       origPushState.apply(this, args)
       Promise.resolve().then(() => {
-        window.dispatchEvent(new PopStateEvent('popstate'))
+        if (isNuclioPath(window.location.pathname)) {
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        }
       })
     }
 
     history.replaceState = function (...args) {
       origReplaceState.apply(this, args)
       Promise.resolve().then(() => {
-        window.dispatchEvent(new PopStateEvent('popstate'))
+        if (isNuclioPath(window.location.pathname)) {
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        }
       })
     }
 


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
[FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
[STYLE] Reformat components for linting compliance
[CI] Run tests on push for all branches
[FEAT] Add dark mode toggle in header
-->

## 📝 Description
<!-- A clear, concise summary of what this PR does. -->
<!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

When a user starts creating a new Nuclio function and navigates away (via breadcrumbs or navbar), two bugs occur:

1. An infinite loop of network requests is triggered (`GET ecliptos_favicon-BP8GXzoH.png` repeating).
2. Clicking the project name in breadcrumbs redirects back to the "Start a new function" page instead of the expected destination.
**Root cause:** `RemoteNuclioRouteWrapper` patches `history.pushState`/`replaceState` to dispatch a synthetic `popstate` so the host router stays in sync with Nuclio-internal navigations. 
The patch fired unconditionally - including for host-side navigations - causing Nuclio's singleton router to process the event and call `replaceState` back to its last known path (`real-time-functions/create-function`), which the host then re-rendered, creating a navigation loop.

---

## 🛠️ Changes Made
<!-- List the main updates in this PR. -->
<!-- Example:
- Replaced Sass styles with CSS Modules
- Updated Button component props for accessibility
- Adjusted CI workflow to run on push for all branches
-->

- Added a module-level `isNuclioPath` predicate matching the three Nuclio-owned routes (`real-time-functions`, `create-function`, `api-gateways`).
- The synthetic `popstate` is now only dispatched when `window.location.pathname` at microtask execution time matches a Nuclio path - by then all synchronous history calls have settled, so host navigations landing outside Nuclio routes are silently skipped.

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ORIS-3152
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
- TODO: Migrate remaining components away from Sass
- Known issue: minor layout flicker on mobile
-->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
