### PR TITLE
[SecVul] [1.1.x] ui/mlrun-ui:sha256 Critical

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,15 @@ RUN if [ "$IS_MF" \
 
 USER $UID
 
+# flatten stage - collapses every layer of production-stage into one, so the
+# removed curl/libcurl files leave no whiteout entries in the shipped image
+FROM scratch AS flatten-stage
+COPY --from=production-stage / /
+
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ARG UID=101
+USER $UID
+
 EXPOSE 8090
 
 CMD ["/etc/nginx/run_nginx"]


### PR DESCRIPTION

  
  ## 📝 Description
Fixes false-positive curl/libcurl CVEs reported by Xray on mlrun-ui. Root cause: curl is installed in the base image and removed in a later layer (whiteout), which Xray's scanner doesn't honor. Flattening the final image into a single layer removes the stale layer history entirely, so the CVEs no longer appear.



---

## 🛠️ Changes Made
Dockerfile — added flatten-stage: collapses production-stage into a single layer via scratch, so removed packages (curl/libcurl) leave no whiteout entries for Xray to misread.

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/issues?filter=14104&selectedIssue=ORIS-3338
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [ ] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
