### PR TITLE
[FIX] [Tests] Resolve CodeQL code scanning alerts in mock server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "express": "^4.17.1",
+        "express-rate-limit": "^8.6.2",
         "file-loader": "^6.2.0",
         "geckodriver": "^6.1.0",
         "globals": "^15.14.0",
@@ -14919,6 +14920,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "express": "^4.17.1",
+    "express-rate-limit": "^8.6.2",
     "file-loader": "^6.2.0",
     "geckodriver": "^6.1.0",
     "globals": "^15.14.0",

--- a/tests/features/common-tools/utils.js
+++ b/tests/features/common-tools/utils.js
@@ -80,7 +80,7 @@ export const getRule = (array, substring) => {
 
   return value
     .split(', ')
-    .map(el => el.replace(/\./g, '\\.'))
+    .map(el => el.replace(/\\/g, '\\\\').replace(/\./g, '\\.'))
     .join('')
 }
 

--- a/tests/mockServer/dataGenerators.js
+++ b/tests/mockServer/dataGenerators.js
@@ -18,6 +18,7 @@ under the Apache 2.0 license is conditioned upon your compliance with
 such restriction.
 */
 // format data in accordance with ISO 8601 with ms
+import crypto from 'node:crypto'
 
 export function makeUID(length) {
   let result = ''
@@ -25,7 +26,7 @@ export function makeUID(length) {
   const charactersLength = characters.length
 
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+    result += characters.charAt(crypto.randomInt(charactersLength))
   }
 
   return result
@@ -224,7 +225,7 @@ export const generateArtifacts = existingArtifacts => {
       let prompt
 
       if (existingPromptsPool.length && Math.random() < 0.5) {
-        const oldPrompt = existingPromptsPool[Math.floor(Math.random() * existingPromptsPool.length)]  
+        const oldPrompt = existingPromptsPool[crypto.randomInt(existingPromptsPool.length)]
         existingPromptsPool
           .filter(p => p.metadata.key === oldPrompt.metadata.key)
           .forEach(p => p.metadata.tag = '')

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -97,8 +97,11 @@ import {
 } from './dataGenerators.js'
 import {
   capCollectionSize,
+  boundArray,
+  rejectIfUnsafeKey,
   safeAssign,
   resolveFunctionYAMLPath,
+  resolveDataFilePath,
   fsAccessLimiter
 } from './security.js'
 
@@ -209,7 +212,6 @@ const secretKeyTemplate = {
 }
 
 // Mock constants
-const mockHome = process.cwd() + '/tests/mockServer'
 const mlrunIngress = '/mlrun-api-ingress.default-tenant.app.vmdev36.lab.iguazeng.com'
 const mlrunAPIIngress = `${mlrunIngress}/api/v1`
 const mlrunAPIIngressV2 = `${mlrunIngress}/api/v2`
@@ -324,7 +326,7 @@ function getPaginationConfig(data, query) {
   let pageData = data
 
   if (query['page-size'] && query.page) {
-    const dataPaginated = chunk(data, query['page-size'])
+    const dataPaginated = chunk(boundArray(data), query['page-size'])
     pageData = dataPaginated[query.page - 1] ?? []
     const pageDataIsEmpty = isEmpty(pageData)
     const nextPageDataIsEmpty = isEmpty(dataPaginated[query.page])
@@ -674,10 +676,18 @@ function putProject(req, res) {
 }
 
 function getSecretKeys(req, res) {
+  if (rejectIfUnsafeKey(res, req.params['project'])) {
+    return
+  }
+
   res.send(secretKeys[req.params['project']])
 }
 
 function postSecretKeys(req, res) {
+  if (rejectIfUnsafeKey(res, req.params['project'])) {
+    return
+  }
+
   let respBody = ''
   const newSecretKey = Object.keys(req.body.secrets)[0]
 
@@ -707,6 +717,10 @@ function postSecretKeys(req, res) {
 }
 
 function deleteSecretKeys(req, res) {
+  if (rejectIfUnsafeKey(res, req.params['project'])) {
+    return
+  }
+
   secretKeys[req.params['project']].secret_keys = secretKeys[
     req.params['project']
   ].secret_keys.filter(item => item !== req.query.secret)
@@ -933,7 +947,7 @@ function getRuns(req, res) {
 
         if (!start_time_from || runStartTime >= new Date(start_time_from)) {
           if (states) {
-            if (isArray(states)) {
+            if (Array.isArray(states)) {
               return states.includes(run.status.state)
             } else {
               return run.status.state === states
@@ -967,7 +981,7 @@ function getRuns(req, res) {
       const states = req.query['states']
 
       collectedRuns = collectedRuns.filter(run => {
-        if (isArray(states)) {
+        if (Array.isArray(states)) {
           return states.includes(run.status.state)
         } else {
           return run.status.state === states
@@ -2049,7 +2063,7 @@ function getFuncs(req, res) {
     })
   }
 
-  collectedFuncs = orderBy(collectedFuncs, 'metadata.updated', 'desc')
+  collectedFuncs = orderBy(boundArray(collectedFuncs), 'metadata.updated', 'desc')
   const [paginatedFuncs, pagination] = getPaginationConfig(collectedFuncs, req.query)
 
   res.send({ funcs: paginatedFuncs, pagination })
@@ -2103,9 +2117,11 @@ function postFunc(req, res) {
 }
 
 function deleteFunc(req, res) {
-  const collectedFunc = funcs.funcs
-    .filter(func => func.metadata.project === req.params.project)
-    .filter(func => func.metadata.name === req.params.func)
+  const collectedFunc = boundArray(
+    funcs.funcs
+      .filter(func => func.metadata.project === req.params.project)
+      .filter(func => func.metadata.name === req.params.func)
+  )
 
   if (collectedFunc.length) {
     const taskFunc = id => {
@@ -2273,15 +2289,22 @@ function deployMLFunction(req, res) {
 }
 
 function getFile(req, res) {
-  const dataRoot = mockHome + '/data/'
-  const filePath = dataRoot + req.query['path'].split('://')[1]
+  const filePath = resolveDataFilePath(req.query['path'])
+  if (!filePath) {
+    res.statusCode = 400
+    return res.send('Invalid path')
+  }
 
   res.sendFile(filePath)
 }
 
 function getFileStats(req, res) {
-  const dataRoot = mockHome + '/data/'
-  const filePath = dataRoot + req.query['path'].split('://')[1]
+  const filePath = resolveDataFilePath(req.query['path'])
+  if (!filePath) {
+    res.statusCode = 400
+    return res.send('Invalid path')
+  }
+
   const { size } = fs.statSync(filePath)
   const mimeType = mime.lookup(filePath)
 
@@ -3017,6 +3040,10 @@ function putIguazioProject(req, res) {
 
 function postProjectMembers(req, res) {
   const projectId = req.body.data.attributes.metadata.project_ids[0]
+  if (rejectIfUnsafeKey(res, projectId)) {
+    return
+  }
+
   const items = req.body.data.attributes.requests
   const projectRelations = cloneDeep(iguazioProjectsRelations[projectId])
 
@@ -3163,14 +3190,18 @@ app.post(`${mlrunAPIIngress}/projects/:project/runs/:uid/abort`, abortRun)
 app.get(`${mlrunIngress}/catalog.json`, getFunctionCatalog)
 app.get(`${mlrunAPIIngress}/hub/sources/:project/items`, getFunctionCatalog)
 app.get(`${mlrunAPIIngress}/hub/sources/:project/items/:uid`, getFunctionItem)
-app.get(`${mlrunAPIIngress}/hub/sources/:project/item-object`, getFunctionObject)
-app.get(`${mlrunIngress}/:function/function.yaml`, getFunctionTemplate)
+app.get(`${mlrunAPIIngress}/hub/sources/:project/item-object`, fsAccessLimiter, getFunctionObject)
+app.get(`${mlrunIngress}/:function/function.yaml`, fsAccessLimiter, getFunctionTemplate)
 
 app.get(`${mlrunAPIIngress}/projects/:project/schedules`, getProjectsSchedules)
 app.get(`${mlrunAPIIngress}/projects/*/schedules`, getProjectsSchedules)
 app.get(`${mlrunAPIIngress}/projects/:project/schedules/:schedule`, getProjectsSchedule)
 app.delete(`${mlrunAPIIngress}/projects/:project/schedules/:schedule`, deleteSchedule)
-app.post(`${mlrunAPIIngress}/projects/:project/schedules/:schedule/invoke`, invokeSchedule)
+app.post(
+  `${mlrunAPIIngress}/projects/:project/schedules/:schedule/invoke`,
+  fsAccessLimiter,
+  invokeSchedule
+)
 app.put(`${mlrunAPIIngress}/projects/:project/schedules/:schedule/`, updateSchedule)
 
 app.get(`${mlrunAPIIngress}/projects/:project/pipelines`, getPipelines)
@@ -3250,7 +3281,7 @@ app.get(`${mlrunAPIIngressV2}/projects/:project/features`, getProjectsFeaturesEn
 app.get(`${mlrunAPIIngressV2}/projects/:project/entities`, getProjectsFeaturesEntities)
 app.get(`${mlrunAPIIngress}/projects/:project/feature-vectors`, getProjectsFeaturesEntities)
 
-app.post(`${mlrunAPIIngress}/submit_job`, postSubmitJob)
+app.post(`${mlrunAPIIngress}/submit_job`, fsAccessLimiter, postSubmitJob)
 
 app.get(`${nuclioApiUrl}/api/functions/:name`, getNuclioFunction)
 app.get(`${nuclioApiUrl}/api/functions`, getNuclioFunctions)

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -21,6 +21,7 @@ import express from 'express'
 import bodyParser from 'body-parser'
 import yaml from 'js-yaml'
 import fs from 'fs'
+import path from 'path'
 import crypto from 'node:crypto'
 import {
   chain,
@@ -101,7 +102,6 @@ import {
   rejectIfUnsafeKey,
   safeAssign,
   resolveFunctionYAMLPath,
-  resolveDataFilePath,
   fsAccessLimiter
 } from './security.js'
 
@@ -212,6 +212,7 @@ const secretKeyTemplate = {
 }
 
 // Mock constants
+const MOCK_DATA_DIR = path.resolve('./tests/mockServer/data')
 const mlrunIngress = '/mlrun-api-ingress.default-tenant.app.vmdev36.lab.iguazeng.com'
 const mlrunAPIIngress = `${mlrunIngress}/api/v1`
 const mlrunAPIIngressV2 = `${mlrunIngress}/api/v2`
@@ -2289,8 +2290,14 @@ function deployMLFunction(req, res) {
 }
 
 function getFile(req, res) {
-  const filePath = resolveDataFilePath(req.query['path'])
-  if (!filePath) {
+  const rawPath = req.query['path']
+  if (typeof rawPath !== 'string' || rawPath.indexOf('..') !== -1) {
+    res.statusCode = 400
+    return res.send('Invalid path')
+  }
+
+  const filePath = path.resolve(MOCK_DATA_DIR, rawPath.split('://')[1] ?? rawPath)
+  if (!filePath.startsWith(MOCK_DATA_DIR + path.sep)) {
     res.statusCode = 400
     return res.send('Invalid path')
   }
@@ -2299,8 +2306,14 @@ function getFile(req, res) {
 }
 
 function getFileStats(req, res) {
-  const filePath = resolveDataFilePath(req.query['path'])
-  if (!filePath) {
+  const rawPath = req.query['path']
+  if (typeof rawPath !== 'string' || rawPath.indexOf('..') !== -1) {
+    res.statusCode = 400
+    return res.send('Invalid path')
+  }
+
+  const filePath = path.resolve(MOCK_DATA_DIR, rawPath.split('://')[1] ?? rawPath)
+  if (!filePath.startsWith(MOCK_DATA_DIR + path.sep)) {
     res.statusCode = 400
     return res.send('Invalid path')
   }

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -718,13 +718,15 @@ function postSecretKeys(req, res) {
 }
 
 function deleteSecretKeys(req, res) {
-  if (rejectIfUnsafeKey(res, req.params['project'])) {
-    return
+  const project = req.params['project']
+  if (project === '__proto__' || project === 'constructor' || project === 'prototype') {
+    res.statusCode = 400
+    return res.send('Invalid key')
   }
 
-  secretKeys[req.params['project']].secret_keys = secretKeys[
-    req.params['project']
-  ].secret_keys.filter(item => item !== req.query.secret)
+  secretKeys[project].secret_keys = secretKeys[project].secret_keys.filter(
+    item => item !== req.query.secret
+  )
 
   res.statusCode = 204
   res.send('')
@@ -3053,8 +3055,9 @@ function putIguazioProject(req, res) {
 
 function postProjectMembers(req, res) {
   const projectId = req.body.data.attributes.metadata.project_ids[0]
-  if (rejectIfUnsafeKey(res, projectId)) {
-    return
+  if (projectId === '__proto__' || projectId === 'constructor' || projectId === 'prototype') {
+    res.statusCode = 400
+    return res.send('Invalid key')
   }
 
   const items = req.body.data.attributes.requests

--- a/tests/mockServer/mock.js
+++ b/tests/mockServer/mock.js
@@ -95,6 +95,12 @@ import {
   generateRuns,
   generateAlerts
 } from './dataGenerators.js'
+import {
+  capCollectionSize,
+  safeAssign,
+  resolveFunctionYAMLPath,
+  fsAccessLimiter
+} from './security.js'
 
 // Updating values in files with synthetic data
 updateRuns(runs)
@@ -440,13 +446,19 @@ function getFeatureSet(req, res) {
     )
   }
 
-  if (req.query['name']) {
+  const featureSetName = req.query['name']
+
+  if (featureSetName) {
     collectedFeatureSets = collectedFeatureSets.filter(featureSet => {
-      if (req.query['name'].startsWith?.('~')) {
-        return featureSet.metadata.name.includes(req.query['name'].slice(1))
+      if (typeof featureSetName !== 'string') {
+        return false
       }
 
-      return featureSet.metadata.name === req.query['name']
+      if (featureSetName.startsWith('~')) {
+        return featureSet.metadata.name.includes(featureSetName.slice(1))
+      }
+
+      return featureSet.metadata.name === featureSetName
     })
   }
 
@@ -482,7 +494,7 @@ function createProjectsFeatureSet(req, res) {
   featureSet.status['state'] = null
   featureSets.feature_sets.push(featureSet)
 
-  res.send(featureSet)
+  res.json(featureSet)
 }
 
 function updateProjectsFeatureSet(req, res) {
@@ -503,7 +515,7 @@ function updateProjectsFeatureSet(req, res) {
   featureSet.metadata.updated = new Date().toISOString()
   featureSets.feature_sets[featureSetIndex] = featureSet
 
-  res.send(featureSet)
+  res.json(featureSet)
 }
 
 function deleteFeatureSet(req, res) {
@@ -561,7 +573,7 @@ function createNewProject(req, res) {
     summary.name = req.body.metadata.name
     projectsSummary.project_summaries.push(summary)
     data = project
-    secretKeys[req.body.metadata.name] = secretKeyTemplate
+    safeAssign(secretKeys, req.body.metadata.name, secretKeyTemplate)
     res.statusCode = 201
   } else {
     res.statusCode = 409
@@ -819,7 +831,11 @@ function getFunctionItem(req, res) {
 function getFunctionObject(req, res) {
   const urlParams = req.query.url
   const urlArray = urlParams.split('/')
-  const funcYAMLPath = `./tests/mockServer/data/mlrun/functions/${urlArray[6]}/${urlArray[6]}.yaml`
+  const funcYAMLPath = resolveFunctionYAMLPath(urlArray[6])
+  if (!funcYAMLPath) {
+    res.statusCode = 400
+    return res.send('Invalid function name')
+  }
   const funcObject = fs.readFileSync(funcYAMLPath, 'utf8')
 
   res.send(funcObject)
@@ -976,12 +992,18 @@ function getRuns(req, res) {
     collectedRuns = getPartitionedData(collectedRuns, pathToPartition, 'status.last_update')
   }
 
-  if (req.query['name']) {
+  const runName = req.query['name']
+
+  if (runName) {
     collectedRuns = collectedRuns.filter(run => {
-      if (req.query['name'].includes('~')) {
-        return run.metadata.name ? run.metadata.name.includes(req.query['name'].slice(1)) : false
+      if (typeof runName !== 'string') {
+        return false
+      }
+
+      if (runName.includes('~')) {
+        return run.metadata.name ? run.metadata.name.includes(runName.slice(1)) : false
       } else {
-        return run.metadata.name === req.query['name']
+        return run.metadata.name === runName
       }
     })
   }
@@ -1010,9 +1032,11 @@ function getAlerts(req, res) {
     collectedAlerts = collectedAlerts.filter(alert => alert.project === req.params.project)
   }
 
-  if (req.query['name']) {
-    collectedAlerts = collectedAlerts.filter(schedule =>
-      schedule.name.includes(req.query['name'].slice(1))
+  const alertName = req.query['name']
+
+  if (alertName) {
+    collectedAlerts = collectedAlerts.filter(
+      schedule => typeof alertName === 'string' && schedule.name.includes(alertName.slice(1))
     )
   }
   if (req.query['severity']) {
@@ -1031,9 +1055,12 @@ function getAlerts(req, res) {
     )
   }
 
-  if (req.query['entity']) {
-    collectedAlerts = collectedAlerts.filter(schedule =>
-      schedule.entity_id.includes(req.query['entity'].slice(1, -1))
+  const alertEntity = req.query['entity']
+
+  if (alertEntity) {
+    collectedAlerts = collectedAlerts.filter(
+      schedule =>
+        typeof alertEntity === 'string' && schedule.entity_id.includes(alertEntity.slice(1, -1))
     )
   }
 
@@ -1165,7 +1192,11 @@ function getFunctionCatalog(req, res) {
 }
 
 function getFunctionTemplate(req, res) {
-  const funcYAMLPath = `./tests/mockServer/data/mlrun/functions/${req.params.function}/${req.params.function}.yaml`
+  const funcYAMLPath = resolveFunctionYAMLPath(req.params.function)
+  if (!funcYAMLPath) {
+    res.statusCode = 400
+    return res.send('Invalid function name')
+  }
   const funcObject = fs.readFileSync(funcYAMLPath, 'utf8')
 
   res.send(funcObject)
@@ -1180,9 +1211,11 @@ function getProjectsSchedules(req, res) {
     )
   }
 
-  if (req.query['name']) {
-    collectedSchedules = collectedSchedules.filter(schedule =>
-      schedule.name.includes(req.query['name'].slice(1))
+  const scheduleName = req.query['name']
+
+  if (scheduleName) {
+    collectedSchedules = collectedSchedules.filter(
+      schedule => typeof scheduleName === 'string' && schedule.name.includes(scheduleName.slice(1))
     )
   }
 
@@ -1275,9 +1308,11 @@ function invokeSchedule(req, res) {
         item.metadata.name === functionName
     )
   } else {
-    const funcYAMLPath = `./tests/mockServer/data/mlrun/functions/${req.body.task.spec.function.slice(
-      6
-    )}/${req.body.task.spec.function.slice(6)}.yaml`
+    const funcYAMLPath = resolveFunctionYAMLPath(req.body.task.spec.function.slice(6))
+    if (!funcYAMLPath) {
+      res.statusCode = 400
+      return res.send('Invalid function name')
+    }
     funcObject = yaml.load(fs.readFileSync(funcYAMLPath, 'utf8'))
   }
   const funcUID = makeUID(32)
@@ -1386,19 +1421,25 @@ function getProjectsFeaturesEntities(req, res) {
       })
     }
 
-    if (req.query['name']) {
+    const artifactItemName = req.query['name']
+
+    if (artifactItemName) {
       collectedArtifacts = collectedArtifacts.filter(feature => {
-        if (req.query['name'].includes('~')) {
+        if (typeof artifactItemName !== 'string') {
+          return false
+        }
+
+        if (artifactItemName.includes('~')) {
           if (artifact === 'feature-vectors') {
-            return feature.metadata.name.includes(req.query['name'].slice(1))
+            return feature.metadata.name.includes(artifactItemName.slice(1))
           } else if (artifact === 'features' || artifact === 'entities') {
-            return feature.name.includes(req.query['name'].slice(1))
+            return feature.name.includes(artifactItemName.slice(1))
           }
         } else {
           if (artifact === 'feature-vectors') {
-            return feature.metadata.name.includes(req.query['name'].slice(1))
+            return feature.metadata.name.includes(artifactItemName.slice(1))
           } else if (artifact === 'features' || artifact === 'entities') {
-            return feature.name === req.query['name']
+            return feature.name === artifactItemName
           }
         }
       })
@@ -1502,20 +1543,26 @@ function getArtifacts(req, res) {
     )
   }
 
-  if (req.query['name']) {
+  const artifactsName = req.query['name']
+
+  if (artifactsName) {
     collectedArtifacts = collectedArtifacts.filter(artifact => {
-      if (req.query['name'].includes('~')) {
+      if (typeof artifactsName !== 'string') {
+        return false
+      }
+
+      if (artifactsName.includes('~')) {
         const value = artifact.spec?.db_key ?? artifact.db_key
 
-        if (req.query['name'].includes('~')) {
-          return value.includes(req.query['name'].slice(1))
+        if (artifactsName.includes('~')) {
+          return value.includes(artifactsName.slice(1))
         } else {
-          return value.includes(req.query['name'])
+          return value.includes(artifactsName)
         }
       } else {
         return (
-          (artifact.spec && artifact.spec.db_key === req.query['name']) ||
-          artifact.db_key === req.query['name']
+          (artifact.spec && artifact.spec.db_key === artifactsName) ||
+          artifact.db_key === artifactsName
         )
       }
     })
@@ -1542,9 +1589,11 @@ function getArtifacts(req, res) {
     )
   }
 
-  if (req.query['parent']) {
-    if (req.query['parent'].includes(':')) {
-      const [key, tag] = req.query['parent'].split(':')
+  const artifactParent = req.query['parent']
+
+  if (artifactParent) {
+    if (typeof artifactParent === 'string' && artifactParent.includes(':')) {
+      const [key, tag] = artifactParent.split(':')
 
       collectedArtifacts = collectedArtifacts.filter(artifact => {
         const match = artifact.spec.parent_uri.match(
@@ -1557,7 +1606,7 @@ function getArtifacts(req, res) {
       collectedArtifacts = collectedArtifacts.filter(artifact =>
         artifact.spec?.parent_uri
           ?.match(/^store:\/\/[^/]+\/[^/]+\/([^#/]+)/)?.[1]
-          ?.includes(req.query['parent'])
+          ?.includes(artifactParent)
       )
     }
   }
@@ -1624,7 +1673,7 @@ function getProjectsFeatureSets(req, res) {
     .filter(artifact => artifact.metadata.name === req.params.name)
     .filter(artifact => artifact.metadata.tag === req.params.tag)
 
-  res.send(featureArtifactTags[0])
+  res.json(featureArtifactTags[0])
 }
 
 function patchProjectsFeatureSets(req, res) {
@@ -1636,7 +1685,7 @@ function patchProjectsFeatureSets(req, res) {
   if (featureArtifactTags.length) {
     featureArtifactTags[0].metadata.labels = req.body.metadata.labels
   }
-  res.send(featureArtifactTags[0])
+  res.json(featureArtifactTags[0])
 }
 
 function postProjectsFeatureVectors(req, res) {
@@ -1654,7 +1703,7 @@ function postProjectsFeatureVectors(req, res) {
 
     featureVectors.feature_vectors.push(newFeatureVector)
 
-    res.send(newFeatureVector)
+    res.json(newFeatureVector)
   } else {
     res.statusCode = 409
     res.send({
@@ -1673,7 +1722,7 @@ function putProjectsFeatureVectors(req, res) {
 
   collectedFV[0] = req.body
 
-  res.send(req.body)
+  res.json(req.body)
 }
 
 function patchProjectsFeatureVectors(req, res) {
@@ -1707,7 +1756,7 @@ function getProjectsFeatureVector(req, res) {
   )
 
   if (featureVector) {
-    res.send(featureVector)
+    res.json(featureVector)
   } else {
     res.statusCode = 404
     res.send({
@@ -1940,12 +1989,18 @@ function getFuncs(req, res) {
     collectedFuncs = funcs.funcs.filter(func => func.metadata.project === req.params['project'])
   }
 
-  if (req.query['name']) {
+  const funcName = req.query['name']
+
+  if (funcName) {
     collectedFuncs = collectedFuncs.filter(func => {
-      if (req.query['name'].includes('~')) {
-        return func.metadata.name.includes(req.query['name'].slice(1))
+      if (typeof funcName !== 'string') {
+        return false
+      }
+
+      if (funcName.includes('~')) {
+        return func.metadata.name.includes(funcName.slice(1))
       } else {
-        return func.metadata.name === req.query['name']
+        return func.metadata.name === funcName
       }
     })
   }
@@ -2042,6 +2097,7 @@ function postFunc(req, res) {
   }
 
   funcs.funcs.push(baseFunc)
+  capCollectionSize(funcs.funcs)
 
   res.send({ hash_key: hashPwd })
 }
@@ -2159,6 +2215,7 @@ function sendLogsData(data, res) {
     })
   }
 
+  res.set('Content-Type', 'text/plain')
   res.send(logText)
 }
 
@@ -2354,9 +2411,11 @@ function postSubmitJob(req, res) {
         .filter(item => item.metadata.project === filterPRJ)
         .filter(item => item.metadata.name === filterFunc)[0]
     } else {
-      const funcYAMLPath = `./tests/mockServer/data/mlrun/functions/${req.body.task.spec.function.slice(
-        6
-      )}/${req.body.task.spec.function.slice(6)}.yaml`
+      const funcYAMLPath = resolveFunctionYAMLPath(req.body.task.spec.function.slice(6))
+      if (!funcYAMLPath) {
+        res.statusCode = 400
+        return res.send('Invalid function name')
+      }
       funcObject = yaml.load(fs.readFileSync(funcYAMLPath, 'utf8'))
     }
 
@@ -2755,7 +2814,7 @@ function getMetricsValues(req, res) {
     )?.metricsValues || []
 
   metricsValues = metricsValues
-    .filter(item => names.includes(item.full_name))
+    .filter(item => typeof names === 'string' && names.includes(item.full_name))
     .map(item => {
       if (!item.data) return item
 
@@ -2862,9 +2921,10 @@ function getIguazioSelf(req, res) {
 
 function getIguazioProject(req, res) {
   let filteredProject = iguazioProjects.data.find(item => item.id === req.params.id)
+  const include = typeof req.query.include === 'string' ? req.query.include : ''
 
   let filteredAuthRoles = []
-  if (req.query.include.includes('project_authorization_roles')) {
+  if (include.includes('project_authorization_roles')) {
     filteredAuthRoles = cloneDeep(
       iguazioProjectAuthorizationRoles.data.filter(
         item => item.relationships.project.data.id === req.params.id
@@ -2877,7 +2937,7 @@ function getIguazioProject(req, res) {
   }
 
   let filteredPrincipalUsers = []
-  if (req.query.include.includes('project_authorization_roles.principal_users')) {
+  if (include.includes('project_authorization_roles.principal_users')) {
     let principalUserIDs = []
     for (let authID of authRolesIDs) {
       let tmp = iguazioProjectsRelations[req.params.id].find(
@@ -2898,7 +2958,7 @@ function getIguazioProject(req, res) {
   }
 
   let filteredPrincipalUserGroups = []
-  if (req.query.include.includes('project_authorization_roles.principal_user_groups')) {
+  if (include.includes('project_authorization_roles.principal_user_groups')) {
     let principalUserGroupIDs = []
     for (let authID of authRolesIDs) {
       let tmp = iguazioProjectsRelations[req.params.id].find(
@@ -2984,7 +3044,7 @@ function postProjectMembers(req, res) {
     }
   })
 
-  iguazioProjectsRelations[projectId] = projectRelations
+  safeAssign(iguazioProjectsRelations, projectId, projectRelations)
 
   res.send({
     data: {
@@ -3010,7 +3070,7 @@ function getNuclioStreams(req, res) {
 }
 
 function getNuclioShardLags(req, res) {
-  res.send({
+  res.json({
     [`${req.body.containerName}${req.body.streamPath}`]: {
       [req.body.consumerGroup]: {
         'shard-id-0': {
@@ -3042,7 +3102,7 @@ function getIguazioJob(req, res) {
 app.post('/set-failure-condition', (req, res) => {
   failAllRequests = req.body.shouldFail
 
-  res.send(`Failure condition set to ${failAllRequests}`)
+  res.json({ message: `Failure condition set to ${failAllRequests}` })
 })
 
 // REQUESTS
@@ -3168,14 +3228,14 @@ app.get(
 
 app.delete(`${mlrunAPIIngressV2}/projects/:project/functions/:func`, deleteFunc)
 
-app.get(`${mlrunAPIIngress}/projects/:project/nuclio/:func/deploy`, getNuclioLogs)
-app.get(`${mlrunAPIIngress}/build/status`, getBuildStatus)
-app.post(`${mlrunAPIIngress}/build/function`, deployMLFunction)
+app.get(`${mlrunAPIIngress}/projects/:project/nuclio/:func/deploy`, fsAccessLimiter, getNuclioLogs)
+app.get(`${mlrunAPIIngress}/build/status`, fsAccessLimiter, getBuildStatus)
+app.post(`${mlrunAPIIngress}/build/function`, fsAccessLimiter, deployMLFunction)
 
-app.get(`${mlrunAPIIngress}/projects/:project/files`, getFile)
-app.get(`${mlrunAPIIngress}/projects/:project/filestat`, getFileStats)
+app.get(`${mlrunAPIIngress}/projects/:project/files`, fsAccessLimiter, getFile)
+app.get(`${mlrunAPIIngress}/projects/:project/filestat`, fsAccessLimiter, getFileStats)
 
-app.get(`${mlrunAPIIngress}/projects/:project/logs/:uid`, getLog)
+app.get(`${mlrunAPIIngress}/projects/:project/logs/:uid`, fsAccessLimiter, getLog)
 
 app.get(`${mlrunAPIIngress}/projects/:project/runtime-resources`, getRuntimeResources)
 

--- a/tests/mockServer/security.js
+++ b/tests/mockServer/security.js
@@ -93,7 +93,13 @@ export function resolveDataFilePath(rawPath) {
   if (typeof rawPath !== 'string' || !rawPath) {
     return null
   }
-  return resolveWithinDir(MOCK_DATA_DIR, rawPath.split('://')[1] ?? rawPath)
+  const relativePath = rawPath.split('://')[1] ?? rawPath
+  const hasTraversalSegment = relativePath.split(/[\\/]/).includes('..')
+
+  if (path.isAbsolute(relativePath) || hasTraversalSegment) {
+    return null
+  }
+  return resolveWithinDir(MOCK_DATA_DIR, relativePath)
 }
 
 // Throttles the routes that touch the filesystem, so repeated requests can't be used

--- a/tests/mockServer/security.js
+++ b/tests/mockServer/security.js
@@ -87,21 +87,6 @@ export function resolveFunctionYAMLPath(rawName) {
   return resolveWithinDir(FUNCTIONS_DATA_DIR, path.join(rawName, `${rawName}.yaml`))
 }
 
-const MOCK_DATA_DIR = path.resolve('./tests/mockServer/data')
-
-export function resolveDataFilePath(rawPath) {
-  if (typeof rawPath !== 'string' || !rawPath) {
-    return null
-  }
-  const relativePath = rawPath.split('://')[1] ?? rawPath
-  const hasTraversalSegment = relativePath.split(/[\\/]/).includes('..')
-
-  if (path.isAbsolute(relativePath) || hasTraversalSegment) {
-    return null
-  }
-  return resolveWithinDir(MOCK_DATA_DIR, relativePath)
-}
-
 // Throttles the routes that touch the filesystem, so repeated requests can't be used
 // to exhaust disk/CPU resources.
 export const fsAccessLimiter = rateLimit({

--- a/tests/mockServer/security.js
+++ b/tests/mockServer/security.js
@@ -33,34 +33,63 @@ export function capCollectionSize(collection) {
   }
 }
 
-// Guards against prototype pollution when the assignment key comes from request data
-// (e.g. a '__proto__'/'constructor'/'prototype' string would otherwise alter Object.prototype).
+// Bounds an array right before it's iterated/sorted/chunked, so a sink can't be driven
+// by an arbitrarily large collection even if it was built up from many prior requests.
+export function boundArray(arr) {
+  return arr.length > MAX_MOCK_COLLECTION_SIZE ? arr.slice(0, MAX_MOCK_COLLECTION_SIZE) : arr
+}
+
+// Prototype pollution guard: a '__proto__'/'constructor'/'prototype' key must never be used
+// to read or write a mock lookup object keyed by request data, since bracket access with one
+// of these names resolves to the object's prototype chain instead of an own property.
 const UNSAFE_OBJECT_KEYS = ['__proto__', 'constructor', 'prototype']
 
+export function isUnsafeObjectKey(key) {
+  return UNSAFE_OBJECT_KEYS.includes(key)
+}
+
+// Rejects the request with a 400 when `key` is unsafe to use against a mock lookup object,
+// so handlers can bail out before the key is ever read from or written to one. Returns
+// whether it rejected, so callers can `if (rejectIfUnsafeKey(res, key)) return`.
+export function rejectIfUnsafeKey(res, key) {
+  if (isUnsafeObjectKey(key)) {
+    res.statusCode = 400
+    res.send('Invalid key')
+    return true
+  }
+  return false
+}
+
 export function safeAssign(obj, key, value) {
-  if (UNSAFE_OBJECT_KEYS.includes(key)) {
+  if (isUnsafeObjectKey(key)) {
     return
   }
   obj[key] = value
 }
 
-// Resolves a mock function YAML file path from a user-supplied function name, rejecting
-// anything that would escape the intended data directory (e.g. via '..' path traversal).
+// Resolves `relativePath` under `baseDir`, rejecting anything that would escape baseDir
+// (e.g. via '..' path traversal) once the two are combined.
+function resolveWithinDir(baseDir, relativePath) {
+  const resolved = path.resolve(baseDir, relativePath)
+  return resolved === baseDir || resolved.startsWith(baseDir + path.sep) ? resolved : null
+}
+
 const FUNCTIONS_DATA_DIR = path.resolve('./tests/mockServer/data/mlrun/functions')
 
 export function resolveFunctionYAMLPath(rawName) {
-  if (typeof rawName !== 'string' || !rawName) {
+  if (typeof rawName !== 'string' || !rawName || path.basename(rawName) !== rawName) {
     return null
   }
-  const safeName = path.basename(rawName)
-  if (safeName !== rawName) {
+  return resolveWithinDir(FUNCTIONS_DATA_DIR, path.join(rawName, `${rawName}.yaml`))
+}
+
+const MOCK_DATA_DIR = path.resolve('./tests/mockServer/data')
+
+export function resolveDataFilePath(rawPath) {
+  if (typeof rawPath !== 'string' || !rawPath) {
     return null
   }
-  const resolved = path.resolve(FUNCTIONS_DATA_DIR, safeName, `${safeName}.yaml`)
-  if (!resolved.startsWith(FUNCTIONS_DATA_DIR + path.sep)) {
-    return null
-  }
-  return resolved
+  return resolveWithinDir(MOCK_DATA_DIR, rawPath.split('://')[1] ?? rawPath)
 }
 
 // Throttles the routes that touch the filesystem, so repeated requests can't be used

--- a/tests/mockServer/security.js
+++ b/tests/mockServer/security.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 Iguazio Systems Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License") with
+an addition restriction as set forth herein. You may not use this
+file except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+In addition, you may not use the software for any purposes that are
+illegal under applicable law, and the grant of the foregoing license
+under the Apache 2.0 license is conditioned upon your compliance with
+such restriction.
+*/
+// Hardening helpers for mock.js request handlers (bounded collection growth,
+// prototype-pollution-safe assignment, path-traversal-safe file resolution,
+// filesystem-route rate limiting).
+import path from 'path'
+import { rateLimit } from 'express-rate-limit'
+
+// Upper bound for mock collections that grow from incoming requests (e.g. funcs.funcs),
+// so their .length stays capped instead of growing indefinitely with request volume.
+const MAX_MOCK_COLLECTION_SIZE = 5000
+
+export function capCollectionSize(collection) {
+  if (collection.length > MAX_MOCK_COLLECTION_SIZE) {
+    collection.splice(0, collection.length - MAX_MOCK_COLLECTION_SIZE)
+  }
+}
+
+// Guards against prototype pollution when the assignment key comes from request data
+// (e.g. a '__proto__'/'constructor'/'prototype' string would otherwise alter Object.prototype).
+const UNSAFE_OBJECT_KEYS = ['__proto__', 'constructor', 'prototype']
+
+export function safeAssign(obj, key, value) {
+  if (UNSAFE_OBJECT_KEYS.includes(key)) {
+    return
+  }
+  obj[key] = value
+}
+
+// Resolves a mock function YAML file path from a user-supplied function name, rejecting
+// anything that would escape the intended data directory (e.g. via '..' path traversal).
+const FUNCTIONS_DATA_DIR = path.resolve('./tests/mockServer/data/mlrun/functions')
+
+export function resolveFunctionYAMLPath(rawName) {
+  if (typeof rawName !== 'string' || !rawName) {
+    return null
+  }
+  const safeName = path.basename(rawName)
+  if (safeName !== rawName) {
+    return null
+  }
+  const resolved = path.resolve(FUNCTIONS_DATA_DIR, safeName, `${safeName}.yaml`)
+  if (!resolved.startsWith(FUNCTIONS_DATA_DIR + path.sep)) {
+    return null
+  }
+  return resolved
+}
+
+// Throttles the routes that touch the filesystem, so repeated requests can't be used
+// to exhaust disk/CPU resources.
+export const fsAccessLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+})

--- a/tests/mockServer/security.js
+++ b/tests/mockServer/security.js
@@ -35,7 +35,11 @@ export function capCollectionSize(collection) {
 
 // Bounds an array right before it's iterated/sorted/chunked, so a sink can't be driven
 // by an arbitrarily large collection even if it was built up from many prior requests.
+// Non-arrays are rejected to avoid trusting an attacker-controlled `.length`.
 export function boundArray(arr) {
+  if (!Array.isArray(arr)) {
+    return []
+  }
   return arr.length > MAX_MOCK_COLLECTION_SIZE ? arr.slice(0, MAX_MOCK_COLLECTION_SIZE) : arr
 }
 


### PR DESCRIPTION
[FIX] [Tests] Resolve CodeQL code scanning alerts in mock server

## 📝 Description
Closes all 51 GitHub Code Scanning (CodeQL) alerts on the mock server, spanning reflected-xss, type-confusion-through-parameter-tampering, path-injection, prototype-polluting-assignment, loop-bound-injection, missing-rate-limiting, insecure-randomness, and incomplete-sanitization
---

## 🛠️ Changes Made
- xss: `res.send(obj)` → `res.json(obj)` for JSON payloads; explicit `text/plain` for the one real string response
- type-confusion: `typeof`/`Array.isArray` guards on `req.query`/`req.params` before string methods (native `Array.isArray`, not lodash's, which CodeQL doesn't treat as a barrier)
- path-injection: inline `indexOf('..')` + resolved-path containment check at `getFile`/`getFileStats` (also caught an unguarded arbitrary file read in `getFile` that wasn't part of the original alert set); `resolveFunctionYAMLPath()` for the function-template routes
- prototype-pollution: inline `__proto__`/`constructor`/`prototype` key checks at each sink (`secretKeys`, `iguazioProjectsRelations`)
- loop-bound-injection: `boundArray()` applied at each iteration site (`chunk`/`orderBy`/`forEach`), rejecting non-arrays
- rate-limiting: `express-rate-limit` (new devDependency) applied to all 10 routes that actually touch the filesystem
- insecure-randomness: `Math.random()` → `crypto.randomInt()` in `makeUID()` and the prompt-pool picker
- incomplete-sanitization: escape backslashes before dots in `getRule()`
- new `tests/mockServer/security.js` holds the reusable hardening helpers instead of inlining them all in `mock.js`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I confirmed that existing tests pass
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No
