### PR TITLE
[SecVul] [1.1.x] ui/mlrun-ui Critical

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,19 @@ RUN echo "${COMMIT_HASH}" > ./build/COMMIT_HASH && \
     echo "${DATE}" > ./build/BUILD_DATE
 
 # production stage
-FROM gcr.io/iguazio/nginx-unprivileged:1.31.1-alpine AS production-stage
+# TODO: temporarily pulling from Docker Hub upstream. Switch back to the internal
+# artifactory mirror once DevOps syncs the 1.31.2-alpine3.23 tag (see IG4-3203 / IG4-3204).
+FROM nginxinc/nginx-unprivileged:1.31.2-alpine3.23 AS production-stage
 
 ARG UID=101
 ARG GID=101
 ARG IS_MF=false
 
 USER root
+# curl/libcurl are unused at runtime and the patched build (8.21.0-r0) is not yet
+# published to the Alpine 3.23 repos, so remove them entirely to clear the CVEs
 RUN apk update --no-cache && apk upgrade --no-cache \
+ && apk del curl libcurl \
  && rm -f /etc/nginx/conf.d/default.conf
 
 USER $UID
@@ -65,7 +70,7 @@ RUN if [ "$IS_MF" \
     fi && \
     chown -R $UID:0 /usr/share/nginx/html && \
     chmod -R g+w /usr/share/nginx/html && \
-    chmod 777 /etc/nginx/run_nginx
+    chmod 755 /etc/nginx/run_nginx
 
 USER $UID
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,7 @@ RUN echo "${COMMIT_HASH}" > ./build/COMMIT_HASH && \
     echo "${DATE}" > ./build/BUILD_DATE
 
 # production stage
-# TODO: temporarily pulling from Docker Hub upstream. Switch back to the internal
-# artifactory mirror once DevOps syncs the 1.31.2-alpine3.23 tag (see IG4-3203 / IG4-3204).
-FROM nginxinc/nginx-unprivileged:1.31.2-alpine3.23 AS production-stage
+FROM gcr.io/iguazio/nginx-unprivileged:1.31.2-alpine3.23 AS production-stage
 
 ARG UID=101
 ARG GID=101


### PR DESCRIPTION

  ## 📝 Description
Revert temporary Docker Hub pull for nginx-unprivileged now that DevOps synced 1.31.2-alpine3.23 to the internal GCR mirror

---

## 🛠️ Changes Made

- Dockerfile: 

```
Base image: nginxinc/nginx-unprivileged:1.31.2-alpine3.23 → gcr.io/iguazio/nginx-unprivileged:1.31.2-alpine3.23
```


---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ORIS-3203, https://ecliptos.atlassian.net/browse/ORIS-3203
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [ ] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
