### PR TITLE
[FIX] Leave confirmation for real-time function navigation

### DIFF
--- a/src/common/HostLeaveGuard/HostLeaveGuard.jsx
+++ b/src/common/HostLeaveGuard/HostLeaveGuard.jsx
@@ -32,7 +32,9 @@ import { useBlocker } from 'react-router-dom'
  * It is a no-op whenever no remote guard is registered.
  */
 const HostLeaveGuard = () => {
-  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+  const blocker = useBlocker(({ currentLocation, nextLocation, historyAction }) => {
+    // POP (back/forward) is handled by the remote's own useBlocker.
+    if (historyAction === 'POP') return false
     try {
       return Boolean(
         window.__igzLeaveGuard?.shouldBlock(currentLocation.pathname, nextLocation.pathname)

--- a/src/common/HostLeaveGuard/HostLeaveGuard.jsx
+++ b/src/common/HostLeaveGuard/HostLeaveGuard.jsx
@@ -19,6 +19,7 @@ such restriction.
 */
 import { useEffect, useRef } from 'react'
 import { useBlocker } from 'react-router-dom'
+import { useSidebar } from 'igz-controls/nextGenComponents'
 
 /**
  * Bridges host (mlrun-ui) navigation to a guard published by an embedded remote
@@ -32,6 +33,8 @@ import { useBlocker } from 'react-router-dom'
  * It is a no-op whenever no remote guard is registered.
  */
 const HostLeaveGuard = () => {
+  const { setOpen: setSidebarOpen } = useSidebar()
+
   const blocker = useBlocker(({ currentLocation, nextLocation, historyAction }) => {
     // POP (back/forward) is handled by the remote's own useBlocker.
     if (historyAction === 'POP') return false
@@ -52,6 +55,8 @@ const HostLeaveGuard = () => {
 
   useEffect(() => {
     if (blocker.state !== 'blocked') return
+
+    setSidebarOpen(false)
 
     let active = true
     const confirm = window.__igzLeaveGuard?.confirm
@@ -74,7 +79,7 @@ const HostLeaveGuard = () => {
     return () => {
       active = false
     }
-  }, [blocker.state])
+  }, [blocker.state, setSidebarOpen])
 
   return null
 }

--- a/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
+++ b/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
@@ -26,6 +26,7 @@ import { Loader } from 'igz-controls/components'
 
 import './RemoteNuclio.scss'
 import Breadcrumbs from '../../common/Breadcrumbs/Breadcrumbs'
+import HostLeaveGuard from '../../common/HostLeaveGuard/HostLeaveGuard'
 
 const RemoteNuclioApp = React.lazy(() => loadNuclioApp())
 
@@ -115,7 +116,10 @@ const RemoteNuclioRouteWrapper = () => {
     )
   }
 
-  return <div className="remote-nuclio-container">{renderContent()}</div>
+  return <>
+    <HostLeaveGuard />
+    <div className="remote-nuclio-container">{renderContent()}</div>
+  </>
 }
 
 export default RemoteNuclioRouteWrapper

--- a/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
+++ b/src/components/RemoteNuclio/RemoteNuclioRouteWrapper.jsx
@@ -116,10 +116,12 @@ const RemoteNuclioRouteWrapper = () => {
     )
   }
 
-  return <>
-    <HostLeaveGuard />
-    <div className="remote-nuclio-container">{renderContent()}</div>
-  </>
+  return (
+    <>
+      <HostLeaveGuard />
+      <div className="remote-nuclio-container">{renderContent()}</div>
+    </>
+  )
 }
 
 export default RemoteNuclioRouteWrapper


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
[FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
[STYLE] Reformat components for linting compliance
[CI] Run tests on push for all branches
[FEAT] Add dark mode toggle in header
-->

## 📝 Description
<!-- A clear, concise summary of what this PR does. -->
<!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

When navigating away from an in-progress function creation page via the sidebar, the "Leave without deploying?" dialog was not shown. Added `HostLeaveGuard` to the nuclio route wrapper to intercept host-level navigation and delegate confirmation to nuclio's guard.

Also closes the sidebar when navigation is blocked.

---

## 🛠️ Changes Made
<!-- List the main updates in this PR. -->
<!-- Example:
- Replaced Sass styles with CSS Modules
- Updated Button component props for accessibility
- Adjusted CI workflow to run on push for all branches
-->

- Add `HostLeaveGuard` to `RemoteNuclioRouteWrapper` to intercept PUSH navigations
- Skip POP in `HostLeaveGuard` - back/forward is delegated to nuclio's own blocker
- Close the sidebar via `useSidebar` when navigation is blocked

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ORIS-2556
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

---

Includes DRC change
- [ ] Yes
- [x] No

If yes -> requires bump NPM version

---

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->
  
- Multi-repo fix: corresponding changes in mlrun-ui and nuclio-ui
  
oris-ui: [oris-ui: [FIX] Sync embedded router on leave confirmation for real-time functions Open](https://github.com/McK-Private/oris-ui/pull/365)
nuclio-ui: [nuclio-ui: [FIX] Leave confirmation for real-time function navigation Open](https://github.com/McK-Private/nuclio-ui/pull/202)
 

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
