### PR TITLE
[FIX] Change scoping of mlrun root element

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
+  .ml-app,
+  :where(:root) {
     --igz-light-purple: #869cff;
     --igz-tab-active-bg: #f5f7ff;
     --igz-purple: #5f52cc;


### PR DESCRIPTION
## 📝 Description

When MLRun UI runs as a Module Federation remote inside the igz host, its theme tokens (`--sidebar-*`, `--primary`, etc.) were declared on `:root`, the same selector the host uses. Whichever stylesheet loaded last won, so after visiting `/projects` the host `/admin` sidebar turned purple until a hard refresh as well as other css abnormalities.

---

## 🛠️ Changes Made

- `src/tailwind.css`: theme token block selector changed from `:root` to `.ml-app, :where(:root)`
  - `.ml-app` keeps the MLRun theme inside the MLRun app tree
  - `:where(:root)` is a zero-specificity fallback for standalone mode that always loses to the host's `:root`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status

---

## 🔗 References
- Related ticket / issue: [ORIS-4487](https://ecliptos.atlassian.net/browse/ORIS-4487)
- Figma / design spec: N/A
- Documentation: N/A

---

## 🚨 Potentially Breaking Changes
- [x] Yes
- [ ] No

---

Includes DRC change
- [ ] Yes
- [x] No

---

## 🔍 Additional Notes


---

## 📸 Screenshots / Demos

---
