### PR TITLE
[FIX] [Filters] Missing space after comma in filter status labels

### DIFF
--- a/src/utils/getNoDataMessage.js
+++ b/src/utils/getNoDataMessage.js
@@ -186,9 +186,11 @@ const generateNoEntriesFoundMessage = (visibleFilterTypes, filtersConfig, filter
           ? formatFilterValue(filters[filterType])
           : filters[filterType]
     const isLastElement = index === visibleFilterTypes.length - 1
+    const displayValue = Array.isArray(value) ? value.join(', ') : value
 
     return (
-      message + `${label.endsWith(':') ? label : `${label}:`} ${value}${isLastElement ? '"' : ', '}`
+      message +
+      `${label.endsWith(':') ? label : `${label}:`} ${displayValue}${isLastElement ? '"' : ', '}`
     )
   }, 'No data matches the filter: "')
 }


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

Added spaces to the filters 
---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ORIS-3692
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

<img width="853" height="95" alt="Screenshot 2026-07-27 at 9 54 02" src="https://github.com/user-attachments/assets/ff270ab7-4c40-4ed3-a506-106ccd28d1c0" />

---
